### PR TITLE
Fix #304 Too many open files

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -933,79 +933,87 @@ namespace Couchbase.Lite
             var token = requestTokenSource != null 
                 ? requestTokenSource.Token
                 : CancellationTokenSource.Token;
+
             Log.D(Tag, "Sending async {0} request to: {1}", method, url);
             client.SendAsync(message, token)
                 .ContinueWith(response =>
                 {
-                    lock(requests)
+                    try 
                     {
-                        requests.Remove(client);
-                    }
-                    HttpResponseMessage result = null;
-                    Exception error = null;
-                    if (!response.IsFaulted)
-                    {
-                        result = response.Result;
-                        UpdateServerType(result);
-                    }
-                    else
-                    {
-                        error = response.Exception.InnerException;
-                        Log.E(Tag, "Http Message failed to send: {0}", message);
-                        Log.E(Tag, "Http exception", response.Exception.InnerException);
-                        if (message.Content != null) {
-                            Log.E(Tag, "\tFailed content: {0}", message.Content.ReadAsStringAsync().Result);
-                        }
-                    }
-                    
-                    if (completionHandler != null)
-                    {
-                        object fullBody = null;
-
-                        try
+                        lock(requests)
                         {
-                            if (response.Status != TaskStatus.RanToCompletion) {
-                                Log.D(Tag, "SendAsyncRequest did not run to completion.", response.Exception);
+                            requests.Remove(client);
+                        }
+                        HttpResponseMessage result = null;
+                        Exception error = null;
+                        if (!response.IsFaulted)
+                        {
+                            result = response.Result;
+                            UpdateServerType(result);
+                        }
+                        else
+                        {
+                            error = response.Exception.InnerException;
+                            Log.E(Tag, "Http Message failed to send: {0}", message);
+                            Log.E(Tag, "Http exception", response.Exception.InnerException);
+                            if (message.Content != null) {
+                                Log.E(Tag, "\tFailed content: {0}", message.Content.ReadAsStringAsync().Result);
                             }
+                        }
 
-                            error = error is AggregateException
-                                ? response.Exception.Flatten()
-                                : response.Exception;
+                        if (completionHandler != null)
+                        {
+                            object fullBody = null;
 
-                            if (error == null )
+                            try
                             {
-                                if (!result.IsSuccessStatusCode) 
+                                if (response.Status != TaskStatus.RanToCompletion) {
+                                    Log.D(Tag, "SendAsyncRequest did not run to completion.", response.Exception);
+                                }
+
+                                error = error is AggregateException
+                                    ? response.Exception.Flatten()
+                                    : response.Exception;
+
+                                if (error == null )
                                 {
-                                    result = response.Result;
-                                    error = new HttpResponseException(result.StatusCode);
+                                    if (!result.IsSuccessStatusCode) 
+                                    {
+                                        result = response.Result;
+                                        error = new HttpResponseException(result.StatusCode);
+                                    }
+                                }
+
+                                if (error == null)
+                                {
+                                    var content = result.Content;
+                                    if (content != null)
+                                    {
+                                        fullBody = mapper.ReadValue<object>(content.ReadAsStreamAsync().Result);
+                                    }
                                 }
                             }
-
-                            if (error == null)
+                            catch (Exception e)
                             {
-                                var content = result.Content;
-                                if (content != null)
-                                {
-                                    fullBody = mapper.ReadValue<object>(content.ReadAsStreamAsync().Result);
-                                }
+                                error = e;
+                                Log.E(Tag, "SendAsyncRequest has an error occurred.", e);
                             }
-                        }
-                        catch (Exception e)
-                        {
-                            error = e;
-                            Log.E(Tag, "SendAsyncRequest has an error occurred.", e);
+
+                            if (response.Status == TaskStatus.Canceled)
+                            {
+                                fullBody = null;
+                                error = new Exception("SendAsyncRequest Task has been canceled.");
+                            }
+
+                            completionHandler(fullBody, error);
                         }
 
-                        if (response.Status == TaskStatus.Canceled)
-                        {
-                            fullBody = null;
-                            error = new Exception("SendAsyncRequest Task has been canceled.");
-                        }
-
-                        completionHandler(fullBody, error);
+                        return result;
                     }
-
-                    return result;
+                    finally
+                    {
+                        client.Dispose();
+                    }
                 }, token, TaskContinuationOptions.None, WorkExecutor.Scheduler);
 
             lock(requests)
@@ -1041,8 +1049,7 @@ namespace Couchbase.Lite
                     client.DefaultRequestHeaders.Authorization = authHeader;
                 }
 
