### PR TITLE
Lowercase document ids and revision ids

### DIFF
--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -4023,7 +4023,7 @@ PRAGMA user_version = 3;";
             var md5DigestResult = md5Digest.Digest();
             var digestAsHex = BitConverter.ToString(md5DigestResult).Replace("-", String.Empty);
             int generationIncremented = generation + 1;
-			return string.Format("{0}-{1}", generationIncremented, digestAsHex).ToLower();
+            return string.Format("{0}-{1}", generationIncremented, digestAsHex).ToLower();
         }
 
         internal IList<String> GetPossibleAncestorRevisionIDs(RevisionInternal rev, int limit, ref Boolean hasAttachment)

--- a/src/Couchbase.Lite.Shared/Util/Misc.cs
+++ b/src/Couchbase.Lite.Shared/Util/Misc.cs
@@ -56,7 +56,7 @@ namespace Couchbase.Lite
     {
         public static string CreateGUID()
         {
-			return Guid.NewGuid().ToString().ToLower();
+            return Guid.NewGuid().ToString().ToLower();
         }
 
         public static string HexSHA1Digest(IEnumerable<Byte> input)


### PR DESCRIPTION
Changes to make sure document ids and revision ids are created with lowercase to match CouchDB.
