### PR TITLE
Made sure all cursors would be disposed in a finally block.

### DIFF
--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -1385,13 +1385,13 @@ PRAGMA user_version = 3;";
             {
                 Log.E(Tag, "Error getting last sequence", e);
             }
-			finally
-			{
-				if (cursor != null)
-				{
-					cursor.Close();
-				}
-			}
+            finally
+            {
+                if (cursor != null)
+                {
+                    cursor.Close();
+                }
+            }
             Log.D(Tag, "LastSequenceWithCheckpointId: {1} -> {0}".Fmt(result, checkpointId));
             return result;
         }
@@ -1736,10 +1736,10 @@ PRAGMA user_version = 3;";
             }
             finally
             {
-				if (cursor != null)
-				{
-					cursor.Close ();
-				}
+                if (cursor != null)
+                {
+                    cursor.Close ();
+                }
             }
             result["rows"] = rows;
             result["total_rows"] = rows.Count;
@@ -2013,10 +2013,10 @@ PRAGMA user_version = 3;";
             }
             finally
             {
-				if (cursor != null)
-				{
-					cursor.Close();
-				}
+                if (cursor != null)
+                {
+                    cursor.Close();
+                }
             }
             return result;
         }
@@ -2128,13 +2128,13 @@ PRAGMA user_version = 3;";
             {
                 Log.E(Tag, "Error querying privateUUID", e);
             }
-			finally
-			{
-				if (cursor != null)
-				{
-					cursor.Close();
-				}
-			}
+            finally
+            {
+                if (cursor != null)
+                {
+                    cursor.Close();
+                }
+            }
             return result;
         }
 

--- a/src/Couchbase.Lite.Shared/View.cs
+++ b/src/Couchbase.Lite.Shared/View.cs
@@ -159,7 +159,7 @@ namespace Couchbase.Lite {
 
             var result = new Status(StatusCode.InternalServerError);
             Cursor cursor = null;
-			Cursor cursor2 = null;
+            Cursor cursor2 = null;
 
             try
             {
@@ -281,8 +281,8 @@ namespace Couchbase.Lite {
                                     }
                                 }
 
-								cursor2.Close();
-								cursor2 = null;
+                                cursor2.Close();
+                                cursor2 = null;
                             }
                             // Get the document properties, to pass to the map function:
                             var contentOptions = DocumentContentOptions.None;
@@ -377,10 +377,10 @@ namespace Couchbase.Lite {
             }
             finally
             {
-				if (cursor2 != null)
-				{
-					cursor2.Close();
-				}
+                if (cursor2 != null)
+                {
+                    cursor2.Close();
+                }
 
                 if (cursor != null)
                 {
@@ -999,7 +999,7 @@ namespace Couchbase.Lite {
                 if (cursor != null)
                 {
                     cursor.Close();
-					cursor = null;
+                    cursor = null;
                 }
 
                 var updateValues = new ContentValues();
@@ -1016,13 +1016,13 @@ namespace Couchbase.Lite {
                 Log.E(Database.Tag, "Error setting map block", e);
                 return false;
             }
-			finally
-			{
-				if (cursor != null)
-				{
-					cursor.Close();
-				}
-			}
+            finally
+            {
+                if (cursor != null)
+                {
+                    cursor.Close();
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
As part of my testing tonight, I added some code to track if cursors weren't being explicitly closed, and found a few cases that either due other exceptions or because they simply were excluded (since they were read only?), they weren't being closed.  Made sure that can't happen in the future.
