### PR TITLE
Complete issue #199

### DIFF
--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -2471,13 +2471,17 @@ PRAGMA user_version = 3;";
         {
             var extra = ExtraPropertiesForRevision(rev, contentOptions);
 
-            if (json != null)
+            if (json != null && json.Count > 0)
             {
                 rev.SetJson(AppendDictToJSON(json, extra));
             }
             else
             {
                 rev.SetProperties(extra);
+                if (json == null)
+                {
+                    rev.SetMissing(true);
+                }
             }
         }
 


### PR DESCRIPTION
In Database.expandStoredJSONIntoRevisionWithAttachments(), ensure that
json has data before appending extra information to it.
