### PR TITLE
Fixes #325.

### DIFF
--- a/src/Couchbase.Lite.Shared/Util/URIUtils.cs
+++ b/src/Couchbase.Lite.Shared/Util/URIUtils.cs
@@ -46,6 +46,7 @@ using System.Web;
 
 using Sharpen;
 using System.Linq;
+using System.IO;
 
 namespace Couchbase.Lite.Util
 {
@@ -362,17 +363,11 @@ namespace Couchbase.Lite.Util
         {
             if (uri == null) return null;
 
-            if (!uri.AbsolutePath.EndsWith("/") && !String.IsNullOrWhiteSpace(path)) 
-            {
-                var newUri = new UriBuilder(uri);
-                newUri.Path += path;
-                var newUriStr = new Uri(Uri.UnescapeDataString(newUri.Uri.AbsoluteUri));
-                return newUriStr;
-            }
-            else
-            {
-                return new Uri(uri, path);
-            }
+            var newUri = new UriBuilder(uri);
+            newUri.Path = Path.Combine(newUri.Path.TrimEnd('/'), path.TrimStart('/'));
+
+            var newUriStr = new Uri(Uri.UnescapeDataString(newUri.Uri.AbsoluteUri));
+            return newUriStr;
         }
     }
 }

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -890,6 +890,21 @@ namespace Couchbase.Lite
 
         /// <exception cref="System.Exception"></exception>
         [Test]
+        public virtual void TestAppendPathURLString([Values("http://10.0.0.3:4984/connect-2014", "http://10.0.0.3:4984/connect-2014/")] String baseUri, [Values("/_bulk_get?revs=true&attachments=true", "_bulk_get?revs=true&attachments=true")] String newPath)
+        {
+            if (!Boolean.Parse((string)Runtime.Properties["replicationTestsEnabled"]))
+            {
+                Assert.Inconclusive("Replication tests disabled.");
+                return;
+            }
+            var dbUrlString = new Uri(baseUri);
+            var relativeUrlString = dbUrlString.AppendPath(newPath).AbsoluteUri;
+            var expected = "http://10.0.0.3:4984/connect-2014/_bulk_get?revs=true&attachments=true";
+            Assert.AreEqual(expected, relativeUrlString);
+        }
+
+        /// <exception cref="System.Exception"></exception>
+        [Test]
         public void TestChannels()
         {
             if (!Boolean.Parse((string)Runtime.Properties["replicationTestsEnabled"]))


### PR DESCRIPTION
BulkDownloader uses a new Uri extention method to
properly concatenate paths. Unfortunately, it failed
to properly address the case where the base uri
ended in a forward slash and the new path part started
with a forward slash.

Includes a test for all four variants.
