### PR TITLE
Fixed change tracker to not throw exception when syncing with with CouchDB

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -459,7 +459,7 @@ namespace Couchbase.Lite.Replicator
                         catch (JsonSerializationException ex)
                         {
                             const string timeoutContent = "{\"results\":[";
-							if (!Encoding.UTF8.GetString(content).Trim().Equals(timeoutContent))
+                            if (!Encoding.UTF8.GetString(content).Trim().Equals(timeoutContent))
                                 throw ex;
                             Log.V(Tag, "Timeout while waiting for changes.");
                             return response;


### PR DESCRIPTION
CouchDB returns "{\"results\":[\n" instead of "{\"results\":[\r\n" which was being looked for.  Updated if statement to compare against the trimmed value to remove linefeeds from the comparison.  Additionally, since CouchDB only had "\n" instead of "\r\n" the JSON exception would be about line 2, not line 3.  I removed the second part of this check since (in my opinion) testing against the exception message is a bit brittle and doesn't work with CouchDB as-is.
