### PR TITLE
Fixed attachment download issue.

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -991,7 +991,7 @@ namespace Couchbase.Lite
                                     {
                                         if (numBytesRead != bufLen)
                                         {
-                                            var bufferToAppend = new ArraySegment<Byte>(buffer, 0, numBytesRead).Array;
+                                            var bufferToAppend = new ArraySegment<Byte>(buffer, 0, numBytesRead);
                                             reader.AppendData(bufferToAppend);
                                         }
                                         else


### PR DESCRIPTION
Passing in the array, as opposed to the ArraySegment would cause some
attachments to download incorrectly.  It would add extra bytes into the
attachment (dependent on the size of the remaining bytes of the last
buffered segment as compared to the buffer size)

Here's a screenshot of the diff of a binary file to illustrate the types of things I seeing in real world use (the one on the left was the temp file downloaded by couchbase lite, the one of the right was what should have been downloaded):
![image](https://cloud.githubusercontent.com/assets/1466386/3745497/4501f8a2-17ad-11e4-8112-d2de9dc2ee02.png)
