### PR TITLE
Fixes IAuthenticator interface. Refactors existing code.

### DIFF
--- a/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
+++ b/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
@@ -9,9 +9,6 @@
     <RootNamespace>CouchbaseSample.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>CouchbaseSampleiOS</AssemblyName>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ReleaseVersion>0.9.2</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
+++ b/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
@@ -16,8 +16,6 @@
     <AssemblyName>SimpleAndroidSync</AssemblyName>
     <TargetFrameworkVersion>v4.0.3</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
+++ b/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
@@ -13,8 +13,6 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>Couchbase.Lite</AssemblyName>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Couchbase.Lite.Shared/Auth/Authenticator.cs
+++ b/src/Couchbase.Lite.Shared/Auth/Authenticator.cs
@@ -43,17 +43,17 @@
 using System;
 using System.Collections.Generic;
 
-namespace Couchbase.Lite.Auth
-{
-    public abstract class Authenticator : IAuthenticator
-    {
-        public virtual string AuthUserInfo { get { return null; } }
-
-        public abstract bool UsesCookieBasedLogin { get; }
-
-        public abstract string LoginPathForSite(Uri site);
-
-        public abstract IDictionary<string, string> LoginParametersForSite(Uri site);
-    }
-}
-
+//namespace Couchbase.Lite.Auth
+//{
+//    public abstract class Authenticator : IAuthenticator
+//    {
+//        public virtual string AuthUserInfo { get { return null; } }
+//
+//        public abstract bool UsesCookieBasedLogin { get; }
+//
+//        public abstract string LoginPathForSite(Uri site);
+//
+//        public abstract IDictionary<string, string> LoginParametersForSite(Uri site);
+//    }
+//}
+//

--- a/src/Couchbase.Lite.Shared/Auth/Authorizer.cs
+++ b/src/Couchbase.Lite.Shared/Auth/Authorizer.cs
@@ -86,18 +86,14 @@ using System.Collections.Generic;
 
 namespace Couchbase.Lite.Auth
 {
-    public class Authorizer : Authenticator
+    internal abstract class Authorizer : IAuthenticator
 	{
-        override public bool UsesCookieBasedLogin { get { return false; } }
+        public abstract string AuthUserInfo { get; }
 
-        override public IDictionary<String, String> LoginParametersForSite(Uri site)
-		{
-			return null;
-		}
+        public abstract bool UsesCookieBasedLogin { get; }
 
-        override public String LoginPathForSite(Uri site)
-		{
-			return null;
-		}
+        public abstract IDictionary<String, String> LoginParametersForSite(Uri site);
+
+        public abstract String LoginPathForSite(Uri site);
 	}
 }

