### PR TITLE
Implement Full Text Search

### DIFF
--- a/src/Couchbase.Lite.Shared/Query.cs
+++ b/src/Couchbase.Lite.Shared/Query.cs
@@ -175,6 +175,7 @@ namespace Couchbase.Lite {
             InclusiveEnd = query.InclusiveEnd;
             IndexUpdateMode = query.IndexUpdateMode;
             AllDocsMode = query.AllDocsMode;
+            FullTextSearch = query.FullTextSearch;
         }
 
 
@@ -211,6 +212,7 @@ namespace Couchbase.Lite {
                 queryOptions.SetAllDocsMode(AllDocsMode);
                 queryOptions.SetStartKeyDocId(StartKeyDocId);
                 queryOptions.SetEndKeyDocId(EndKeyDocId);
+                queryOptions.SetFullTextSearch(FullTextSearch);
                 return queryOptions;
             }
         }
@@ -354,6 +356,8 @@ namespace Couchbase.Lite {
                                  : AllDocsMode.AllDocs;
             } 
         }
+
+        public string FullTextSearch { get; set; }
 
         /// <summary>
         /// Event raised when a query has finished running.

--- a/src/Couchbase.Lite.Shared/Query/QueryOptions.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryOptions.cs
@@ -87,6 +87,8 @@ namespace Couchbase.Lite
 
         private string endKeyDocId;
 
+        string fullTextSearch;
+
         // only works with _all_docs, not regular views
         public object GetStartKey()
         {
@@ -278,6 +280,16 @@ namespace Couchbase.Lite
         public void SetEndKeyDocId(string endKeyDocId)
         {
             this.endKeyDocId = endKeyDocId;
+        }
+
+        public string GetFullTextSearch()
+        {
+            return fullTextSearch;
+        }
+
+        public void SetFullTextSearch(string fullTextSearch)
+        {
+            this.fullTextSearch = fullTextSearch;
         }
     }
 }

--- a/src/Couchbase.Lite.Shared/Query/QueryRow.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryRow.cs
@@ -54,7 +54,7 @@ namespace Couchbase.Lite
     /// <summary>
     /// A result row for a Couchbase Lite <see cref="Couchbase.Lite.View"/> <see cref="Couchbase.Lite.Query"/>.
     /// </summary>
-    public sealed class QueryRow 
+    public class QueryRow 
     {
 
     #region Constructors
@@ -99,13 +99,13 @@ namespace Couchbase.Lite
         /// Gets the <see cref="Couchbase.Lite.QueryRow"/>'s key.
         /// </summary>
         /// <value>The <see cref="Couchbase.Lite.QueryRow"/>'s key.</value>
-        public Object Key { get; private set; }
+        public Object Key { get; protected set; }
 
         /// <summary>
         /// Gets the <see cref="Couchbase.Lite.QueryRow"/>'s value.
         /// </summary>
         /// <value>Rhe <see cref="Couchbase.Lite.QueryRow"/>'s value.</value>
-        public Object Value { get; private set; }
+        public Object Value { get; protected set; }
 
         /// <summary>
         /// Gets the Id of the associated <see cref="Couchbase.Lite.Document"/>.
@@ -140,7 +140,7 @@ namespace Couchbase.Lite
         /// don't correspond to individual <see cref="Couchbase.Lite.Document"/>.
         /// </summary>
         /// <value>The source document identifier.</value>
-        public String SourceDocumentId { get; private set; }
+        public String SourceDocumentId { get; protected set; }
 
         /// <summary>
         /// Gets the Id of the associated <see cref="Couchbase.Lite.Revision"/>.
@@ -173,13 +173,13 @@ namespace Couchbase.Lite
         /// Gets the properties of the associated <see cref="Couchbase.Lite.Document"/>.
         /// </summary>
         /// <value>The properties of the associated <see cref="Couchbase.Lite.Document"/>.</value>
-        public IDictionary<String, Object> DocumentProperties { get; private set; }
+        public IDictionary<String, Object> DocumentProperties { get; protected set; }
 
         /// <summary>
         /// Gets the sequence number of the associated <see cref="Couchbase.Lite.Revision"/>.
         /// </summary>
         /// <value>The sequence number.</value>
-        public Int64 SequenceNumber { get; private set; }
+        public Int64 SequenceNumber { get; protected set; }
 
         /// <summary>
         /// Gets the conflicting <see cref="Couchbase.Lite.Revision"/>s of the associated <see cref="Couchbase.Lite.Document"/>. 
@@ -267,7 +267,7 @@ namespace Couchbase.Lite
 
     #region Non-public Members
 
-        public IDictionary<string, object> AsJSONDictionary()
+        public virtual IDictionary<string, object> AsJSONDictionary()
         {
             var result = new Dictionary<string, object>();
             if (Value != null || SourceDocumentId != null)
@@ -294,4 +294,30 @@ namespace Couchbase.Lite
     #endregion
     }
 
+    public class FullTextQueryRow: QueryRow
+    {
+        internal FullTextQueryRow(string documentId, long sequence, long fullTextId, object value) :
+            base(documentId, sequence, null, value, null)
+        {
+            SourceDocumentId = documentId;
+            SequenceNumber = sequence;
+            FullTextID = fullTextId;
+            Value = value;
+        }
+
+        public long FullTextID {
+            get;
+            private set;
+        }
+
+        public override IDictionary<string, object> AsJSONDictionary()
+        {
+            var dict = base.AsJSONDictionary();
+
+            if (!dict.ContainsKey("error")) {
+                dict.Remove("key");
+            }
+            return dict;
+        }
+    }
 }


### PR DESCRIPTION
Initial implementation of Full Text Search based on the [iOS implementation](https://github.com/couchbase/couchbase-lite-ios/wiki/Full-Text-Search)

The query property fullTextSnippets is not implemented yet.

The results does not include matchCount, textRangeOfMatch, termIndexOfMatch and snippetWithWordStart:wordEnd: yet.

