### PR TITLE
Automate the build process

### DIFF
--- a/script/bootstrap.bat
+++ b/script/bootstrap.bat
@@ -1,0 +1,25 @@
+call git submodule update --init --recursive
+
+rem Save off the script directory
+set script_dir=%~dp0
+
+rem Pop the current working directory so we can return later
+pushd %cd%
+
+rem For paket to work off the script directory, we have to change the working directory
+cd %script_dir%
+
+.paket\paket.bootstrapper.exe
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
+
+.paket\paket.exe restore
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
+
+rem Return to the directory we originally called this from
+popd 
+
+call move %cd%\script\paket-files\github.com %cd%\src\Couchbase.Lite.Shared\vendor\cbforest\CSharp\prebuilt

--- a/script/paket.dependencies
+++ b/script/paket.dependencies
@@ -1,0 +1,4 @@
+source https://nuget.org/api/v2
+nuget FAKE
+
+http https://github.com/couchbaselabs/cbforest/releases/download/1.2-net/1.2-CBForest-Interop.zip

--- a/script/paket.lock
+++ b/script/paket.lock
@@ -1,0 +1,8 @@
+NUGET
+  remote: https://www.nuget.org/api/v2
+  specs:
+    FAKE (4.23.1)
+HTTP
+  remote: https://github.com
+  specs:
+    1.2-CBForest-Interop.zip (/couchbaselabs/cbforest/releases/download/1.2-net/1.2-CBForest-Interop.zip)


### PR DESCRIPTION
Adding scripts to automate the retrieval of dependencies, building of the project, and creation of packages.  This will lower the bar for anyone who wants to checkout the project and build it.  It will also simplify the setup in a CI server.