### PR TITLE
Fixes #102.

### DIFF
--- a/packaging/component/component.yaml
+++ b/packaging/component/component.yaml
@@ -9,19 +9,27 @@ publisher-url: http://www.couchbase.com
 source-url: https://github.com/couchbaselabs/couchbase-lite-net
 documentation-url: http://developer.couchbase.com/mobile/develop/guides/couchbase-lite/native-api/index.html
 build:
-  - ../../src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
-  - ../../src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
+  - 
+    path: ../../src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
+    configuration: Release|iPhone
+  - 
+    path: ../../src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
+    configuration: Release|AnyCPU
 libraries: 
   ios: 
      - ../../src/Couchbase.Lite.iOS/bin/Release/Couchbase.Lite.dll
      - ../../src/Couchbase.Lite.iOS/bin/Release/Couchbase.Lite.dll.mdb
      - ../../src/Couchbase.Lite.iOS/bin/Release/Couchbase.Lite.xml
      - ../../src/Couchbase.Lite.iOS/bin/Release/Newtonsoft.Json.dll
+     - ../../src/Couchbase.Lite.iOS/bin/Release/SqlitePCL.dll
+     - ../../src/Couchbase.Lite.iOS/bin/Release/SqlitePCL.ugly.dll
   android: 
      - ../../src/Couchbase.Lite.Android/bin/Release/Couchbase.Lite.dll
      - ../../src/Couchbase.Lite.Android/bin/Release/Couchbase.Lite.dll.mdb
      - ../../src/Couchbase.Lite.Android/bin/Release/Couchbase.Lite.xml
      - ../../src/Couchbase.Lite.Android/bin/Release/Newtonsoft.Json.dll
+     - ../../src/Couchbase.Lite.Android/bin/Release/SqlitePCL.dll
+     - ../../src/Couchbase.Lite.Android/bin/Release/SqlitePCL.ugly.dll
 summary: A lightweight, document-oriented (NoSQL), syncable database engine. 
 details: Details.md
 screenshots: 

--- a/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
+++ b/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
@@ -9,6 +9,9 @@
     <RootNamespace>CouchbaseSample.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>CouchbaseSampleiOS</AssemblyName>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ReleaseVersion>0.9.2</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,13 +31,20 @@
     <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-    <DebugType>full</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <OutputPath>bin\iPhone\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchLink>None</MtouchLink>
     <ConsolePause>false</ConsolePause>
+    <DebugSymbols>true</DebugSymbols>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchExtraArgs>--registrar=static</MtouchExtraArgs>
+    <MtouchI18n>
+    </MtouchI18n>
+    <MtouchArch>ARMv7</MtouchArch>
+    <Platform>iPhone</Platform>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,19 +64,21 @@
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchExtraArgs>--registrar=static</MtouchExtraArgs>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-    <DebugType>full</DebugType>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release' ">
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
     <ConsolePause>false</ConsolePause>
-    <BuildIpa>true</BuildIpa>
     <MtouchExtraArgs>--registrar=static</MtouchExtraArgs>
     <MtouchI18n>
     </MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
+    <Platform>iPhone</Platform>
+    <IpaPackageName>
+    </IpaPackageName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>
@@ -97,10 +109,20 @@
     <OutputPath>bin\Debug</OutputPath>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release' ">
+    <Platform Condition=" '$(Platform)' == '' ">iPhone</Platform>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <ConsolePause>false</ConsolePause>
+    <BuildIpa>false</BuildIpa>
+    <MtouchExtraArgs>--registrar=static</MtouchExtraArgs>
+    <MtouchI18n>
+    </MtouchI18n>
+    <MtouchArch>ARMv7</MtouchArch>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -110,6 +132,12 @@
     <Reference Include="System.Json" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\src\packages\Newtonsoft.Json.6.0.3\lib\portable-net40+sl4+wp7+win8\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>packages\SQLitePCL.raw_basic.0.4.0-alpha\lib\MonoTouch\SQLitePCL.raw.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCL.ugly">
