### PR TITLE
Attachment upload issue

### DIFF
--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -3589,7 +3589,7 @@ PRAGMA user_version = 3;";
                     revPos = Convert.ToInt64(attachment["revpos"]);
                 }
 
-                var includeAttachment = (revPos == 0 || revPos >= minRevPos);
+                var includeAttachment = (revPos == 0 || revPos <= minRevPos);
                 var stubItOut = !includeAttachment && (!attachment.ContainsKey("stub") || (bool)attachment["stub"] == false);
                 var addFollows = includeAttachment && attachmentsFollow && (!attachment.ContainsKey("follows") || (bool)attachment["follows"] == false);
 


### PR DESCRIPTION
After updating to master yesterday, none of my attachments would no longer be uploaded by the pusher.  I tracked it down to the fact that "follows" was always being removed from the attachment before the MultiPartUploader had a chance to upload the file.

It appears to me that "includeAttachment" was not being calculated correctly, causing "follows" to be removed, thus preventing the upload.
