### PR TITLE
Test HTTPS Sync Gateway for issue #9

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/CouchbaseLiteHttpClientFactory.cs
+++ b/src/Couchbase.Lite.Shared/Replication/CouchbaseLiteHttpClientFactory.cs
@@ -45,9 +45,13 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Couchbase.Lite.Replicator;
 using Couchbase.Lite.Support;
 using Couchbase.Lite.Util;
+
+
 
 namespace Couchbase.Lite.Support
 {
@@ -62,6 +66,58 @@ namespace Couchbase.Lite.Support
         {
             this.cookieStore = cookieStore;
             Headers = new ConcurrentDictionary<string,string>();
+
+            //
+            // Source: http://msdn.microsoft.com/en-us/library/office/dd633677(v=exchg.80).aspx
+            // ServerCertificateValidationCallback returns true if either of the following criteria are met:
+            // The certificate is valid and signed with a valid root certificate.
+            // The certificate is self-signed by the server that returned the certificate.
+            //
+            ServicePointManager.ServerCertificateValidationCallback = 
+                (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            {
+                // If the certificate is a valid, signed certificate, return true.
+                if (sslPolicyErrors == System.Net.Security.SslPolicyErrors.None)
+                {
+                    return true;
+                }
+
+                // If there are errors in the certificate chain, look at each error to determine the cause.
+                if ((sslPolicyErrors & System.Net.Security.SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+                {
+                    if (chain != null && chain.ChainStatus != null)
+                    {
+                        foreach (System.Security.Cryptography.X509Certificates.X509ChainStatus status in chain.ChainStatus)
+                        {
+                            if ((certificate.Subject == certificate.Issuer) &&
+                                (status.Status == System.Security.Cryptography.X509Certificates.X509ChainStatusFlags.UntrustedRoot))
+                            {
+                                // Self-signed certificates with an untrusted root are valid. 
+                                continue;
+                            }
+                            else
+                            {
+                                if (status.Status != System.Security.Cryptography.X509Certificates.X509ChainStatusFlags.NoError)
+                                {
+                                    // If there are any other errors in the certificate chain, the certificate is invalid,
+                                    // so the method returns false.
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+
+                    // When processing reaches this line, the only errors in the certificate chain are 
+                    // untrusted root errors for self-signed certificates. These certificates are valid
+                    // for default Exchange server installations, so return true.
+                    return true;
+                }
+                else
+                {
+                    // In all other cases, return false.
+                    return false;
+                }
+            };
         }
 
         public HttpClient GetHttpClient(ICredentials credentials = null)


### PR DESCRIPTION
- Add ServicePointManager.ServerCertificateValidationCallback method to
  validate server certificates
- Test HTTPS Sync Gateway with self-signed certificate