+      <HintPath>packages\SQLitePCL.ugly.0.4.0-alpha\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.sln
+++ b/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.sln
@@ -5,6 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CouchbaseSample.iOS", "Couc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Lite.iOS", "..\..\src\Couchbase.Lite.iOS\Couchbase.Lite.iOS.csproj", "{443E1BEE-43B3-45A1-ACEA-F7BA71BDAAB1}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Couchbase.Lite.Shared", "..\..\src\Couchbase.Lite.Shared\Couchbase.Lite.Shared.shproj", "{0A88C2A7-7AD8-46F9-9D31-869E3466B791}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
@@ -42,5 +44,6 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = CouchbaseSample.iOS.csproj
+		version = 0.9.2
 	EndGlobalSection
 EndGlobal

--- a/samples/CouchbaseSample.iOS/packages.config
+++ b/samples/CouchbaseSample.iOS/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="MonoTouch10" />
+  <package id="SQLitePCL.raw_basic" version="0.4.0-alpha" targetFramework="MonoTouch10" />
+  <package id="SQLitePCL.ugly" version="0.4.0-alpha" targetFramework="MonoTouch10" />
 </packages>

--- a/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
+++ b/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
@@ -13,6 +13,8 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>Couchbase.Lite</AssemblyName>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,11 +51,11 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Web.Services" />
-    <Reference Include="SQLitePCL">
-      <HintPath>..\packages\SQLitePCL.raw_basic.0.2.0-alpha\lib\MonoAndroid\SQLitePCL.dll</HintPath>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>..\..\samples\SimpleAndroidSync\packages\SQLitePCL.raw_basic.0.4.0-alpha\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCL.ugly">
-      <HintPath>..\packages\SQLitePCL.ugly.0.2.0-alpha\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
+      <HintPath>..\..\samples\SimpleAndroidSync\packages\SQLitePCL.ugly.0.4.0-alpha\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Couchbase.Lite.Android/packages.config
+++ b/src/Couchbase.Lite.Android/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="MonoAndroid44" />
-  <package id="SQLitePCL.raw_basic" version="0.2.0-alpha" targetFramework="MonoAndroid22" />
-  <package id="SQLitePCL.ugly" version="0.2.0-alpha" targetFramework="MonoAndroid22" />
+  <package id="SQLitePCL.raw_basic" version="0.4.0-alpha" targetFramework="MonoAndroid22" />
+  <package id="SQLitePCL.ugly" version="0.4.0-alpha" targetFramework="MonoAndroid22" />
 </packages>

--- a/src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
+++ b/src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
@@ -9,6 +9,9 @@
     <RootNamespace>Couchbase.Lite.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Couchbase.Lite</AssemblyName>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ReleaseVersion>0.9.2</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +25,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Debug\Couchbase.Lite.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -30,8 +33,18 @@
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Release\Couchbase.Lite.xml</DocumentationFile>
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Couchbase.Lite.xml</DocumentationFile>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -43,11 +56,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.Services" />
-    <Reference Include="SQLitePCL">
-      <HintPath>..\packages\SQLitePCL.raw_basic.0.2.0-alpha\lib\MonoTouch\SQLitePCL.dll</HintPath>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>..\..\samples\CouchbaseSample.iOS\packages\SQLitePCL.raw_basic.0.4.0-alpha\lib\MonoTouch\SQLitePCL.raw.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCL.ugly">
-      <HintPath>..\packages\SQLitePCL.ugly.0.2.0-alpha\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
+      <HintPath>..\..\samples\CouchbaseSample.iOS\packages\SQLitePCL.ugly.0.4.0-alpha\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Couchbase.Lite.iOS/packages.config
+++ b/src/Couchbase.Lite.iOS/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="MonoTouch10" />
-  <package id="SQLitePCL.raw_basic" version="0.2.0-alpha" targetFramework="MonoTouch10" />
-  <package id="SQLitePCL.ugly" version="0.2.0-alpha" targetFramework="MonoTouch10" />
+  <package id="SQLitePCL.raw_basic" version="0.4.0-alpha" targetFramework="MonoTouch10" />
+  <package id="SQLitePCL.ugly" version="0.4.0-alpha" targetFramework="MonoTouch10" />
 </packages>


### PR DESCRIPTION
The NuGet packages for SqlitePCL.raw underwent name changes.
Updated the nuget package names, and had to manually add
SqlitePCL.raw-basic package first, as the SqlitePCL.ugly
package was picking up the (older) cached package instead.
