### PR TITLE
Fixes #272.

### DIFF
--- a/src/Couchbase.Lite.Shared/Util/SingleThreadTaskScheduler.cs
+++ b/src/Couchbase.Lite.Shared/Util/SingleThreadTaskScheduler.cs
@@ -10,8 +10,7 @@ namespace Couchbase.Lite.Util
     sealed internal class SingleThreadTaskScheduler : TaskScheduler 
     {
         const string Tag = "SingleThreadTaskScheduler";
-
- 
+         
         private readonly BlockingCollection<Task> queue = new BlockingCollection<Task>(new ConcurrentQueue<Task>());
         private const int maxConcurrency = 1;
         private int runningTasks = 0;
@@ -34,6 +33,7 @@ namespace Couchbase.Lite.Util
             Log.D(Tag, " --> Queued a task: {0}/{1}/{2}", queue.Count, runningTasks, longRunningTasks);
             if (runningTasks < maxConcurrency)
             {
+                Interlocked.MemoryBarrier();
                 Interlocked.Increment(ref runningTasks);
                 QueueThreadPoolWorkItem (); 
             }


### PR DESCRIPTION
Prevents ARM CPU's from reordering read/write
sequences such that writes to a guard variable
are reordered ahead of reads.

In this case, our task scheduler was periodically
allowing two concurrent tasks using shared
state, causing one to overwrite the other.
