### PR TITLE
Make MaxRevTreeDepth a public Property like specified in the docs

### DIFF
--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -844,8 +844,6 @@ PRAGMA user_version = 3;";
         internal IDictionary<String, WeakReference>     UnsavedRevisionDocumentCache { get; set; }
 
 
-        //TODO: Should thid be a public member?
-
         /// <summary>
         /// Maximum depth of a document's revision tree (or, max length of its revision history.)
         /// Revisions older than this limit will be deleted during a -compact: operation.
@@ -855,7 +853,7 @@ PRAGMA user_version = 3;";
         /// Revisions older than this limit will be deleted during a -compact: operation.
         /// Smaller values save space, at the expense of making document conflicts somewhat more likely.
         /// </remarks>
-        internal Int32                                  MaxRevTreeDepth { get; set; }
+        public Int32                                     MaxRevTreeDepth { get; set; }
 
         internal Int64                                   StartTime { get; private set; }
         private IDictionary<String, FilterDelegate>     Filters { get; set; }


### PR DESCRIPTION
This property is mentioned in the [docs](http://developer.couchbase.com/mobile/develop/guides/couchbase-lite/native-api/database/index.html) as public API:

*You can tune the maximum revision tree depth parameter (the Database object's maxRevTreeDepth property). This governs how old a revision must be before its metadata is discarded. It defaults to 20, meaning that each document will remember the history of its latest 20 revisions. Setting this to a smaller value will save storage space, but can result in spurious conflicts if clients are making lots of offline changes and then sync.*