### PR TITLE
Check for OperationCanceledException instead of TaskCanceledException.

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -367,7 +367,7 @@ namespace Couchbase.Lite.Replicator
                     catch (Exception ex) {
                         // Swallow TaskCancelledExceptions, which will always happen
                         // if either errorHandler or successHandler don't need to fire.
-                        if (!(ex.InnerException is TaskCanceledException))
+                        if (!(ex.InnerException is OperationCanceledException))
                             throw ex;
                     } 
                     finally 


### PR DESCRIPTION
There are cases where an OperationCanceledException could be thrown instead of the subclass TaskCanceledException (I've seen it happen in a real world app), so I think it should be checking for OperationCanceledException instead of the TaskCanceledException so that both exception types are covered.
