### PR TITLE
Fix querying for keys which are arrays

### DIFF
--- a/src/Couchbase.Lite.Shared/Store/SqliteViewStore.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqliteViewStore.cs
@@ -958,11 +958,12 @@ namespace Couchbase.Lite.Store
             // If given keys, sort the output into that order, and add entries for missing keys:
             if (options.Keys != null) {
                 // Group rows by key:
-                var rowsByKey = new Dictionary<object, List<QueryRow>>();
+                var rowsByKey = new Dictionary<string, List<QueryRow>>();
                 foreach (var row in rows) {
-                    var dictRows = rowsByKey.Get(row.Key);
+                    var key = ToJSONString(row.Key);
+                    var dictRows = rowsByKey.Get(key);
                     if (dictRows == null) {
-                        dictRows = rowsByKey[row.Key] = new List<QueryRow>();
+                        dictRows = rowsByKey[key] = new List<QueryRow>();
                     }
 
                     dictRows.Add(row);
@@ -970,7 +971,7 @@ namespace Couchbase.Lite.Store
 
                 // Now concatenate them in the order the keys are given in options:
                 var sortedRows = new List<QueryRow>();
-                foreach (var key in options.Keys) {
+                foreach (var key in options.Keys.Select(x => ToJSONString(x))) {
                     var dictRows = rowsByKey.Get(key);
                     if (dictRows != null) {
                         sortedRows.AddRange(dictRows);

--- a/src/Couchbase.Lite.Tests.Shared/ViewsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ViewsTest.cs
@@ -564,6 +564,103 @@ namespace Couchbase.Lite
             Assert.AreEqual(dict4["key"], rows[1].Key);
         }
 
+        /// <exception cref="Couchbase.Lite.CouchbaseLiteException"></exception>
+        [Test]
+        public void TestViewQueryWithDictSentinel()
+        {
+            var key1 = new List<string>();
+            key1.Add("red");
+            key1.Add("model1");
+            var dict1 = new Dictionary<string, object>();
+            dict1.Add("id", "11");
+            dict1.Add("key", key1);
+            PutDoc(database, dict1);
+
+            var key2 = new List<string>();
+            key2.Add("red");
+            key2.Add("model2");
+            var dict2 = new Dictionary<string, object>();
+            dict2.Add("id", "12");
+            dict2.Add("key", key2);
+            PutDoc(database, dict2);
+
+            var key3 = new List<string>();
+            key3.Add("green");
+            key3.Add("model1");
+            var dict3 = new Dictionary<string, object>();
+            dict3.Add("id", "21");
+            dict3.Add("key", key3);
+            PutDoc(database, dict3);
+
+            var key4 = new List<string>();
+            key4.Add("yellow");
+            key4.Add("model2");
+            var dict4 = new Dictionary<string, object>();
+            dict4.Add("id", "31");
+            dict4.Add("key", key4);
+            PutDoc(database, dict4);
+
+            var view = CreateView(database);
+
+            view.UpdateIndex();
+
+            // Query all rows:
+            QueryOptions options = new QueryOptions();
+            IList<QueryRow> rows = view.QueryWithOptions(options).ToList();
+
+            Assert.AreEqual(4, rows.Count);
+            Assert.AreEqual(new object[] { "green", "model1" }, ((JArray)rows[0].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model1" }, ((JArray)rows[1].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model2" }, ((JArray)rows[2].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "yellow", "model2" }, ((JArray)rows[3].Key).ToObject<object[]>());
+
+            // Start/end key query:
+            options = new QueryOptions();
+            options.StartKey = "a";
+            options.EndKey = new List<object> { "red", new Dictionary<string, object>() };
+            rows = view.QueryWithOptions(options).ToList();
+            Assert.AreEqual(3, rows.Count);
+            Assert.AreEqual(new object[] { "green", "model1" }, ((JArray)rows[0].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model1" }, ((JArray)rows[1].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model2" }, ((JArray)rows[2].Key).ToObject<object[]>());
+
+            // Start/end query without inclusive end:
+            options.EndKey = new List<object> { "red", "model1" };
+            options.InclusiveEnd = false;
+            rows = view.QueryWithOptions(options).ToList();
+            Assert.AreEqual(1, rows.Count); //1
+            Assert.AreEqual(new object[] { "green", "model1" }, ((JArray)rows[0].Key).ToObject<object[]>());
+
+            // Reversed:
+            options = new QueryOptions();
+            options.StartKey = new List<object> { "red", new Dictionary<string, object>() };
+            options.EndKey = new List<object> { "green", "model1" };
+            options.Descending = true;
+            rows = view.QueryWithOptions(options).ToList();
+            Assert.AreEqual(3, rows.Count);
+            Assert.AreEqual(new object[] { "red", "model2" }, ((JArray)rows[0].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model1" }, ((JArray)rows[1].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "green", "model1" }, ((JArray)rows[2].Key).ToObject<object[]>());
+
+            // Reversed, no inclusive end:
+            options.InclusiveEnd = false;
+            rows = view.QueryWithOptions(options).ToList();
+            Assert.AreEqual(2, rows.Count);
+            Assert.AreEqual(new object[] { "red", "model2" }, ((JArray)rows[0].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model1" }, ((JArray)rows[1].Key).ToObject<object[]>());
+
+            // Specific keys:
+            options = new QueryOptions();
+            IList<object> keys = new List<object>();
+            keys.Add(new object[] { "red", "model2" });
+            keys.Add(new object[] { "red", "model1" });
+            options.Keys = keys;
+            rows = view.QueryWithOptions(options).ToList();
+            Assert.AreEqual(2, rows.Count);
+            Assert.AreEqual(new object[] { "red", "model2" }, ((JArray)rows[0].Key).ToObject<object[]>());
+            Assert.AreEqual(new object[] { "red", "model1" }, ((JArray)rows[1].Key).ToObject<object[]>());
+        }
+
         [Test]
         public void TestLiveQueryStartEndKey()
         {


### PR DESCRIPTION
When querying a map-only view for a specific set of keys, where the keys of the view are arrays, no results are being returned.

The problem occurs when sorting the results in the same order as the keys given to the query. The results are grouped together by key by adding them to a `Dictionary<object, List<QueryRow>>`. However, keys which are arrays are returned as `JArray`, which needs to use `JTokenEqualityComparer` to be used as a `Dictionary` key.

This solution simply converts the keys to JSON strings before adding to and retrieving from the `Dictionary`.

The test was taken from the Android project:
https://github.com/couchbase/couchbase-lite-android/tree/36b977c7389aaebf466229b198784363d7b7cef9/src/androidTest/java/com/couchbase/lite/ViewsTest.java#L583