### PR TITLE
Users can control the max number of HTTP Connections and sizes of bulk downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ TestResults
 *.user
 *.sln.docstates
 local-test.properties
+*.DS_Store
 
 # Build results
 [Dd]ebug/
@@ -37,7 +38,7 @@ x64/
 *.log
 *.vspscc
 *.vssscc
-.builds
+.build
 
 # Package
 *.xam

--- a/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
+++ b/samples/CouchbaseSample.iOS/CouchbaseSample.iOS.csproj
@@ -99,20 +99,20 @@
     <MtouchArch>ARMv7</MtouchArch>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>packages\Newtonsoft.Json.6.0.4\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="SQLitePCL.raw">
-      <HintPath>packages\SQLitePCL.raw_basic.0.7.0\lib\Xamarin.iOS10\SQLitePCL.raw.dll</HintPath>
-    </Reference>
-    <Reference Include="SQLitePCL.ugly">
-      <HintPath>packages\SQLitePCL.ugly.0.7.0\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.Json" />
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="SQLitePCL.ugly">
+      <HintPath>..\..\src\packages\SQLitePCL.ugly.0.7.1\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>..\..\src\packages\SQLitePCL.raw_basic.0.7.1\lib\Xamarin.iOS10\SQLitePCL.raw.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\src\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/samples/CouchbaseSample.iOS/packages.config
+++ b/samples/CouchbaseSample.iOS/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="xamarinios10" />
-  <package id="SQLitePCL.raw_basic" version="0.7.0" targetFramework="xamarinios10" />
-  <package id="SQLitePCL.ugly" version="0.7.0" targetFramework="xamarinios10" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="xamarinios10" />
+  <package id="SQLitePCL.raw_basic" version="0.7.1" targetFramework="xamarinios10" />
+  <package id="SQLitePCL.ugly" version="0.7.1" targetFramework="xamarinios10" />
 </packages>

--- a/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
+++ b/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
@@ -41,11 +41,7 @@
     <ConsolePause>false</ConsolePause>
     <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="SQLitePCL.raw">       <HintPath>packages\SQLitePCL.raw_basic.0.7.0\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>     </Reference>     <Reference Include="SQLitePCL.ugly">       <HintPath>packages\SQLitePCL.ugly.0.7.0\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>     </Reference>   <Reference Include="System" /><Reference Include="System.Xml" /><Reference Include="System.Core" /><Reference Include="Mono.Android" /></ItemGroup>
+  <ItemGroup>        <Reference Include="System" /><Reference Include="System.Xml" /><Reference Include="System.Core" /><Reference Include="Mono.Android" /><Reference Include="SQLitePCL.ugly"><HintPath>..\..\src\packages\SQLitePCL.ugly.0.7.1\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath></Reference><Reference Include="SQLitePCL.raw"><HintPath>..\..\src\packages\SQLitePCL.raw_basic.0.7.1\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath></Reference><Reference Include="Newtonsoft.Json"><HintPath>..\..\src\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath></Reference></ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />

--- a/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
+++ b/samples/SimpleAndroidSync/SimpleAndroidSync.csproj
@@ -41,7 +41,21 @@
     <ConsolePause>false</ConsolePause>
     <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
-  <ItemGroup>        <Reference Include="System" /><Reference Include="System.Xml" /><Reference Include="System.Core" /><Reference Include="Mono.Android" /><Reference Include="SQLitePCL.ugly"><HintPath>..\..\src\packages\SQLitePCL.ugly.0.7.1\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath></Reference><Reference Include="SQLitePCL.raw"><HintPath>..\..\src\packages\SQLitePCL.raw_basic.0.7.1\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath></Reference><Reference Include="Newtonsoft.Json"><HintPath>..\..\src\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath></Reference></ItemGroup>
+  <ItemGroup> 
+      <Reference Include="System" />
+      <Reference Include="System.Xml" />
+      <Reference Include="System.Core" />
+      <Reference Include="Mono.Android" />
+      <Reference Include="SQLitePCL.ugly">
+         <HintPath>..\..\src\packages\SQLitePCL.ugly.0.7.1\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
+      </Reference>
+      <Reference Include="SQLitePCL.raw">
+         <HintPath>..\..\src\packages\SQLitePCL.raw_basic.0.7.1\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>
+      </Reference>
+      <Reference Include="Newtonsoft.Json">
+         <HintPath>..\..\src\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />

--- a/samples/SimpleAndroidSync/packages.config
+++ b/samples/SimpleAndroidSync/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoAndroid10" />
-  <package id="SQLitePCL.raw_basic" version="0.7.0" targetFramework="MonoAndroid10" />
-  <package id="SQLitePCL.ugly" version="0.7.0" targetFramework="MonoAndroid10" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="MonoAndroid50" />
+  <package id="SQLitePCL.raw_basic" version="0.7.1" targetFramework="MonoAndroid50" />
+  <package id="SQLitePCL.ugly" version="0.7.1" targetFramework="MonoAndroid50" />
 </packages>

--- a/src/Couchbase.Lite.Android.Tests/Couchbase.Lite.Android.Tests.csproj
+++ b/src/Couchbase.Lite.Android.Tests/Couchbase.Lite.Android.Tests.csproj
@@ -40,9 +40,6 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
@@ -51,6 +48,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.Services" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/src/Couchbase.Lite.Android.Tests/packages.config
+++ b/src/Couchbase.Lite.Android.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoAndroid50" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="MonoAndroid50" />
 </packages>

--- a/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
+++ b/src/Couchbase.Lite.Android/Couchbase.Lite.Android.csproj
@@ -40,21 +40,21 @@
     <DocumentationFile>bin\Release\Couchbase.Lite.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="SQLitePCL.raw">
-      <HintPath>..\packages\SQLitePCL.raw_basic.0.7.0\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>
-    </Reference>
-    <Reference Include="SQLitePCL.ugly">
-      <HintPath>..\packages\SQLitePCL.ugly.0.7.0\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Data" />
     <Reference Include="System.Web.Services" />
+    <Reference Include="SQLitePCL.ugly">
+      <HintPath>..\packages\SQLitePCL.ugly.0.7.1\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>..\packages\SQLitePCL.raw_basic.0.7.1\lib\MonoAndroid\SQLitePCL.raw.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />

--- a/src/Couchbase.Lite.Android/packages.config
+++ b/src/Couchbase.Lite.Android/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoAndroid23" />
-  <package id="SQLitePCL.raw_basic" version="0.7.0" targetFramework="MonoAndroid23" />
-  <package id="SQLitePCL.ugly" version="0.7.0" targetFramework="MonoAndroid23" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="MonoAndroid23" />
+  <package id="SQLitePCL.raw_basic" version="0.7.1" targetFramework="MonoAndroid23" />
+  <package id="SQLitePCL.ugly" version="0.7.1" targetFramework="MonoAndroid23" />
 </packages>

