### PR TITLE
Fix: Manager static ctor crashes on Azure #364

### DIFF
--- a/src/Couchbase.Lite.Shared/Manager.cs
+++ b/src/Couchbase.Lite.Shared/Manager.cs
@@ -121,7 +121,16 @@ namespace Couchbase.Lite
             illegalCharactersPattern = new Regex(IllegalCharacters);
             mapper = new ObjectWriter();
             DefaultOptions = ManagerOptions.Default;
-            defaultDirectory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+            //
+            // Note: Environment.SpecialFolder.LocalApplicationData returns null on Azure (and possibly other Windows Server environments)
+            // and this is only needed by the default constructor or when accessing the SharedInstanced
+            // So, let's only set it only when GetFolderPath returns something and allow the directory to be
+            // manually specified via the ctor that accepts a DirectoryInfo
+            var defaultDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!String.IsNullOrWhiteSpace(defaultDirectoryPath))
+            {
+                defaultDirectory = new DirectoryInfo(defaultDirectoryPath);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is my official first pull request on an open source project, so let me know if I'm doing something stupid.

This patch is for #364 which allows cblite to function in a .NET web app hosted in Azure.  By enabling the .NET API to working in Azure, we are able to much more quickly generate initial snapshots of databases for mobile clients (as opposed to waiting for hundreds of thousands of records to stream down).