### PR TITLE
Complete issue #202

### DIFF
--- a/src/Couchbase.Lite.Shared/Manager.cs
+++ b/src/Couchbase.Lite.Shared/Manager.cs
@@ -238,7 +238,11 @@ namespace Couchbase.Lite
             var db = GetDatabaseWithoutOpening(name, false);
             if (db != null)
             {
-                db.Open();
+                var opened = db.Open();
+                if (!opened)
+                {
+                    return null;
+                }
             }
             return db;
         }


### PR DESCRIPTION
In Manager.GetDatabase(), return null if database cannot be opened.
