### PR TITLE
Adds debounce logic for Android network changes.

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -356,6 +356,7 @@ namespace Couchbase.Lite.Replicator
                         var err = t.Exception.Flatten();
                         Log.D(Tag, "ChangeFeedResponseHandler faulted.", err.InnerException ?? err);
                         Error = err.InnerException ?? err;
+                        backoff.SleepAppropriateAmountOfTime();
                         return true; // a real error.
                     }, changesFeedRequestTokenSource.Token, TaskContinuationOptions.OnlyOnFaulted, WorkExecutor.Scheduler);
 
@@ -423,55 +424,6 @@ namespace Couchbase.Lite.Replicator
                         Stop();
                     }
                 }
-//                var singleRequestTokenSource = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token);
-//                var cTask = httpClient.SendAsync(Request, HttpCompletionOption.ResponseHeadersRead, singleRequestTokenSource.Token);
-//                var bTask = cTask
-//                    .ContinueWith<HttpResponseMessage>(t =>
-//                    {
-//                        if (!IsRunning)
-//                        {
-//                            return null;
-//                            // swallow
-//                        }
-//                        if (t.IsFaulted && t.Exception.InnerException is IOException)
-//                        {
-//                            // in this case, just silently absorb the exception because it
-//                            // frequently happens when we're shutting down and have to
-//                            // close the socket underneath our read.
-//                            Log.E(Tag, "Exception in change tracker", t.Exception);
-//                            return null;
-//                        }
-//                        if (!singleRequestTokenSource.IsCancellationRequested && t.Exception != null)
-//                        {
-//                            var e = t.Exception.InnerException as WebException;
-//                            var status = (HttpStatusCode)e.Status;
-//                            if ((Int32)status >= 300 && !Misc.IsTransientError(status))
-//                            {
-//                                var response = t.Result;
-//                                var msg = response.Content != null 
-//                                    ? String.Format("Change tracker got error with status code: {0}", status)
-//                                    : String.Format("Change tracker got error with status code: {0} and null response content", status);
-//                                Log.E(Tag, msg);
-//                                Error = new CouchbaseLiteException(msg, new Status(status.GetStatusCode()));
-//                                Stop();
-//                            }
-//                            backoff.SleepAppropriateAmountOfTime();
-//                        }
-//                        return t.Result;
-//                    }, singleRequestTokenSource.Token, TaskContinuationOptions.OnlyOnFaulted, WorkExecutor.Scheduler)
-//                    .ContinueWith<HttpResponseMessage>(ChangeFeedResponseHandler, singleRequestTokenSource.Token, TaskContinuationOptions.OnlyOnRanToCompletion, WorkExecutor.Scheduler)
-//                    .ContinueWith<HttpResponseMessage>(t => 
-//                    {
-//                        Log.D(Tag, "ChangeFeedResponseHandler finished.");
-//                        singleRequestTokenSource.Token.ThrowIfCancellationRequested();
-//                        if (t != null) t.Result.Dispose();
-//                        return null;
-//                    }, singleRequestTokenSource.Token, TaskContinuationOptions.OnlyOnRanToCompletion, WorkExecutor.Scheduler);
-//                changesRequestTask = bTask;
-//                    .ContinueWith((t) => 
-//                    {
-//                        Log.D(Tag, "ChangeFeedResponseHandler faulted.");
-//                    }, singleRequestTokenSource.Token, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.AttachedToParent, TaskScheduler.Default);
             }
         }
 

--- a/src/Couchbase.Lite.Shared/Replication/ChangeTrackerBackoff.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTrackerBackoff.cs
@@ -41,17 +41,17 @@
 //
 
 using System;
-using Couchbase.Lite;
-using Couchbase.Lite.Replicator;
 using Couchbase.Lite.Util;
-using Sharpen;
 using System.Threading;
 
 namespace Couchbase.Lite.Replicator
 {
     internal class ChangeTrackerBackoff
     {
-        public const int MaxSleepMilliseconds = 5 * 60 * 1000; // 5 Mins
+        internal const int MaxSleepMilliseconds = 5 * 60 * 1000;
+        private const string Tag = "ChangeTrackerBackoff";
+
+ // 5 Mins
 
         public Int32 NumAttempts { get; private set; }
 
@@ -82,6 +82,7 @@ namespace Couchbase.Lite.Replicator
                 var sleepMilliseconds = GetSleepMilliseconds();
                 if (sleepMilliseconds > 0)
                 {
+                    Log.D(Tag, "Sleeping for {0} milliseconds.", sleepMilliseconds);
                     Thread.Sleep(TimeSpan.FromMilliseconds(sleepMilliseconds));
                 }
             }


### PR DESCRIPTION
Android will send duplicate network change intents.
This adds some debounce logic to prevent the change
handler logic from calling online/offline too many
times.