--- a/src/Couchbase.Lite.Shared/Auth/BasicAuthenticator.cs
+++ b/src/Couchbase.Lite.Shared/Auth/BasicAuthenticator.cs
@@ -45,7 +45,7 @@ using System.Collections.Generic;
 
 namespace Couchbase.Lite.Auth
 {
-    public class BasicAuthenticator : Authenticator
+    public class BasicAuthenticator : IAuthenticator
     {
         private string username;
         private string password;
@@ -55,11 +55,11 @@ namespace Couchbase.Lite.Auth
             this.password = password;
         }
 
-        public override bool UsesCookieBasedLogin {
+        public bool UsesCookieBasedLogin {
             get { return true; }
         }
             
-        public override string AuthUserInfo
+        public string AuthUserInfo
         {
             get 
             {
@@ -67,15 +67,15 @@ namespace Couchbase.Lite.Auth
                 {
                     return this.username + ":" + this.password;
                 }
-                return base.AuthUserInfo;
+                return null;
             }
         }
             
-        public override string LoginPathForSite(Uri site) {
+        public string LoginPathForSite(Uri site) {
             return "/_session";
         }
             
-        public override IDictionary<String, String> LoginParametersForSite(Uri site) {
+        public IDictionary<String, String> LoginParametersForSite(Uri site) {
             // This method has different implementation from the iOS's.
             // It is safe to return NULL as the method is not called
             // when Basic Authenticator is used. Also theoretically, the

--- a/src/Couchbase.Lite.Shared/Auth/FacebookAuthorizer.cs
+++ b/src/Couchbase.Lite.Shared/Auth/FacebookAuthorizer.cs
@@ -49,7 +49,7 @@ using Sharpen;
 
 namespace Couchbase.Lite.Auth
 {
-	public class FacebookAuthorizer : Authorizer
+    internal class FacebookAuthorizer : Authorizer
 	{
 		public const string LoginParameterAccessToken = "access_token";
 
@@ -65,6 +65,8 @@ namespace Couchbase.Lite.Auth
 		{
 			this.emailAddress = emailAddress;
 		}
+
+        public override string AuthUserInfo { get { return null; } }
 
         public override bool UsesCookieBasedLogin { get { return true; } }
 

--- a/src/Couchbase.Lite.Shared/Auth/IAuthenticator.cs
+++ b/src/Couchbase.Lite.Shared/Auth/IAuthenticator.cs
@@ -39,11 +39,20 @@
 // either express or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 //
+using System.Collections.Generic;
+using System;
 
 namespace Couchbase.Lite.Auth
 {
     public interface IAuthenticator
     {
+        string AuthUserInfo { get; }
+
+        bool UsesCookieBasedLogin { get; }
+
+        string LoginPathForSite(Uri site);
+
+        IDictionary<string, string> LoginParametersForSite(Uri site);
 
     }
 }

--- a/src/Couchbase.Lite.Shared/Auth/PersonaAuthorizer.cs
+++ b/src/Couchbase.Lite.Shared/Auth/PersonaAuthorizer.cs
@@ -53,7 +53,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Couchbase.Lite.Auth
 {
-	public class PersonaAuthorizer : Authorizer
+	internal class PersonaAuthorizer : Authorizer
 	{
 		public const string LoginParameterAssertion = "assertion";
 
@@ -123,6 +123,8 @@ namespace Couchbase.Lite.Auth
             var result = ParseAssertion(assertion);
 			return IsAssertionExpired (result) ? null : assertion;
 		}
+
+        public override string AuthUserInfo { get { return null; } }
 
         public override bool UsesCookieBasedLogin
         {

--- a/src/Couchbase.Lite.Shared/Auth/TokenAuthenticator.cs
+++ b/src/Couchbase.Lite.Shared/Auth/TokenAuthenticator.cs
@@ -45,7 +45,7 @@ using System.Collections.Generic;
 
 namespace Couchbase.Lite.Auth
 {
-    public class TokenAuthenticator : Authenticator
+    public class TokenAuthenticator : IAuthenticator
     {
         private string loginPath;
         private IDictionary<string, string>loginParams;
@@ -56,17 +56,23 @@ namespace Couchbase.Lite.Auth
             this.loginParams = loginParams;
         }
 
-        public override bool UsesCookieBasedLogin
+        public bool UsesCookieBasedLogin
         {
             get { return true; }
         }
             
-        public override IDictionary<string, string> LoginParametersForSite(Uri site) 
+        public IDictionary<string, string> LoginParametersForSite(Uri site) 
         {
             return loginParams;
         }
             
-        public override string LoginPathForSite(Uri site) 
+        public string AuthUserInfo {
+            get {
+                return null;
+            }
+        }
+
+        public string LoginPathForSite(Uri site) 
         {
             var path = loginPath;
             if (path != null && !path.StartsWith("/")) {

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -257,7 +257,7 @@ namespace Couchbase.Lite
         protected internal Int32 asyncTaskCount;
         protected internal Boolean active;
 
-        internal Authenticator Authenticator { get; set; }
+        internal IAuthenticator Authenticator { get; set; }
 
         internal CookieContainer CookieContainer 
         { 

--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -282,7 +282,7 @@ namespace Couchbase.Lite.Replicator
                 Request = new HttpRequestMessage(HttpMethod.Get, url);
 				AddRequestHeaders(Request);
 
-                ICredentials credentials = AuthUtils.GetCredentialsIfAvailable((Authenticator)Authenticator, Request);
+                ICredentials credentials = AuthUtils.GetCredentialsIfAvailable (Authenticator, Request);
                 var httpClient = client.GetHttpClient(credentials);
 
 				try

--- a/src/Couchbase.Lite.Shared/Util/AuthUtils.cs
+++ b/src/Couchbase.Lite.Shared/Util/AuthUtils.cs
@@ -51,7 +51,7 @@ namespace Couchbase.Lite.Util
     {
         const String Tag = "AuthUtils";
 
-        internal static ICredentials GetCredentialsIfAvailable (Authenticator authenticator, HttpRequestMessage request)
+        internal static ICredentials GetCredentialsIfAvailable (IAuthenticator authenticator, HttpRequestMessage request)
         {
             ICredentials credentials = null;
 

--- a/src/Couchbase.Lite.Tests.Shared/AuthTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/AuthTest.cs
@@ -122,8 +122,8 @@ namespace Couchbase.Lite
             Assert.AreEqual(tokenAuthParams.Count, parameters.Count);
             Assert.AreEqual(tokenAuthParams["access_token"], parameters["access_token"]);
             Assert.AreEqual(tokenAuth.LoginPathForSite(null), "/_facebook");
-            Assert.IsTrue(tokenAuth.UsesCookieBasedLogin());
-            Assert.IsNull(tokenAuth.AuthUserInfo());
+            Assert.IsTrue(tokenAuth.UsesCookieBasedLogin);
+            Assert.IsNull(tokenAuth.AuthUserInfo);
         }
 
         [Test]
@@ -134,8 +134,8 @@ namespace Couchbase.Lite
             var basicAuth = new BasicAuthenticator(username, password);
 
             Assert.IsNull(basicAuth.LoginParametersForSite(null));
-            Assert.IsTrue(basicAuth.UsesCookieBasedLogin());
-            Assert.AreEqual(basicAuth.AuthUserInfo(), username + ":" + password);
+            Assert.IsTrue(basicAuth.UsesCookieBasedLogin);
+            Assert.AreEqual(basicAuth.AuthUserInfo, username + ":" + password);
         }
 
         [Test]
@@ -143,7 +143,7 @@ namespace Couchbase.Lite
         {
             var username1 = "username1";
             var password1 = "password1";
-            var auth = (Authenticator)AuthenticatorFactory.CreateBasicAuthenticator(username1, password1);
+            var auth = AuthenticatorFactory.CreateBasicAuthenticator(username1, password1);
 
             var credentials = AuthUtils.GetCredentialsIfAvailable(auth, null);
             Assert.IsNotNull(credentials);
@@ -171,7 +171,7 @@ namespace Couchbase.Lite
             credentials = AuthUtils.GetCredentialsIfAvailable(null, request);
             Assert.IsNull(credentials);
 
-            auth = (Authenticator)AuthenticatorFactory.CreateFacebookAuthenticator("1234");
+            auth = AuthenticatorFactory.CreateFacebookAuthenticator("1234");
             credentials = AuthUtils.GetCredentialsIfAvailable(null, null);
             Assert.IsNull(credentials);
         }

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -579,7 +579,7 @@ namespace Couchbase.Lite.Replicator
 
             var url = GetReplicationURLWithoutCredentials();
             Replication replicator = database.CreatePushReplication(url);
-            replicator.Authenticator = AuthenticatorFactory.CreateFacebookAuthenticator(accessToken);
+            replicator.Authenticator = AuthenticatorFactory.CreateFacebookAuthenticator (accessToken);
 
 			Assert.IsNotNull(replicator);
             Assert.IsNotNull(replicator.Authenticator);
@@ -593,7 +593,7 @@ namespace Couchbase.Lite.Replicator
             var mockHttpClientFactory = new MockHttpClientFactory();
             manager.DefaultHttpClientFactory = mockHttpClientFactory;
 
-            var mockHttpHandler = (MockHttpRequestHandler)mockHttpClientFactory.HttpHandler;
+            var mockHttpHandler = mockHttpClientFactory.HttpHandler;
             mockHttpHandler.AddResponderFailAllRequests(HttpStatusCode.InternalServerError);
 
 			var dbUrlString = "http://fake.test-url.com:4984/fake/";
@@ -619,7 +619,7 @@ namespace Couchbase.Lite.Replicator
             FacebookAuthorizer.RegisterAccessToken(accessToken, email, remoteUrl);
 
             var replicator = database.CreatePullReplication(GetReplicationURL());
-            replicator.Authenticator = AuthenticatorFactory.CreateFacebookAuthenticator(accessToken);
+            replicator.Authenticator = AuthenticatorFactory.CreateFacebookAuthenticator (accessToken);
 
             RunReplication(replicator);
 
@@ -721,7 +721,7 @@ namespace Couchbase.Lite.Replicator
             var mockHttpClientFactory = new MockHttpClientFactory();
             manager.DefaultHttpClientFactory = mockHttpClientFactory;
 
-            var mockHttpHandler = (MockHttpRequestHandler)mockHttpClientFactory.HttpHandler;
+            var mockHttpHandler = mockHttpClientFactory.HttpHandler;
             mockHttpHandler.AddResponderThrowExceptionAllRequests();
 
             Uri remote = GetReplicationURL();
@@ -752,7 +752,7 @@ namespace Couchbase.Lite.Replicator
         public void TestAllLeafRevisionsArePushed()
         {
             var httpClientFactory = new MockHttpClientFactory();
-            var httpHandler = (MockHttpRequestHandler) httpClientFactory.HttpHandler; 
+            var httpHandler = httpClientFactory.HttpHandler; 
             httpHandler.AddResponderRevDiffsAllMissing();
             httpHandler.AddResponderFakeLocalDocumentUpdate404();
             httpHandler.ResponseDelayMilliseconds = 250;

--- a/src/Couchbase.Lite.Tests.Shared/Util/AlwaysFailingClientFactory.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/AlwaysFailingClientFactory.cs
@@ -61,7 +61,7 @@ namespace Couchbase.Lite.Tests
             HttpHandler = new FailEveryRequestHandler();
         }
 
-        public HttpClient GetHttpClient()
+        public HttpClient GetHttpClient(ICredentials credentials = null)
         {
             var mockHttpClient = new HttpClient(HttpHandler);
             return mockHttpClient;

--- a/src/Couchbase.Lite.sln
+++ b/src/Couchbase.Lite.sln
@@ -125,24 +125,6 @@ Global
 		{590609C7-0AC7-49AF-A888-8D90812F351F}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{590609C7-0AC7-49AF-A888-8D90812F351F}.Release|x86.ActiveCfg = Release|iPhoneSimulator
 		{590609C7-0AC7-49AF-A888-8D90812F351F}.Release|x86.Build.0 = Release|iPhoneSimulator
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.AppStore|iPhone.ActiveCfg = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.AppStore|iPhone.Build.0 = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Debug|x86.Build.0 = Debug|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|iPhone.Build.0 = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|x86.ActiveCfg = Release|Any CPU
-		{6F8EE00A-5F9D-4E6F-8153-19F8FD01A6F9}.Release|x86.Build.0 = Release|Any CPU
 		{AF7359A0-D709-491C-8DEE-5C5C1E9521B1}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
 		{AF7359A0-D709-491C-8DEE-5C5C1E9521B1}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
 		{AF7359A0-D709-491C-8DEE-5C5C1E9521B1}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
@@ -196,6 +178,6 @@ Global
 		{F970485C-CE53-457A-AAF6-7896C40F8243} = {5D187322-B6C6-4B74-A097-179F97B61B75}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = ..\samples\CouchbaseSample.iOS\CouchbaseSample.iOS.csproj
+		StartupItem = Couchbase.Lite.Android.Tests\Couchbase.Lite.Android.Tests.csproj
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Previously IAuthenticator was an empty tag interface.
This provided no benefit, despite the cost of casting
in numerous locations. This changes the interface so
that the needed members are specified, and migrates
existing subclasses to use interface implementation
instead of inheritance, making them more flexible.
