### PR TITLE
Change CouchbaseLiteException to inherit from Exception

### DIFF
--- a/src/Couchbase.Lite.Shared/Exceptions/CouchbaseLiteException.cs
+++ b/src/Couchbase.Lite.Shared/Exceptions/CouchbaseLiteException.cs
@@ -47,7 +47,7 @@ namespace Couchbase.Lite {
     /// <summary>
     /// The main class of exception used for indicating Couchbase Lite errors
     /// </summary>
-    public class CouchbaseLiteException : ApplicationException {
+    public class CouchbaseLiteException : Exception {
 
         internal StatusCode Code { get; set; }
 


### PR DESCRIPTION
Both a bad practice (see "CLR Via CSharp") and also required for UWP.