### PR TITLE
Fix null reference exception when setting cookie

### DIFF
--- a/src/Couchbase.Lite.Shared/Util/CookieStore.cs
+++ b/src/Couchbase.Lite.Shared/Util/CookieStore.cs
@@ -198,7 +198,7 @@ namespace Couchbase.Lite.Util
                 var json = reader.ReadToEnd();
 
                 var cookies = JsonConvert.DeserializeObject<List<Cookie>>(json);
-				cookies = cookies ?? new List<Cookie>();
+                cookies = cookies ?? new List<Cookie>();
 
                 foreach(Cookie cookie in cookies)
                 {

--- a/src/Couchbase.Lite.Shared/Util/CookieStore.cs
+++ b/src/Couchbase.Lite.Shared/Util/CookieStore.cs
@@ -198,6 +198,8 @@ namespace Couchbase.Lite.Util
                 var json = reader.ReadToEnd();
 
                 var cookies = JsonConvert.DeserializeObject<List<Cookie>>(json);
+				cookies = cookies ?? new List<Cookie>();
+
                 foreach(Cookie cookie in cookies)
                 {
                     Add(cookie);


### PR DESCRIPTION
This fixes a null reference exception I encountered when using CBL from
my own .Net45 unit tests.  I was getting a null reference exception when
setting the replicator cookies.  The CBL unit test for adding/deleting
cookies seems to work fine without this though.