--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -4744,7 +4744,7 @@ PRAGMA user_version = 3;";
             ActiveReplicators.Add(replication);
             replication.Changed += (sender, e) => 
             {
-                if (!e.Source.IsRunning && ActiveReplicators != null)
+                if (e.Source != null && !e.Source.IsRunning && ActiveReplicators != null)
                 {
                     ActiveReplicators.Remove(e.Source);
                 }

--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -4699,10 +4699,16 @@ PRAGMA user_version = 3;";
         {
             long curSequence = LastSequenceNumber;
             if (curSequence > 0) {
-                var c = StorageEngine.RawQuery("SELECT value FROM info WHERE key=?", "last_optimized");
+                Cursor cursor = StorageEngine.RawQuery("SELECT value FROM info WHERE key=?", "last_optimized");
+                if (cursor == null) {
+                    //Will not optimize this time
+                    Log.D(Tag, "Optimizing SQL indexes failed");
+                    return;
+                }
+
                 long lastOptimized = 0;
-                if (c.MoveToNext()) {
-                    lastOptimized = long.Parse(c.GetString(0));
+                if (cursor.MoveToNext()) {
+                    lastOptimized = long.Parse(cursor.GetString(0));
                 }
 
                 if (lastOptimized <= curSequence / 10) {

--- a/src/Couchbase.Lite.Shared/Manager/ManagerOptions.cs
+++ b/src/Couchbase.Lite.Shared/Manager/ManagerOptions.cs
@@ -76,6 +76,10 @@ namespace Couchbase.Lite
         {
             MaxRetries = 10;
 
+            MaxOpenHttpConnections = 16;
+
+            MaxRevsToGetInBulk = 50;
+
             RequestTimeout = TimeSpan.FromSeconds(90);
 
             TaskScheduler scheduler = null;
@@ -103,5 +107,17 @@ namespace Couchbase.Lite
         /// </summary>
         /// <value>The request timeout. Defaults to 30 seconds.</value>
         public TimeSpan RequestTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets max number of open Http Connections
+        /// </summary>
+        /// <value>Max number of connections</value>
+        public int MaxOpenHttpConnections { get; set; }
+
+        /// <summary>
+        /// Get or sets the max revs to get in a bulk download
+        /// </summary>
+        /// <value>Max revs to get in bulk download</value>
+        public int MaxRevsToGetInBulk { get; set; }
     }
 }

--- a/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/ChangeTracker.cs
@@ -359,7 +359,6 @@ namespace Couchbase.Lite.Replicator
 
                     try 
                     {
-
                         Task.WaitAll(new Task[] { successHandler, errorHandler }, (Int32)ManagerOptions.Default.RequestTimeout.TotalMilliseconds, changesFeedRequestTokenSource.Token);
                         Log.D(Tag, "Finished processing changes feed.");
                     } 
@@ -372,31 +371,47 @@ namespace Couchbase.Lite.Replicator
                     } 
                     finally 
                     {
-                        if (changesRequestTask.IsCompleted) 
+                        if (changesRequestTask != null) 
                         {
-                        changesRequestTask.Dispose();
-                        }
-                        changesRequestTask = null;
+                            if(changesRequestTask.IsCompleted)
+                            {
+                                changesRequestTask.Dispose();
+                            }
 
-                        if (successHandler.IsCompleted) 
-                        {
-                        successHandler.Dispose();
-                        }
-
-                        successHandler = null;
-
-                        if (errorHandler.IsCompleted) 
-                        {
-                        errorHandler.Dispose();
+                            changesRequestTask = null;
                         }
 
-                        errorHandler = null;
+                        if (successHandler != null)
+                        {
+                            if(successHandler.IsCompleted)
+                            {
+                                successHandler.Dispose();
+                            }
 
-                        Request.Dispose();
-                        Request = null;
+                            successHandler = null;
+                        }
 
-                        changesFeedRequestTokenSource.Dispose();
-						changesFeedRequestTokenSource = null;
+                        if (errorHandler != null) 
+                        {
+                            if(errorHandler.IsCompleted)
+                            {
+                                errorHandler.Dispose();
+                            }
+
+                            errorHandler = null;
+                        }
+
+                        if(Request != null)
+                        {
+                            Request.Dispose();
+                            Request = null;
+                        }
+
+                        if(changesFeedRequestTokenSource != null)
+                        {
+                            changesFeedRequestTokenSource.Dispose();
+                            changesFeedRequestTokenSource = null;
+                        }
                     }
                 }
                 catch (Exception e)

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -57,20 +57,13 @@ using Couchbase.Lite.Support;
 using Couchbase.Lite.Util;
 using Sharpen;
 using System.Threading;
+using System.Data;
 using Newtonsoft.Json;
-
-#if !NET_3_5
-using StringEx = System.String;
-#endif
 
 namespace Couchbase.Lite.Replicator
 {
     internal sealed class Puller : Replication, IChangeTrackerClient
     {
-        private const int MaxOpenHttpConnections = 16;
-
-        private const int MaxRevsToGetInBulk = 50;
-
         internal const int MaxNumberOfAttsSince = 50;
 
         readonly string Tag = "Puller";
@@ -123,6 +116,9 @@ namespace Couchbase.Lite.Replicator
 
         internal override void BeginReplicating()
         {
+            Log.D(Tag, string.Format("Using MaxOpenHttpConnections({0}), MaxRevsToGetInBulk({1})", 
+                ManagerOptions.Default.MaxOpenHttpConnections, ManagerOptions.Default.MaxRevsToGetInBulk));
+            
             if (downloadsToInsert == null)
             {
                 const int capacity = 200;
@@ -419,12 +415,12 @@ namespace Couchbase.Lite.Replicator
             var bulkWorkToStartNow = new List<RevisionInternal>();
             lock (locker)
             {
-                while (httpConnectionCount + bulkWorkToStartNow.Count + workToStartNow.Count < MaxOpenHttpConnections)
+                while (httpConnectionCount + bulkWorkToStartNow.Count + workToStartNow.Count < ManagerOptions.Default.MaxOpenHttpConnections)
                 {
                     int nBulk = 0;
                     if (bulkRevsToPull != null)
                     {
-                        nBulk = (bulkRevsToPull.Count < MaxRevsToGetInBulk) ? bulkRevsToPull.Count : MaxRevsToGetInBulk;
+                        nBulk = (bulkRevsToPull.Count < ManagerOptions.Default.MaxRevsToGetInBulk) ? bulkRevsToPull.Count : ManagerOptions.Default.MaxRevsToGetInBulk;
                     }
                     if (nBulk == 1)
                     {
@@ -688,7 +684,7 @@ namespace Couchbase.Lite.Replicator
                 }
 
                 var errorStr = (string)item.Get ("error");
-                if (StringEx.IsNullOrWhiteSpace(errorStr)) {
+                if (errorStr == null || errorStr.IsEmpty ()) {
                     return new Status (StatusCode.Ok);
                 }
 
@@ -711,7 +707,7 @@ namespace Couchbase.Lite.Replicator
                 if (errorStr.Equals ("conflict", StringComparison.InvariantCultureIgnoreCase)) {
                     return new Status (StatusCode.Conflict);
                 }
-
+                    
                 return new Status (StatusCode.UpStreamError);
             }
             catch (Exception e)

--- a/src/Couchbase.Lite.Shared/Replication/Puller.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Puller.cs
@@ -684,7 +684,7 @@ namespace Couchbase.Lite.Replicator
                 }
 
                 var errorStr = (string)item.Get ("error");
-                if (errorStr == null || errorStr.IsEmpty ()) {
+                if (string.IsNullOrEmpty(errorStr) == true) {
                     return new Status (StatusCode.Ok);
                 }
 

--- a/src/Couchbase.Lite.Shared/Store/Cursor.cs
+++ b/src/Couchbase.Lite.Shared/Store/Cursor.cs
@@ -64,6 +64,10 @@ namespace Couchbase.Lite
 
         Int64 currentRow;
 
+        /// <summary>
+        /// Can throw an exception
+        /// </summary>
+        /// <param name="stmt">Statement.</param>
         internal Cursor (sqlite3_stmt stmt)
         {
             this.statement = stmt;

--- a/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
@@ -329,8 +329,10 @@ namespace Couchbase.Lite.Shared
                 Open(Path);
             }
 
-            if (transactionCount == 0)
+            if (transactionCount == 0) 
+            {
                 return RawQuery(sql, paramArgs);
+            }
 
             var t = Factory.StartNew(() =>
             {
@@ -479,6 +481,8 @@ namespace Couchbase.Lite.Shared
             }, CancellationToken.None);
 
             // NOTE.ZJG: Just a sketch here. Needs better error handling, etc.
+
+            //doesn't look good
             var r = t.GetAwaiter().GetResult();
             if (t.Exception != null)
                 throw t.Exception;
@@ -517,10 +521,15 @@ namespace Couchbase.Lite.Shared
                 }
                 return resultCount;
             });
+
             // NOTE.ZJG: Just a sketch here. Needs better error handling, etc.
             var r = t.GetAwaiter().GetResult();
-            if (t.Exception != null)
+            if (t.Exception != null) 
+            {
+                //this is bad: should not arbitrarily crash the app
                 throw t.Exception;
+            }
+                
             return r;
         }
 

--- a/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
@@ -606,11 +606,14 @@ namespace Couchbase.Lite.Shared
             {
                 if (!IsOpen)
                 {
-                    Open(Path);
+                    if(Open(Path) == false)
+                    {
+                        throw new Exception("Failed to Open " + Path);
+                    }
                 }
-                    
+
                 int err = raw.sqlite3_prepare_v2(db, sql, out command);
-                if (paramArgs.Length > 0 && command != null)
+                if (paramArgs.Length > 0 && command != null && err != raw.SQLITE_ERROR)
                 {
                     command.bind(paramArgs);
                 }

--- a/src/Couchbase.Lite.Shared/Store/SqlitePclStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqlitePclStorageEngine.cs
@@ -214,6 +214,7 @@ namespace Couchbase.Lite.Shared
                 command.Dispose();
             }
 
+            //Cursor can be null if there is an exception
             return cursor;
         }
 

--- a/src/Couchbase.Lite.Shared/View.cs
+++ b/src/Couchbase.Lite.Shared/View.cs
@@ -754,6 +754,7 @@ namespace Couchbase.Lite {
             argsList.AddItem(options.GetLimit().ToString());
             argsList.AddItem(options.GetSkip().ToString());
             Log.D(Database.Tag, "Query {0}:{1}", Name, sql);
+
             var cursor = Database.StorageEngine.IntransactionRawQuery(sql, argsList.ToArray());
             return cursor;
         }

--- a/src/Couchbase.Lite.Tests.Shared/LiteTestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LiteTestCase.cs
@@ -584,6 +584,10 @@ namespace Couchbase.Lite
         public void DumpTableMaps()
         {
             var cursor = database.StorageEngine.RawQuery("SELECT * FROM maps", null);
+            if (cursor == null) {
+                throw new Exception();
+            }
+
             while (cursor.MoveToNext())
             {
                 var viewId = cursor.GetInt(0);
@@ -615,6 +619,10 @@ namespace Couchbase.Lite
         public void DumpTableRevs()
         {
             var cursor = database.StorageEngine.RawQuery("SELECT * FROM revs", null);
+            if (cursor == null) {
+                throw new Exception();
+            }
+
             while (cursor.MoveToNext())
             {
                 var sequence = cursor.GetInt(0);

--- a/src/Couchbase.Lite.Tests.Shared/StorageEngineTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/StorageEngineTest.cs
@@ -22,6 +22,9 @@ namespace Couchbase.Lite
             });
 
             var result = storageEngine.RawQuery("SELECT EXISTS (SELECT 1 FROM transTest WHERE id=0 AND whatever=1)");
+            if (result == null) {
+                throw new Exception();
+            }
 
             Assert.AreEqual(1, result.GetInt(0));
         }
@@ -41,6 +44,9 @@ namespace Couchbase.Lite
             });
 
             var result = storageEngine.RawQuery("SELECT EXISTS (SELECT 1 FROM transTest WHERE id=0 AND whatever=1)");
+            if (result == null) {
+                throw new Exception();
+            }
 
             Assert.AreEqual(0, result.GetInt(0));
         }

--- a/src/Couchbase.Lite.iOS.Tests/Couchbase.Lite.iOS.Tests.csproj
+++ b/src/Couchbase.Lite.iOS.Tests/Couchbase.Lite.iOS.Tests.csproj
@@ -71,9 +71,6 @@
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
@@ -82,6 +79,9 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.Services" />
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/src/Couchbase.Lite.iOS.Tests/packages.config
+++ b/src/Couchbase.Lite.iOS.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="xamarinios10" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="xamarinios10" />
 </packages>

--- a/src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
+++ b/src/Couchbase.Lite.iOS/Couchbase.Lite.iOS.csproj
@@ -41,21 +41,21 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SQLitePCL.raw">
-      <HintPath>..\packages\SQLitePCL.raw_basic.0.7.0\lib\Xamarin.iOS10\SQLitePCL.raw.dll</HintPath>
-    </Reference>
-    <Reference Include="SQLitePCL.ugly">
-      <HintPath>..\packages\SQLitePCL.ugly.0.7.0\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.Services" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Core" />
     <Reference Include="System" />
+    <Reference Include="SQLitePCL.ugly">
+      <HintPath>..\packages\SQLitePCL.ugly.0.7.1\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.ugly.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCL.raw">
+      <HintPath>..\packages\SQLitePCL.raw_basic.0.7.1\lib\Xamarin.iOS10\SQLitePCL.raw.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Couchbase.Lite.iOS/packages.config
+++ b/src/Couchbase.Lite.iOS/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="xamarinios10" />
-  <package id="SQLitePCL.raw_basic" version="0.7.0" targetFramework="xamarinios10" />
-  <package id="SQLitePCL.ugly" version="0.7.0" targetFramework="xamarinios10" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="xamarinios10" />
+  <package id="SQLitePCL.raw_basic" version="0.7.1" targetFramework="xamarinios10" />
+  <package id="SQLitePCL.ugly" version="0.7.1" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
@brettharrison had to take it upon himself to reduce the maximum size that Couchbase Lite tries to download at once. When users are on bad connections, the bulk downloads would fail every time because they were too large. He also noticed several issues with concurrent download threads, so he created a parameter to reduce the number of maximum http connections to allow at once.

I fixed several places where the dll would crash hard because things were not null checked. Other pieces of code that could throw exceptions were for some reason being performed outside of the try catch. We request you pull these changes into the main repository to benefit others and move this dll along.