### PR TITLE
Fix issue #78

### DIFF
--- a/src/Couchbase.Lite.iOS/CouchbaseTableSource.cs
+++ b/src/Couchbase.Lite.iOS/CouchbaseTableSource.cs
@@ -67,18 +67,14 @@ namespace Couchbase.Lite.iOS
             if (evt != null)
             {
                 var args = new ReloadEventArgs(Query);
-//                UIApplication.SharedApplication.InvokeOnMainThread(new NSAction(()=> evt(this, args)));
                 evt(this, args);
             }
 
             var reloadEvt = Reload;
-            if (evt != null) {
+            if (reloadEvt != null) {
                 var args = new ReloadEventArgs(Query, oldRows);
                 reloadEvt(this, args);
-//                UIApplication.SharedApplication.InvokeOnMainThread(new NSAction(()=> reloadEvt(this, args)));
             } else {
-//                UIApplication.SharedApplication.InvokeOnMainThread(
-//                    new NSAction (TableView.ReloadData));
                 TableView.ReloadData();
             }
         }


### PR DESCRIPTION
- Fix deadlock caused by ReRunUpdateQueryTask and UpdateQueryTask are waiting for each other due to the shared UpdateQueryTask and UpdateQueryTokenSource variable.
- Synchronize Update method
