### PR TITLE
Added bool type checking to the RevisionInternal constructor.  

### DIFF
--- a/src/Couchbase.Lite.Shared/Revisions/RevisionInternal.cs
+++ b/src/Couchbase.Lite.Shared/Revisions/RevisionInternal.cs
@@ -79,7 +79,7 @@ namespace Couchbase.Lite.Internal
         }
 
         internal RevisionInternal(Body body)
-            : this((string)body.GetPropertyForKey("_id"), (string)body.GetPropertyForKey("_rev"), (body.HasValueForKey("_deleted") && (bool)body.GetPropertyForKey("_deleted")))
+            : this((string)body.GetPropertyForKey("_id"), (string)body.GetPropertyForKey("_rev"), (body.HasValueForKey("_deleted") && body.GetPropertyForKey("_deleted") is bool && (bool)body.GetPropertyForKey("_deleted")))
         {
             this.body = body;
         }

--- a/src/Couchbase.Lite.Tests.Shared/RevisionsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/RevisionsTest.cs
@@ -363,5 +363,38 @@ namespace Couchbase.Lite
             Assert.AreEqual(1, doc.ConflictingRevisions.Count());
             Assert.AreEqual(2, doc.GetLeafRevisions(true).Count);
         }
+
+        [Test]
+        [Description("Handle the case where _deleted is not a bool.  See: https://github.com/couchbase/couchbase-lite-net/issues/414")]
+        public void TestRevisionWithNull()
+        {
+
+            RevisionInternal revisionWitDeletedNull  = new RevisionInternal(new Dictionary<string, Object>
+                            {
+                                {"_id", Guid.NewGuid().ToString()},
+                                {"_rev", "1-23243234"},
+                                {"_deleted", null}
+                            });
+
+            RevisionInternal revisionWithDeletedFalse = new RevisionInternal(new Dictionary<string, Object>
+                            {
+                                {"_id", Guid.NewGuid().ToString()},
+                                {"_rev", "1-23243234"},
+                                {"_deleted", false}
+                            });
+
+            RevisionInternal revisionWithDeletedTrue = new RevisionInternal(new Dictionary<string, Object>
+                            {
+                                {"_id", Guid.NewGuid().ToString()},
+                                {"_rev", "1-23243234"},
+                                {"_deleted", true}
+                            });
+
+
+            Assert.IsFalse(revisionWitDeletedNull.IsDeleted());
+            Assert.IsFalse(revisionWithDeletedFalse.IsDeleted());
+            Assert.IsTrue(revisionWithDeletedTrue.IsDeleted());
+        }
+
     }
 }

--- a/src/Couchbase.Lite.Tests.Shared/RevisionsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/RevisionsTest.cs
@@ -390,9 +390,16 @@ namespace Couchbase.Lite
                                 {"_deleted", true}
                             });
 
+            RevisionInternal revisionWithDeletedString = new RevisionInternal(new Dictionary<string, Object>
+                            {
+                                {"_id", Guid.NewGuid().ToString()},
+                                {"_rev", "1-23243234"},
+                                {"_deleted", "foo"}
+                            });
 
             Assert.IsFalse(revisionWitDeletedNull.IsDeleted());
             Assert.IsFalse(revisionWithDeletedFalse.IsDeleted());
+            Assert.IsFalse(revisionWithDeletedString.IsDeleted());
             Assert.IsTrue(revisionWithDeletedTrue.IsDeleted());
         }
 


### PR DESCRIPTION
This handles the case where _deleted is set to either null or a non-boolean type in the JSON.  Addresses issue #414.