### PR TITLE
Fixes #292.

### DIFF
--- a/src/Couchbase.Lite.Shared/Util/StreamUtils.cs
+++ b/src/Couchbase.Lite.Shared/Util/StreamUtils.cs
@@ -27,8 +27,8 @@ namespace Couchbase.Lite.Util
             {
                 outStream.Write(buffer, 0, n);
             }
-            outStream.Close();
-            inStream.Close();
+            outStream.Dispose();
+            inStream.Dispose();
         }
     }
 }


### PR DESCRIPTION
ReplaceDatabase would previously result in a
database file corrupt error after calling
it on an existing database.

This was largely because it replaced the file
without reopening the database. Instead,
we don't first open the database, replace
the files, and _then_ open it.