-                client.SendAsync(message, CancellationTokenSource.Token)
-                .ContinueWith(new Action<Task<HttpResponseMessage>>(responseMessage =>
+                client.SendAsync(message, CancellationTokenSource.Token).ContinueWith(new Action<Task<HttpResponseMessage>>(responseMessage =>
                 {
                     object fullBody = null;
                     Exception error = null;
@@ -1152,6 +1159,10 @@ namespace Couchbase.Lite
                         Log.E(Tag, "IO Exception", e);
                         error = e;
                     }
+                    finally
+                    {
+                        client.Dispose();
+                    }
                 }), WorkExecutor.Scheduler);
             }
             catch (UriFormatException e)
@@ -1190,30 +1201,39 @@ namespace Couchbase.Lite
                     if (response.Status != TaskStatus.RanToCompletion)
                     {
                         Log.E(Tag, "SendAsyncRequest did not run to completion.", response.Exception);
+                        client.Dispose();
                         return null;
                     }
                     if ((Int32)response.Result.StatusCode > 300) {
                         SetLastError(new HttpResponseException(response.Result.StatusCode));
                         Log.E(Tag, "Server returned HTTP Error", LastError);
+                        client.Dispose();
                         return null;
                     }
                     return response.Result.Content.ReadAsStreamAsync();
                 }, CancellationTokenSource.Token)
                 .ContinueWith(response=> {
-                    var hasEmptyResult = response.Result == null || response.Result.Result == null || response.Result.Result.Length == 0;
-                    if (response.Status != TaskStatus.RanToCompletion) {
-                        Log.E (Tag, "SendAsyncRequest did not run to completion.", response.Exception);
-                    } else if (hasEmptyResult) {
-                        Log.E (Tag, "Server returned an empty response.", response.Exception ?? LastError);
-                    }
-                    if (completionHandler != null) {
-                        object fullBody = null;
-                        if (!hasEmptyResult)
-                        {
-                            var mapper = Manager.GetObjectMapper();
-                            fullBody = mapper.ReadValue<Object> (response.Result.Result);
+                    try 
+                    {
+                        var hasEmptyResult = response.Result == null || response.Result.Result == null || response.Result.Result.Length == 0;
+                        if (response.Status != TaskStatus.RanToCompletion) {
+                            Log.E (Tag, "SendAsyncRequest did not run to completion.", response.Exception);
+                        } else if (hasEmptyResult) {
+                            Log.E (Tag, "Server returned an empty response.", response.Exception ?? LastError);
                         }
-                        completionHandler (fullBody, response.Exception);
+                        if (completionHandler != null) {
+                            object fullBody = null;
+                            if (!hasEmptyResult)
+                            {
+                                var mapper = Manager.GetObjectMapper();
+                                fullBody = mapper.ReadValue<Object> (response.Result.Result);
+                            }
+                            completionHandler (fullBody, response.Exception);
+                        }
+                    }
+                    finally
+                    {
+                        client.Dispose();
                     }
                 }, CancellationTokenSource.Token);
         }

--- a/src/Couchbase.Lite.Shared/Replication/BulkDownloader.cs
+++ b/src/Couchbase.Lite.Shared/Replication/BulkDownloader.cs
@@ -69,20 +69,31 @@ namespace Couchbase.Lite.Replicator
 
         public override void Run()
         {
-            var httpClient = clientFactory.GetHttpClient();
-
-            requestMessage.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("multipart/related"));
-
-            var authHeader = AuthUtils.GetAuthenticationHeaderValue(Authenticator, requestMessage.RequestUri);
-            if (authHeader != null)
+            HttpClient httpClient = null;
+            try 
             {
-                httpClient.DefaultRequestHeaders.Authorization = authHeader;
+                httpClient = clientFactory.GetHttpClient();
+                requestMessage.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("multipart/related"));
+
+                var authHeader = AuthUtils.GetAuthenticationHeaderValue(Authenticator, requestMessage.RequestUri);
+                if (authHeader != null)
+                {
+                    httpClient.DefaultRequestHeaders.Authorization = authHeader;
+                }
+
+                //TODO: implement gzip support for server response see issue #172
+                //request.addHeader("X-Accept-Part-Encoding", "gzip");
+                AddRequestHeaders(requestMessage);
+                SetBody(requestMessage);
+                ExecuteRequest(httpClient, requestMessage);
             }
