### PR TITLE
Added tests that check if RunInTransaction works as expected

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -454,8 +454,8 @@ namespace Couchbase.Lite
         }
 
         [Test]
-        //[Ignore("This test just attempts to reproduce issue https://github.com/couchbase/couchbase-lite-net/issues/257")]
-        [Description("Potentially nested transactions should not affect each others outcome.")]
+        [Ignore("This test just attempts to reproduce issue https://github.com/couchbase/couchbase-lite-net/issues/257")]
+        [Description("Potentially nested transactions should not affect each others outcome. Unfortunately, they currently do.")]
         public void TestRunInTransactionCommitsThreadSafe()
         {
             var storageEngine = database.StorageEngine;


### PR DESCRIPTION
I wrote two simple tests for both committing and "rollbacking" a transaction. Additionally I created a test to reproduce issue https://github.com/couchbase/couchbase-lite-net/issues/25

If multiple calls to RunInTransaction are made from different threads, the transactions will overlap causing the issue already reported. 

Ideally, we should use SAVEPOINT and RELEASE instead of BEGIN TRANSACTION, COMMIT and ROLLBACK. "For nested transactions, use the SAVEPOINT and RELEASE commands." can be found here: https://www.sqlite.org/lang_transaction.html

This change would require the API to handle the generation of SAVEPOINT IDs and then map them to the calling connection/thread. SQLite-Net seems to use a naive approach (which works AFAIK) to track savepoints: https://github.com/praeclarum/sqlite-net/blob/1167955b4c751ff6db58234d21ce2c3b24faa322/src/SQLite.cs#L1070

I will attempt to introduce the SAVEPOINT/RELEASE commands unless @zgramana prefers to use a different approach at a higher level in the API (serialising transactions, multiple readers / single writer, etc).

The tests have been placed in the DatabaseTests class since it's related to one of the Database class methods. If we start having more tests related to handling transactions, maybe we could have a dedicated test class for it.
