### PR TITLE
Completion handler exception handling

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -562,10 +562,10 @@ namespace Couchbase.Lite
                         }
                     }
                 }
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
                 finally
                 {
                     Log.D(Tag, "checkSessionAtPath() calling asyncTaskFinished()");
@@ -603,10 +603,10 @@ namespace Couchbase.Lite
                         FetchRemoteCheckpointDoc ();
                     }
                 }
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
                 finally
                 {
                     Log.D(Tag, "login() calling asyncTaskFinished()");

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -562,6 +562,10 @@ namespace Couchbase.Lite
                         }
                     }
                 }
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
                 finally
                 {
                     Log.D(Tag, "checkSessionAtPath() calling asyncTaskFinished()");
@@ -599,6 +603,10 @@ namespace Couchbase.Lite
                         FetchRemoteCheckpointDoc ();
                     }
                 }
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
                 finally
                 {
                     Log.D(Tag, "login() calling asyncTaskFinished()");
@@ -819,59 +827,66 @@ namespace Couchbase.Lite
             savingCheckpoint = true;
             //Log.D(Tag, "put remote _local document.  checkpointID: " + remoteCheckpointDocID);
             SendAsyncRequest(HttpMethod.Put, "/_local/" + remoteCheckpointDocID, body, (result, e) => {
-                savingCheckpoint = false;
-                if (e != null)
-                {
-                    Log.V (Tag, "Unable to save remote checkpoint", e as HttpResponseException);
-                }
+				try
+				{
+	                savingCheckpoint = false;
+	                if (e != null)
+	                {
+	                    Log.V (Tag, "Unable to save remote checkpoint", e as HttpResponseException);
+	                }
 
-                if (LocalDatabase == null)
-                {
-                    Log.W(Tag, "Database is null, ignoring remote checkpoint response");
-                    return;
-                }
+	                if (LocalDatabase == null)
+	                {
+	                    Log.W(Tag, "Database is null, ignoring remote checkpoint response");
+	                    return;
+	                }
 
-                if (!LocalDatabase.Open())
-                {
-                    Log.W(Tag, "Database is closed, ignoring remote checkpoint response");
-                    return;
-                }
+	                if (!LocalDatabase.Open())
+	                {
+	                    Log.W(Tag, "Database is closed, ignoring remote checkpoint response");
+	                    return;
+	                }
 
-                if (e != null)
-                {
-                    switch (GetStatusFromError(e))
-                    {
-                        case StatusCode.NotFound:
-                            {
-                                remoteCheckpoint = null;
-                                overdueForSave = true;
-                                break;
-                            }
-                        case StatusCode.Conflict:
-                            {
-                                RefreshRemoteCheckpointDoc();
-                                break;
-                            }
-                        default:
-                            {
-                                // TODO: On 401 or 403, and this is a pull, remember that remote
-                                // TODO: is read-only & don't attempt to read its checkpoint next time.
-                                break;
-                            }
-                    }
-                }
-                else
-                {
-                    Log.D(Tag, "Save checkpoint response: " + result.ToString());
-                    var response = ((JObject)result).ToObject<IDictionary<string, object>>();
-                    body.Put ("_rev", response.Get ("rev"));
-                    remoteCheckpoint = body;
-                    LocalDatabase.SetLastSequence(LastSequence, RemoteCheckpointDocID(), !IsPull);
-                }
+	                if (e != null)
+	                {
+	                    switch (GetStatusFromError(e))
+	                    {
+	                        case StatusCode.NotFound:
+	                            {
+	                                remoteCheckpoint = null;
+	                                overdueForSave = true;
+	                                break;
+	                            }
+	                        case StatusCode.Conflict:
+	                            {
+	                                RefreshRemoteCheckpointDoc();
+	                                break;
+	                            }
+	                        default:
+	                            {
+	                                // TODO: On 401 or 403, and this is a pull, remember that remote
+	                                // TODO: is read-only & don't attempt to read its checkpoint next time.
+	                                break;
+	                            }
+	                    }
+	                }
+	                else
+	                {
+	                    Log.D(Tag, "Save checkpoint response: " + result.ToString());
+	                    var response = ((JObject)result).ToObject<IDictionary<string, object>>();
+	                    body.Put ("_rev", response.Get ("rev"));
+	                    remoteCheckpoint = body;
+	                    LocalDatabase.SetLastSequence(LastSequence, RemoteCheckpointDocID(), !IsPull);
+	                }
 
-                if (overdueForSave) {
-                    SaveLastSequence ();
-                }
+	                if (overdueForSave) {
+	                    SaveLastSequence ();
+	                }
+				}
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
             });
         }
 