-            //TODO: implement gzip support for server response see issue #172
-            //request.addHeader("X-Accept-Part-Encoding", "gzip");
-            AddRequestHeaders(requestMessage);
-            SetBody(requestMessage);
-            ExecuteRequest(httpClient, requestMessage);
+            finally
+            {
+                if (httpClient != null) 
+                {
+                    httpClient.Dispose();
+                }
+            }
         }
 
         private string Description()

--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -272,13 +272,6 @@ namespace Couchbase.Lite.Replicator
 
             while (IsRunning && !tokenSource.Token.IsCancellationRequested)
             {
-//                if (changesRequestTask != null && !changesRequestTask.IsCanceled && !changesRequestTask.IsFaulted) 
-//                {
-//                    Thread.Sleep(500);
-//                    continue;
-//                }
-                var httpClient = client.GetHttpClient();
-
                 if (Request != null)
                 {
                     Request.Dispose();
@@ -300,24 +293,28 @@ namespace Couchbase.Lite.Replicator
 
                 AddRequestHeaders(Request);
 
-                var authHeader = AuthUtils.GetAuthenticationHeaderValue(Authenticator, Request.RequestUri);
-                if (authHeader != null)
-                {
-                    httpClient.DefaultRequestHeaders.Authorization = authHeader;
-                }
-
                 var maskedRemoteWithoutCredentials = url.ToString();
                 maskedRemoteWithoutCredentials = maskedRemoteWithoutCredentials.ReplaceAll("://.*:.*@", "://---:---@");
                 Log.V(Tag, "Making request to " + maskedRemoteWithoutCredentials);
 
                 if (tokenSource.Token.IsCancellationRequested)
+                {
                     break;
+                }
 
                 Task<HttpResponseMessage> changesRequestTask = null;
                 Task<HttpResponseMessage> successHandler;
                 Task<Boolean> errorHandler;
 
+                HttpClient httpClient = null;
                 try {
+                    httpClient = client.GetHttpClient();
+                    var authHeader = AuthUtils.GetAuthenticationHeaderValue(Authenticator, Request.RequestUri);
+                    if (authHeader != null)
+                    {
+                        httpClient.DefaultRequestHeaders.Authorization = authHeader;
+                    }
+
                     changesFeedRequestTokenSource = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token);
 
                     var evt = new ManualResetEvent(false);
@@ -350,7 +347,8 @@ namespace Couchbase.Lite.Replicator
 
                     errorHandler = changesRequestTask.ContinueWith(t =>
                     {
-                        if (t.IsCanceled) {
+                        if (t.IsCanceled) 
+                        {
                             return false; // Not a real error.
                         }
                         var err = t.Exception.Flatten();
@@ -360,16 +358,20 @@ namespace Couchbase.Lite.Replicator
                         return true; // a real error.
                     }, changesFeedRequestTokenSource.Token, TaskContinuationOptions.OnlyOnFaulted, WorkExecutor.Scheduler);
 
-                    try {
+                    try 
+                    {
                         var completedTask = Task.WhenAll(successHandler, errorHandler);
                         completedTask.Wait((Int32)ManagerOptions.Default.RequestTimeout.TotalMilliseconds, changesFeedRequestTokenSource.Token);
                         Log.D(Tag, "Finished processing changes feed.");
-                    } catch (Exception ex) {
+                    } 
+                    catch (Exception ex) {
                         // Swallow TaskCancelledExceptions, which will always happen
                         // if either errorHandler or successHandler don't need to fire.
                         if (!(ex.InnerException is TaskCanceledException))
                             throw ex;
-                    } finally {
+                    } 
+                    finally 
+                    {
                         if (changesRequestTask.IsCompleted) 
                         {
                             changesRequestTask.Dispose();
@@ -395,11 +397,6 @@ namespace Couchbase.Lite.Replicator
 
                         changesFeedRequestTokenSource.Dispose();
 						changesFeedRequestTokenSource = null;
-
-                        if (httpClient != null) 
-                        {
-                            httpClient.Dispose();
-                        }
                     }
                 }
                 catch (Exception e)
@@ -419,6 +416,11 @@ namespace Couchbase.Lite.Replicator
                 }
                 finally
                 {
+                    if (httpClient != null)
+                    {
+                        httpClient.Dispose();
+                    }
+
                     if (mode == ChangeTrackerMode.OneShot)
                     {
                         Stop();

--- a/src/Couchbase.Lite.Shared/Replication/CouchbaseLiteHttpClientFactory.cs
+++ b/src/Couchbase.Lite.Shared/Replication/CouchbaseLiteHttpClientFactory.cs
@@ -137,7 +137,11 @@ namespace Couchbase.Lite.Support
         public HttpClient GetHttpClient()
         {
             var authHandler = BuildHandlerPipeline();
-            var client =  new HttpClient(authHandler, false) // <- don't dispose the handler, which we reuse.
+
+            // As the handler will not be shared, client.Dispose() needs to be 
+            // called once the operation is done to release the unmanaged resources 
+            // and disposes of the managed resources.
+            var client =  new HttpClient(authHandler, true) 
             {
                 Timeout = ManagerOptions.Default.RequestTimeout,
             };

--- a/src/Couchbase.Lite.Shared/Replication/RemoteRequest.cs
+++ b/src/Couchbase.Lite.Shared/Replication/RemoteRequest.cs
@@ -107,23 +107,34 @@ namespace Couchbase.Lite.Replicator
         {
             Log.V(Tag, "{0}: RemoteRequest run() called, url: {1}".Fmt(this, url));
 
-            var httpClient = clientFactory.GetHttpClient();
-            
-            //var manager = httpClient.GetConnectionManager();
-            var authHeader = AuthUtils.GetAuthenticationHeaderValue(Authenticator, requestMessage.RequestUri);
-            if (authHeader != null)
+            HttpClient httpClient = null;
+            try
             {
-                httpClient.DefaultRequestHeaders.Authorization = authHeader;
-            }
+                httpClient = clientFactory.GetHttpClient();
 
-            requestMessage.Headers.Add("Accept", "multipart/related, application/json");           
-            AddRequestHeaders(requestMessage);
-            
-            SetBody(requestMessage);
-            
-            ExecuteRequest(httpClient, requestMessage);
-            
-            Log.V(Tag, "{0}: RemoteRequest run() finished, url: {1}".Fmt(this, url));
+                //var manager = httpClient.GetConnectionManager();
+                var authHeader = AuthUtils.GetAuthenticationHeaderValue(Authenticator, requestMessage.RequestUri);
+                if (authHeader != null)
+                {
+                    httpClient.DefaultRequestHeaders.Authorization = authHeader;
+                }
+
+                requestMessage.Headers.Add("Accept", "multipart/related, application/json");           
+                AddRequestHeaders(requestMessage);
+
+                SetBody(requestMessage);
+
+                ExecuteRequest(httpClient, requestMessage);
+
+                Log.V(Tag, "{0}: RemoteRequest run() finished, url: {1}".Fmt(this, url));
+            }
+            finally
+            {
+                if (httpClient != null)
+                {
+                    httpClient.Dispose();
+                }
+            }
         }
 
         public virtual void Abort()

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -652,11 +652,11 @@ namespace Couchbase.Lite
             CountDownLatch httpRequestDoneSignal = new CountDownLatch(1);
             Task.Factory.StartNew(() =>
             {
-                var httpclient = new HttpClient(); //CouchbaseLiteHttpClientFactory.Instance.GetHttpClient();
-                HttpResponseMessage response;
-
+                HttpClient httpclient = null;
                 try
                 {
+                    httpclient = new HttpClient();
+                    HttpResponseMessage response;
                     var request = new HttpRequestMessage();
                     request.Headers.Add("Accept", "*/*");
 
@@ -673,6 +673,10 @@ namespace Couchbase.Lite
                 catch (IOException e)
                 {
                     Assert.IsNull(e, "Got IOException: " + e.Message);
+                }
+                finally
+                {
+                    httpclient.Dispose();
                 }
 
                 httpRequestDoneSignal.CountDown();


### PR DESCRIPTION
As the HttpClient's handler is not shared anymore, we need to ensure that the HttpClient is disposed after done using it.
