### PR TITLE
Fixed NRE in bulk downloader.

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/BulkDownloader.cs
+++ b/src/Couchbase.Lite.Shared/Replication/BulkDownloader.cs
@@ -172,11 +172,21 @@ namespace Couchbase.Lite.Replicator
 
             try
             {
-                var status = response.StatusCode;
-                if (response == null || !response.IsSuccessStatusCode)
+                if (response == null)
                 {
+                    Log.E(Tag, "Didn't get response for {0}", request);
+
+                    error = new HttpRequestException();
+                    RespondWithResult(fullBody, error, response);
+                }
+                else if (!response.IsSuccessStatusCode)
+                {
+                    HttpStatusCode status = response.StatusCode;
+
                     Log.E(Tag, "Got error status: {0} for {1}.  Reason: {2}", status.GetStatusCode(), request, response.ReasonPhrase);
                     error = new HttpResponseException(status);
+
+                    RespondWithResult(fullBody, error, response);
                 }
                 else
                 {


### PR DESCRIPTION
Hi, I've fixed what I understand to be a bug in BulkDownloader.

You can see how in the first removed line you've requested the `response.StatusCode` while in the second line there is a condition `response == null` making the first line prone to NREs. (And I've got this NRE while running the replication when the server refuses connection.)
