### PR TITLE
Fixes #749

### DIFF
--- a/src/StorageEngines/ForestDB/storage.forestdb.shared/src/ForestDBCouchStore.cs
+++ b/src/StorageEngines/ForestDB/storage.forestdb.shared/src/ForestDBCouchStore.cs
@@ -1328,15 +1328,16 @@ namespace Couchbase.Lite.Storage.ForestDB
                     var docId = inDocId;
                     var prevRevId = inPrevRevId;
 
-                    // https://github.com/couchbase/couchbase-lite-net/issues/749
-                    // Need to ensure revpos is correct for a revision inserted on top
-                    // of a deletion
-                    var existing = (C4Document*)ForestDBBridge.Check(err => Native.c4doc_getForPut(Forest, docId, prevRevId?.ToString(), deleting,
-                        allowConflict, err));
+                    var attachments = properties.CblAttachments();
+                    if(attachments != null) {
 
-                    if(existing->IsDeleted) {
-                        var attachments = properties.CblAttachments();
-                        if(attachments != null) {
+                        // https://github.com/couchbase/couchbase-lite-net/issues/749
+                        // Need to ensure revpos is correct for a revision inserted on top
+                        // of a deletion
+                        var existing = (C4Document*)ForestDBBridge.Check(err => Native.c4doc_getForPut(Forest, docId, prevRevId?.ToString(), deleting,
+                            allowConflict, err));
+
+                        if(existing->IsDeleted) {
                             foreach(var attach in attachments) {
                                 var metadata = attach.Value.AsDictionary<string, object>();
                                 if(metadata != null) {


### PR DESCRIPTION
Delay encoding the JSON until after we know whether or not this insertion is on top of a deletion.  On ForestDB this is awkward and requires an extra read, unless there is a better way that I missed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/couchbase-lite-net/790)
<!-- Reviewable:end -->