### PR TITLE
Fixes ChangeTracker crash.

### DIFF
--- a/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
+++ b/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
@@ -24,7 +24,7 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchI18n>
     </MtouchI18n>
-    <MtouchArch>ARMv7s</MtouchArch>
+    <MtouchArch>i386</MtouchArch>
     <MtouchSdkVersion>7.0</MtouchSdkVersion>
     <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>

--- a/samples/CouchbaseSample.iOS/Info.plist
+++ b/samples/CouchbaseSample.iOS/Info.plist
@@ -5,13 +5,10 @@
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
-		<integer>2</integer>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>CFBundleIconFiles</key>
 	<array>

--- a/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
+++ b/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
@@ -44,14 +44,14 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
-    <Reference Include="SQLitePCL.raw">
-      <HintPath>packages\SQLitePCL.raw_basic.0.4.0-alpha\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>
-    </Reference>
     <Reference Include="SQLitePCL.ugly">
-      <HintPath>packages\SQLitePCL.ugly.0.4.0-alpha\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
+      <HintPath>..\..\src\packages\SQLitePCL.ugly.0.5.0\lib\portable-net45+netcore45+wp8+MonoAndroid+MonoTouch\SQLitePCL.ugly.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>..\..\src\packages\SQLitePCL.raw_basic.0.5.0\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>packages\Newtonsoft.Json.6.0.3\lib\portable-net40+sl4+wp7+win8\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\src\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/SimpleAndroidSync/packages.config
+++ b/samples/SimpleAndroidSync/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="MonoAndroid403" />
-  <package id="SQLitePCL.raw_basic" version="0.4.0-alpha" targetFramework="MonoAndroid403" />
-  <package id="SQLitePCL.ugly" version="0.4.0-alpha" targetFramework="MonoAndroid403" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoAndroid403" />
+  <package id="SQLitePCL.raw_basic" version="0.5.0" targetFramework="MonoAndroid403" />
+  <package id="SQLitePCL.ugly" version="0.5.0" targetFramework="MonoAndroid403" />
 </packages>

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -1698,8 +1698,8 @@ namespace Couchbase.Lite
         public Int32 ChangesCount {
             get { return changesCount; }
             protected set {
-                Debug.Assert(value > 0);
-                Log.V(Tag, "Updating changes count from " + changesCount + " -> " + value);
+                //Debug.Assert(value > 0);
+                Log.V(Tag, "Updating changes count by {0} to {1}", value, changesCount);
                 changesCount = value;
                 NotifyChangeListeners();
             }

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -525,7 +525,7 @@ namespace Couchbase.Lite.Replicator
 
                 dl.Complete += (sender, args) => 
                 {
-                    if (args != null)
+                    if (args != null && args.Error != null)
                     {
                         SetLastError(args.Error);
                         RevisionFailed();

--- a/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
@@ -225,6 +225,7 @@ namespace Couchbase.Lite.Shared
 
         public void ExecSQL (String sql, params Object[] paramArgs)
         {
+            Log.D(Tag + ".ExecSQL", "{0} with values: {1}", sql, String.Join(", ", paramArgs.ToString()));
             lock (dbLock) {
                 var command = BuildCommand (sql, paramArgs);
 
@@ -256,7 +257,7 @@ namespace Couchbase.Lite.Shared
             var command = BuildCommand (sql, paramArgs);
 
             try {
-                Log.V(Tag, "RawQuery sql: {0}".Fmt(sql));
+                Log.V(Tag, "RawQuery sql: {0} ({1})", sql, String.Join(", ", paramArgs));
                 lock (dbLock) {
                 cursor = new Cursor(command, dbLock);
                 }

--- a/src/Couchbase.Lite.Shared/Util/DefaultAuthHandler.cs
+++ b/src/Couchbase.Lite.Shared/Util/DefaultAuthHandler.cs
@@ -53,14 +53,11 @@ namespace Couchbase.Lite.Replicator
 
     internal sealed class DefaultAuthHandler : MessageProcessingHandler
     {
-        internal IDictionary<CancellationToken, HttpRequestMessage> Requests { get; set; }
-
         public DefaultAuthHandler(HttpClientHandler context, CookieStore cookieStore) : base()
         {
             this.context = context;
             this.cookieStore = cookieStore;
             InnerHandler = this.context;
-            Requests = new Dictionary<CancellationToken, HttpRequestMessage>();
         }
 
         #region implemented abstract members of MessageProcessingHandler
@@ -82,7 +79,7 @@ namespace Couchbase.Lite.Replicator
         }
 
         /// <exception cref="System.IO.IOException"></exception>
-        protected override HttpRequestMessage ProcessRequest(HttpRequestMessage request, CancellationToken token)
+        protected override HttpRequestMessage ProcessRequest(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             // TODO: We could make this class handle more than one request using a dictionary of cancellation tokens,
             //       but that would require using unique tokens per request, instead of sharing them. In order to

--- a/src/Couchbase.Lite.Tests.Shared/LiteTestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LiteTestCase.cs
@@ -77,11 +77,8 @@ namespace Couchbase.Lite
         protected void SetUp()
         {
             Log.V(Tag, "SetUp");
-//#if !(__IOS__)
-//            Trace.Listeners.Clear();
-//            Trace.Listeners.Add(new ConsoleTraceListener());
             ManagerOptions.Default.CallbackScheduler = TaskScheduler.Default;
-//#endif
+
             LoadCustomProperties();
             StartCBLite();
             StartDatabase();

--- a/src/Couchbase.Lite.sln
+++ b/src/Couchbase.Lite.sln
@@ -250,7 +250,7 @@ Global
 		{F376966C-CCAB-4C5C-A81A-E2A754AA7A4C} = {3D44EF32-EE84-42A0-B586-6AE71AB75CFF}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = Couchbase.Lite.iOS.Tests\Couchbase.Lite.iOS.Tests.csproj
+		StartupItem = ..\samples\CouchbaseSample.iOS\CouchbaseSample.iOS.csproj
 		Policies = $0
 		$0.TextStylePolicy = $1
 		$1.FileWidth = 120


### PR DESCRIPTION
Works around the InvalidOperationException that intermittently
crops up during a heavy sync session, bearing the message:

  Cannot re-call start of asynchronous while
  method while a previous call is still in progress
