### PR TITLE
Media type header value cannot be null.

### DIFF
--- a/src/Couchbase.Lite.Shared/Replication/Pusher.cs
+++ b/src/Couchbase.Lite.Shared/Replication/Pusher.cs
@@ -616,7 +616,7 @@ namespace Couchbase.Lite.Replicator
                         {
                             FileName = Path.GetFileName(blobStore.PathForKey(blobKey))
                         };
-                        content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                        content.Headers.ContentType = new MediaTypeHeaderValue(contentType ?? "application/octet-stream");
 
                         multiPart.Add(content);
                     }


### PR DESCRIPTION
If the content type has not explicitly been set an exception will be thrown when the pusher runs because null is not a valid media type header value.  