### PR TITLE
Fix deadlock when multiple UpdateIndex operations are queued

### DIFF
--- a/src/Couchbase.Lite.Shared/View/UpdateJob.cs
+++ b/src/Couchbase.Lite.Shared/View/UpdateJob.cs
@@ -73,7 +73,7 @@ namespace Couchbase.Lite.Internal
                     if(Finished != null) {
                         Finished(this, null);
                     }
-                });
+                }, TaskScheduler.Default);
             }
         }
 


### PR DESCRIPTION
My project makes heavy use of asynchronous queries, and I was occasionally seeing a deadlock of the Manager's workExecutor. 

I did some digging and found that the UpdateJob task continuation was not always being executed, even though the task ran to completion. If another UpdateIndex operation was queued and the previous continuation did not execute, the View would end up waiting forever for the new operation to complete. 

Scheduling the continuation on TaskScheduler.Default ensures the continuation is always executed.