### PR TITLE
Complete issue #118

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -544,7 +544,7 @@ namespace Couchbase.Lite.Replicator
 			return HttpUtility.UrlEncode(Runtime.GetStringForBytes(json));
 		}
 
-        public Boolean GoOffline()
+        internal Boolean GoOffline()
         {
             Log.D(Tag, this + " goOffline() called, stopping changeTracker: " + changeTracker);
             if (!base.GoOffline())

--- a/src/Couchbase.Lite.Shared/Replication/Pusher.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Pusher.cs
@@ -130,10 +130,10 @@ namespace Couchbase.Lite.Replicator
 
         internal override void BeginReplicating()
 		{
-            // If we're still waiting to create the remote db, do nothing now. (This method will be
-            // re-invoked after that request finishes; see maybeCreateRemoteDB() above.)
             Log.D(Database.Tag, this + "|" + Sharpen.Thread.CurrentThread() + ": beginReplicating() called");
 
+            // If we're still waiting to create the remote db, do nothing now. (This method will be
+            // re-invoked after that request finishes; see maybeCreateRemoteDB() above.)
             if (CreateTarget)
             {
                 Log.D(Tag, this + "|" + Sharpen.Thread.CurrentThread() + ": creatingTarget == true, doing nothing");
@@ -168,13 +168,12 @@ namespace Couchbase.Lite.Replicator
                 Batcher.QueueObjects(changes);
                 Batcher.Flush();
             }
+
             // Now listen for future changes (in continuous mode):
             if (continuous)
             {
                 observing = true;
                 LocalDatabase.Changed += OnChanged;
-                Log.D(Tag, this + "|" + Thread.CurrentThread() + ": pusher.beginReplicating() calling asyncTaskStarted()");
-                AsyncTaskStarted();
             }
 		}
 


### PR DESCRIPTION
- Refactor Replication.GoOffline() and GoOnline() to operate async within Manager.WorkExecutor.
- Fix Replication.TestGoOffline().
- Pusher.BeginReplication no longer called AsyncTaskStarted() according to the upstream iOS code.
- Puller.GoOffline() is set to an internal method.
- Improve some logging messages.
