### PR TITLE
Fix #322 Cannot push a document with an attachment

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/Pusher.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Pusher.cs
@@ -342,7 +342,7 @@ namespace Couchbase.Lite.Replicator
 
                                 if (!dontSendMultipart && revisionBodyTransformationFunction == null)
                                 {
-                                    contentOptions &= DocumentContentOptions.BigAttachmentsFollow;
+                                    contentOptions |= DocumentContentOptions.BigAttachmentsFollow;
                                 }
 
 


### PR DESCRIPTION
- Fix the contentOptions operation.
- Add ReplicationTest.TestPushPullDocumentWithAttachment()