@@ -1375,6 +1390,10 @@ namespace Couchbase.Lite
                     }
 
                 }
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
                 finally
                 {
                     AsyncTaskFinished(1);

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -827,8 +827,8 @@ namespace Couchbase.Lite
             savingCheckpoint = true;
             //Log.D(Tag, "put remote _local document.  checkpointID: " + remoteCheckpointDocID);
             SendAsyncRequest(HttpMethod.Put, "/_local/" + remoteCheckpointDocID, body, (result, e) => {
-				try
-				{
+                try
+                {
 	                savingCheckpoint = false;
 	                if (e != null)
 	                {
@@ -882,11 +882,11 @@ namespace Couchbase.Lite
 	                if (overdueForSave) {
 	                    SaveLastSequence ();
 	                }
-				}
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                }
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
             });
         }
 
@@ -1390,10 +1390,10 @@ namespace Couchbase.Lite
                     }
 
                 }
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
                 finally
                 {
                     AsyncTaskFinished(1);

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -618,53 +618,62 @@ namespace Couchbase.Lite.Replicator
 
             SendAsyncRequest(HttpMethod.Post, "/_all_docs?include_docs=true", body, (result, e) =>
             {
-                var res = result.AsDictionary<string, object>();
-                if (e != null) {
-                    SetLastError(e);
-                    RevisionFailed();
-                    SafeAddToCompletedChangesCount(bulkRevs.Count);
-                } else {
-                    // Process the resulting rows' documents.
-                    // We only add a document if it doesn't have attachments, and if its
-                    // revID matches the one we asked for.
-                    var rows = res.Get ("rows").AsList<IDictionary<string, object>>();
-                    Log.V (Tag, "Checking {0} bulk-fetched remote revisions", rows.Count);
+				try
+				{
+	                var res = result.AsDictionary<string, object>();
+	                if (e != null) {
+	                    SetLastError(e);
+	                    RevisionFailed();
+	                    SafeAddToCompletedChangesCount(bulkRevs.Count);
+	                } else {
+	                    // Process the resulting rows' documents.
+	                    // We only add a document if it doesn't have attachments, and if its
+	                    // revID matches the one we asked for.
+	                    var rows = res.Get ("rows").AsList<IDictionary<string, object>>();
+	                    Log.V (Tag, "Checking {0} bulk-fetched remote revisions", rows.Count);
 
-                    foreach (var row in rows) {
-                        var doc = row.Get ("doc").AsDictionary<string, object>();
-                        if (doc != null && doc.Get ("_attachments") == null)
-                        {
-                            var rev = new RevisionInternal (doc, LocalDatabase);
-                            var pos = remainingRevs.IndexOf (rev);
-                            if (pos > -1) 
-                            {
-                                rev.SetSequence(remainingRevs[pos].GetSequence());
-                                remainingRevs.Remove (pos);
-                                QueueDownloadedRevision (rev);
-                            }
-                        }
-                    }
-                }
+	                    foreach (var row in rows) {
+	                        var doc = row.Get ("doc").AsDictionary<string, object>();
+	                        if (doc != null && doc.Get ("_attachments") == null)
+	                        {
+	                            var rev = new RevisionInternal (doc, LocalDatabase);
+	                            var pos = remainingRevs.IndexOf (rev);
+	                            if (pos > -1) 
+	                            {
+	                                rev.SetSequence(remainingRevs[pos].GetSequence());
+	                                remainingRevs.Remove (pos);
+	                                QueueDownloadedRevision (rev);
+	                            }
+	                        }
+	                    }
+	                }
 
-                // Any leftover revisions that didn't get matched will be fetched individually:
-                if (remainingRevs.Count > 0) 
-                {
-                    Log.V (Tag, "Bulk-fetch didn't work for {0} of {1} revs; getting individually", remainingRevs.Count, bulkRevs.Count);
-                    foreach (var rev in remainingRevs) 
-                    {
-                        QueueRemoteRevision (rev);
-                    }
-                    PullRemoteRevisions ();
-                }
+	                // Any leftover revisions that didn't get matched will be fetched individually:
+	                if (remainingRevs.Count > 0) 
+	                {
+	                    Log.V (Tag, "Bulk-fetch didn't work for {0} of {1} revs; getting individually", remainingRevs.Count, bulkRevs.Count);
+	                    foreach (var rev in remainingRevs) 
+	                    {
+	                        QueueRemoteRevision (rev);
+	                    }
+	                    PullRemoteRevisions ();
+	                }
+				}
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
+				finally
+				{
+					// Note that we've finished this task:
+					Log.V (Tag, "PullBulkWithAllDocs() calling AsyncTaskFinished()");
+					AsyncTaskFinished (1);
 
-                // Note that we've finished this task:
-                Log.V (Tag, "PullBulkWithAllDocs() calling AsyncTaskFinished()");
-                AsyncTaskFinished (1);
+					--httpConnectionCount;
 
-                --httpConnectionCount;
-
-                // Start another task if there are still revisions waiting to be pulled:
-                PullRemoteRevisions();
+					// Start another task if there are still revisions waiting to be pulled:
+					PullRemoteRevisions();
+				}
             });
         }
 

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -659,21 +659,21 @@ namespace Couchbase.Lite.Replicator
 	                    PullRemoteRevisions ();
 	                }
 				}
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
-				finally
-				{
-					// Note that we've finished this task:
-					Log.V (Tag, "PullBulkWithAllDocs() calling AsyncTaskFinished()");
-					AsyncTaskFinished (1);
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
+                finally
+                {
+                    // Note that we've finished this task:
+                    Log.V (Tag, "PullBulkWithAllDocs() calling AsyncTaskFinished()");
+                    AsyncTaskFinished (1);
 
-					--httpConnectionCount;
+                    --httpConnectionCount;
 
-					// Start another task if there are still revisions waiting to be pulled:
-					PullRemoteRevisions();
-				}
+                    // Start another task if there are still revisions waiting to be pulled:
+                    PullRemoteRevisions();
+                }
             });
         }
 

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -618,8 +618,8 @@ namespace Couchbase.Lite.Replicator
 
             SendAsyncRequest(HttpMethod.Post, "/_all_docs?include_docs=true", body, (result, e) =>
             {
-				try
-				{
+                try
+                {
 	                var res = result.AsDictionary<string, object>();
 	                if (e != null) {
 	                    SetLastError(e);

--- a/src/Couchbase.Lite.Shared/Replication/Pusher.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Pusher.cs
@@ -703,8 +703,8 @@ namespace Couchbase.Lite.Replicator
             var path = string.Format("/{0}?new_edits=false", Uri.EscapeUriString(rev.GetDocId()));
             SendAsyncRequest(HttpMethod.Put, path, rev.GetProperties(), (result, e) =>
             {
-				try
-				{
+                try
+                {
 	                if (e != null) 
 	                {
 	                    SetLastError(e);
@@ -720,11 +720,11 @@ namespace Couchbase.Lite.Replicator
                 {
                     Log.E(Tag, "Unhandled exception", exc);
                 }
-				finally
-				{
-					Log.V(Tag, "UploadJsonRevision() calling AsyncTaskFinished()");
-					AsyncTaskFinished (1);
-				}
+                finally
+                {
+                    Log.V(Tag, "UploadJsonRevision() calling AsyncTaskFinished()");
+                    AsyncTaskFinished (1);
+                }
             });
         }
 

--- a/src/Couchbase.Lite.Shared/Replication/Pusher.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Pusher.cs
@@ -130,6 +130,10 @@ namespace Couchbase.Lite.Replicator
                         BeginReplicating();
                     }
                 }
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
                 finally
                 {
                     Log.D(Tag, "maybeCreateRemoteDB.onComplete() calling asyncTaskFinished()");
@@ -489,6 +493,10 @@ namespace Couchbase.Lite.Replicator
                     }
                     SafeAddToCompletedChangesCount(numDocsToSend);
                 }
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
                 finally
                 {
                     Log.D(Tag, "ProcessInbox() after _bulk_docs() calling AsyncTaskFinished()");
@@ -695,18 +703,28 @@ namespace Couchbase.Lite.Replicator
             var path = string.Format("/{0}?new_edits=false", Uri.EscapeUriString(rev.GetDocId()));
             SendAsyncRequest(HttpMethod.Put, path, rev.GetProperties(), (result, e) =>
             {
-                if (e != null) 
-                {
-                    SetLastError(e);
-                    RevisionFailed();
-                } 
-                else 
-                {
-                    Log.V(Tag, "Sent {0} (JSON), response={1}", rev, result);
-                    RemovePending (rev);
-                }
-                Log.V(Tag, "UploadJsonRevision() calling AsyncTaskFinished()");
-                AsyncTaskFinished (1);
+				try
+				{
+	                if (e != null) 
+	                {
+	                    SetLastError(e);
+	                    RevisionFailed();
+	                } 
+	                else 
+	                {
+	                    Log.V(Tag, "Sent {0} (JSON), response={1}", rev, result);
+	                    RemovePending (rev);
+	                }
+				}
+				catch (Exception exc)
+				{
+					Log.E(Tag, "Unhandled exception", exc);
+				}
+				finally
+				{
+					Log.V(Tag, "UploadJsonRevision() calling AsyncTaskFinished()");
+					AsyncTaskFinished (1);
+				}
             });
         }
 

--- a/src/Couchbase.Lite.Shared/Replication/Pusher.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Pusher.cs
@@ -130,10 +130,10 @@ namespace Couchbase.Lite.Replicator
                         BeginReplicating();
                     }
                 }
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
                 finally
                 {
                     Log.D(Tag, "maybeCreateRemoteDB.onComplete() calling asyncTaskFinished()");
@@ -493,10 +493,10 @@ namespace Couchbase.Lite.Replicator
                     }
                     SafeAddToCompletedChangesCount(numDocsToSend);
                 }
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
                 finally
                 {
                     Log.D(Tag, "ProcessInbox() after _bulk_docs() calling AsyncTaskFinished()");
@@ -716,10 +716,10 @@ namespace Couchbase.Lite.Replicator
 	                    RemovePending (rev);
 	                }
 				}
-				catch (Exception exc)
-				{
-					Log.E(Tag, "Unhandled exception", exc);
-				}
+                catch (Exception exc)
+                {
+                    Log.E(Tag, "Unhandled exception", exc);
+                }
 				finally
 				{
 					Log.V(Tag, "UploadJsonRevision() calling AsyncTaskFinished()");


### PR DESCRIPTION
Added exception handling to all of the completion handlers.  Without the exception handling, if an exception occurs within the handlers, the app will crash on Xamarin.iOS since it's being run on a new thread.
