### PR TITLE
Fix for CouchDB/Cloudant syncing

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -55,6 +55,7 @@ using Couchbase.Lite.Auth;
 using Couchbase.Lite.Support;
 using Couchbase.Lite.Internal;
 using Sharpen;
+using System.Net.Http.Headers;
 
 
 namespace Couchbase.Lite
@@ -804,6 +805,7 @@ namespace Couchbase.Lite
                 var bytes = mapper.WriteValueAsBytes(body).ToArray();
                 var byteContent = new ByteArrayContent(bytes);
                 message.Content = byteContent;
+				message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             }
             message.Headers.Add("Accept", new[] { "multipart/related", "application/json" });
 


### PR DESCRIPTION
Trying again: CouchDB (actually Cloudant, but I assume the behavior is the same) was throwing a HTTP 415 “Unsupported media type” when syncing because the POSTs to _bulk_docs did not have a “Content-Type: application/json” header.

Once I made this change, the sample app was able to sync with my database very nicely.
