### PR TITLE
Fixes #286 - Loads message contents in DefaultAuthHandler

### DIFF
--- a/src/Couchbase.Lite.Net45/Couchbase.Lite.Net45.csproj
+++ b/src/Couchbase.Lite.Net45/Couchbase.Lite.Net45.csproj
@@ -36,6 +36,8 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Release\Couchbase.Lite.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -1128,7 +1128,7 @@ namespace Couchbase.Lite
                     }
                     catch (IOException e)
                     {
-                        Log.E(Tag, "io exception", e);
+                        Log.E(Tag, "IO Exception", e);
                         error = e;
                     }
                 }), WorkExecutor.Scheduler);

--- a/src/Couchbase.Lite.Shared/Replication/BulkDownloader.cs
+++ b/src/Couchbase.Lite.Shared/Replication/BulkDownloader.cs
@@ -183,13 +183,13 @@ namespace Couchbase.Lite.Replicator
             catch (AggregateException e)
             {
                 var err = e.InnerException;
-                Log.E(Tag, "io exception", err);
+                Log.E(Tag, "Unhandled Exception", err);
                 error = err;
                 RespondWithResult(fullBody, err, response);
             }
             catch (IOException e)
             {
-                Log.E(Tag, "io exception", e);
+                Log.E(Tag, "IO Exception", e);
                 error = e;
                 RespondWithResult(fullBody, e, response);
             }

--- a/src/Couchbase.Lite.Shared/Util/CouchbaseTraceListener.cs
+++ b/src/Couchbase.Lite.Shared/Util/CouchbaseTraceListener.cs
@@ -40,7 +40,8 @@
 // and limitations under the License.
 //
 #if DEBUG
-//#define __DEBUGGER__
+define __DEBUGGER__
+#else
 #define __CONSOLE__
 #endif
 

--- a/src/Couchbase.Lite.Shared/Util/DefaultAuthHandler.cs
+++ b/src/Couchbase.Lite.Shared/Util/DefaultAuthHandler.cs
@@ -66,6 +66,9 @@ namespace Couchbase.Lite.Replicator
 
         protected override HttpResponseMessage ProcessResponse (HttpResponseMessage response, CancellationToken cancellationToken)
         {
+            if (response.Content != null) {
+                response.Content.LoadIntoBufferAsync().Wait();
+            }
             var hasSetCookie = response.Headers.Contains("Set-Cookie");
             if (hasSetCookie)
             {
@@ -81,6 +84,9 @@ namespace Couchbase.Lite.Replicator
         /// <exception cref="System.IO.IOException"></exception>
         protected override HttpRequestMessage ProcessRequest(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (request.Content != null) {
+                request.Content.LoadIntoBufferAsync().Wait();
+            }
             // TODO: We could make this class handle more than one request using a dictionary of cancellation tokens,
             //       but that would require using unique tokens per request, instead of sharing them. In order to
             //       keep our easy cancellability, we can use linked cancellation sourceses that all link back

--- a/src/Couchbase.Lite.Shared/Util/Log.cs
+++ b/src/Couchbase.Lite.Shared/Util/Log.cs
@@ -122,7 +122,7 @@ namespace Couchbase.Lite.Util
         /// the class or activity where the log call occurs.
         /// </param>
         /// <param name="msg">The message you would like logged.</param>
-        [System.Diagnostics.Conditional("TRACE")]
+        [System.Diagnostics.Conditional("DEBUG")]
         public static void D(string tag, string msg)
         {
             if (Logger != null)
@@ -139,7 +139,7 @@ namespace Couchbase.Lite.Util
         /// </param>
         /// <param name="msg">The message you would like logged.</param>
         /// <param name="tr">An exception to log</param>
-        [System.Diagnostics.Conditional("TRACE")]
+        [System.Diagnostics.Conditional("DEBUG")]
         public static void D(string tag, string msg, Exception tr)
         {
             if (Logger != null)
@@ -156,7 +156,7 @@ namespace Couchbase.Lite.Util
         /// </param>
         /// <param name="format">The message you would like logged.</param>
         /// <param name="args">string format arguments</param>
-        [System.Diagnostics.Conditional("TRACE")]
+        [System.Diagnostics.Conditional("DEBUG")]
         public static void D(string tag, string  format, params object[] args)
         {
             if (Logger != null)
@@ -172,7 +172,6 @@ namespace Couchbase.Lite.Util
         /// the class or activity where the log call occurs.
         /// </param>
         /// <param name="msg">The message you would like logged.</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void I(string tag, string msg)
         {
             if (Logger != null)
@@ -189,7 +188,6 @@ namespace Couchbase.Lite.Util
         /// </param>
         /// <param name="msg">The message you would like logged.</param>
         /// <param name="tr">An exception to log</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void I(string tag, string msg, Exception tr)
         {
             if (Logger != null)
@@ -206,7 +204,6 @@ namespace Couchbase.Lite.Util
         /// </param>
         /// <param name="format">The message you would like logged.</param>
         /// <param name="args">string format arguments</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void I(string tag, string  format, params object[] args)
         {
             if (Logger != null)
@@ -222,7 +219,6 @@ namespace Couchbase.Lite.Util
         /// the class or activity where the log call occurs.
         /// </param>
         /// <param name="msg">The message you would like logged.</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void W(string tag, string msg)
         {
             if (Logger != null)
@@ -235,7 +231,6 @@ namespace Couchbase.Lite.Util
         /// <remarks>Send a WARN message.</remarks>
         /// <param name="tag">Tag.</param>
         /// <param name="tr">Exception</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void W(string tag, Exception tr)
         {
             if (Logger != null)
@@ -252,7 +247,6 @@ namespace Couchbase.Lite.Util
         /// </param>
         /// <param name="msg">The message you would like logged.</param>
         /// <param name="tr">An exception to log</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void W(string tag, string msg, Exception tr)
         {
             if (Logger != null)
@@ -269,7 +263,6 @@ namespace Couchbase.Lite.Util
         /// </param>
         /// <param name="format">The message you would like logged.</param>
         /// <param name="args">string format arguments</param>
-        [System.Diagnostics.Conditional("TRACE")]
         public static void W(string tag, string  format, params object[] args)
         {
             if (Logger != null)


### PR DESCRIPTION
Many parts of the code read request or response message
contents. HttpClient only allows one read before disposing,
thus creating a problem. Our DefaultAuthHandler loads the
content to an internal buffer, resolving the problem.
