### PR TITLE
Fixes #294.

### DIFF
--- a/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
+++ b/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
@@ -25,7 +25,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Debug\Couchbase.Lite.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Release\Couchbase.Lite.xml</DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>pdbonly</DebugType>

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -913,7 +913,7 @@ namespace Couchbase.Lite
                 ? requestTokenSource.Token
                 : CancellationTokenSource.Token;
             Log.D(Tag, "Sending async {0} request to: {1}", method, url);
-            client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, token)
+            client.SendAsync(message, token)
                 .ContinueWith(response =>
                 {
                     lock(requests)

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -792,7 +792,7 @@ namespace Couchbase.Lite.Replicator
         /// <summary>This will be called when _revsToInsert fills up:</summary>
         public void InsertDownloads(IList<RevisionInternal> downloads)
         {
-            Log.I(Tag, "inserting " + downloads.Count + " revisions...");
+            Log.V(Tag, "Inserting " + downloads.Count + " revisions...");
 
             var time = DateTime.UtcNow;
 

--- a/src/Couchbase.Lite.Shared/Replication/RemoteRequest.cs
+++ b/src/Couchbase.Lite.Shared/Replication/RemoteRequest.cs
@@ -158,7 +158,7 @@ namespace Couchbase.Lite.Replicator
         protected HttpRequestMessage CreateConcreteRequest()
         {
             var httpMethod = new HttpMethod(method);
-            var newRequest = new HttpRequestMessage(httpMethod, url.AbsoluteUri);;
+            var newRequest = new HttpRequestMessage(httpMethod, url.AbsoluteUri);
             return newRequest;
         }
 
@@ -179,6 +179,10 @@ namespace Couchbase.Lite.Replicator
                 var entity = new ByteArrayContent(bodyBytes);
                 entity.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                 request.Content = entity;
+            }
+            else
+            {
+                Log.W(Tag + ".SetBody", "No body found for this request to {0}", request.RequestUri);
             }
         }
 
@@ -222,7 +226,7 @@ namespace Couchbase.Lite.Replicator
                     return;
                 }
                 Log.V(Tag, "{0}: RemoteRequest calling httpClient.execute", this);
-                response = httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, _tokenSource.Token).Result;
+                response = httpClient.SendAsync(requestMessage, _tokenSource.Token).Result;
                 Log.V(Tag, "{0}: RemoteRequest called httpClient.execute", this);
                 var status = response.StatusCode;
                 if (Misc.IsTransientError(status) && RetryRequest())


### PR DESCRIPTION
Adds quite a bit of new error handling code.
Most importantly, no longer uses the
HttpCompletionOptions overload of SendAsync.
Also adjusts some logging level of a few
trace statements.
