### PR TITLE
Fixes #88.

### DIFF
--- a/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
@@ -69,6 +69,9 @@ namespace Couchbase.Lite.Shared
 
         public bool Open (String path)
         {
+            if (IsOpen)
+                return true;
+
             var errMessage = "Cannot open Sqlite Database at pth {0}".Fmt(path);
 
             var result = true;

--- a/src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
+++ b/src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
@@ -15,7 +15,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;__IOS__;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;__IOS__;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>


### PR DESCRIPTION
Attempting to open and existing sqlite db can generate
an 'out of memory' error as well, so the Open method
now checks to see if a database is already open.

Also cleans up TestBatcherLatencyInitialBatch to use
.NET types in lieu of Sharpen shims.
