### PR TITLE
ExtensionMethods.ToCredentialsFromUri would always return null

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -290,7 +290,7 @@ namespace Couchbase.Lite.Replicator
                     if (credentials != null)
 					{
                         var handler = client.HttpHandler;
-                        if (handler.Credentials == null || !handler.Credentials.Equals(credentials))
+						if (handler != null && (handler.Credentials == null || !handler.Credentials.Equals(credentials)))
                             client.HttpHandler.Credentials = credentials;
 					}
 					else

--- a/src/Couchbase.Lite.Shared/Util/ExtensionMethods.cs
+++ b/src/Couchbase.Lite.Shared/Util/ExtensionMethods.cs
@@ -109,7 +109,7 @@ namespace Couchbase.Lite
                                     ? System.Web.HttpUtility.UrlDecode(request.RequestUri.UserInfo)
                                     : request.RequestUri.UserInfo;
 
-            var userAndPassword = unescapedUserInfo.Split(new[] { ':' }, 1, StringSplitOptions.None);
+            var userAndPassword = unescapedUserInfo.Split(new[] { ':' }, 2, StringSplitOptions.None);
             if (userAndPassword.Length != 2)
                 return null;
 


### PR DESCRIPTION
The method ExtensionMethods.ToCredentialsFromUri would always return
null because it was telling string.Split to only return 1 value.

Once that bug was fixed, it would cause units tests to fail because the
IChangeTrackerClient (specifically Puller) would not always have an
HttpClient.  Added an additional null check to ChangeTracker.
