### PR TITLE
Couple issues running with Xamarin.iOS

### DIFF
--- a/Couchbase.Lite/Couchbase.Lite/Manager.cs
+++ b/Couchbase.Lite/Couchbase.Lite/Manager.cs
@@ -334,7 +334,7 @@ namespace Couchbase.Lite
 
         private string PathForName(string name)
         {
-            if (String.IsNullOrEmpty (name) || !pattern.IsMatch (name))
+            if (String.IsNullOrEmpty (name) || pattern.IsMatch (name))
             {
                 return null;
             }


### PR DESCRIPTION
Found a couple issues trying test this with a Xamarin.iOS app:
- I couldn't run this with the Indie Xamarin license since it references System.Data.SqlClient. However, this wasn't necessary since it uses Sqlite. I changed the SqlParameters to SqliteParameters and was able to get it to compile.
- Got a null reference when calling SharedManager.GetDatabase("something"). This seems to be because the logic to validate the name is reversed. After I changed that I was able to get a Database object back.
