### PR TITLE
Fixes #130.

### DIFF
--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -3666,8 +3666,8 @@ PRAGMA user_version = 3;";
                 }
                 if (attachInfo.ContainsKey("revpos"))
                 {
-                    var revpos = (long)attachInfo.Get("revpos");
-                    attachment.SetRevpos((int)revpos);
+                    var revpos = Convert.ToInt32(attachInfo.Get("revpos"));
+                    attachment.SetRevpos(revpos);
                 }
                 else
                 {


### PR DESCRIPTION
Normally revpos will be a long, but in some cases,
it will be an int. This fix handles both cases.
