### PR TITLE
Added support to use default system proxy

### DIFF
--- a/src/Couchbase.Lite.Shared/Manager/NetworkReachabilityManager.cs
+++ b/src/Couchbase.Lite.Shared/Manager/NetworkReachabilityManager.cs
@@ -51,8 +51,10 @@ namespace Couchbase.Lite
         {
             CouchbaseLiteHttpClientFactory.SetupSslCallback();
             var uri = new Uri(remoteUri);
-            try {
-                using(var c = new TcpClient(uri.Host, uri.Port)) {
+            try
+            {
+                Uri proxy = WebRequest.DefaultWebProxy.GetProxy(new Uri(remoteUri));
+                using(var c = new TcpClient(proxy.DnsSafeHost, proxy.Port)) {
                     return true;
                 }
             } catch(Exception e) {

--- a/src/Couchbase.Lite.Shared/Replication/WebSocketChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/WebSocketChangeTracker.cs
@@ -230,7 +230,7 @@ namespace Couchbase.Lite.Internal
             _client.OnMessage += OnReceive;
             _client.OnError += OnError;
             _client.OnClose += OnClose;
-            _client.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+            _client.SslConfiguration.EnabledSslProtocols |= SslProtocols.Tls;    
             foreach(Cookie cookie in Client.GetCookieStore().GetCookies(ChangesFeedUrl)) {
                 _client.SetCookie(new WebSocketSharp.Net.Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain));
             }

--- a/src/Couchbase.Lite.Shared/Replication/WebSocketChangeTracker.cs
+++ b/src/Couchbase.Lite.Shared/Replication/WebSocketChangeTracker.cs
@@ -222,12 +222,15 @@ namespace Couchbase.Lite.Internal
             _usePost = false;
             _caughtUp = false;
             _client = new WebSocket(ChangesFeedUrl.AbsoluteUri);
+            var systemProxy = WebRequest.DefaultWebProxy.GetProxy(DatabaseUrl).ToString();
+            var proxyCredentials = WebRequest.DefaultWebProxy.Credentials.GetCredential(DatabaseUrl, "");
+            _client.SetProxy(systemProxy, proxyCredentials.UserName, proxyCredentials.Password);
             _client.WaitTime = TimeSpan.FromSeconds(2);
             _client.OnOpen += OnConnect;
             _client.OnMessage += OnReceive;
             _client.OnError += OnError;
             _client.OnClose += OnClose;
-            _client.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls;
+            _client.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
             foreach(Cookie cookie in Client.GetCookieStore().GetCookies(ChangesFeedUrl)) {
                 _client.SetCookie(new WebSocketSharp.Net.Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain));
             }


### PR DESCRIPTION
If a user has a proxy, TcpClient() by default doesn't take that into account.

Same with the WebSocket class in websocket-sharp, which I believe actually uses TcpClient(), but they have a way to set a proxy.

I'm on .NET version 4.5, but according to documentation, the properties used, such as WebRequest.DefaultWebProxy, Uri.DnsSafeHost has been available since at least .NET 2.0

https://msdn.microsoft.com/en-us/library/system.net.webrequest.defaultwebproxy(v=vs.110).aspx
https://msdn.microsoft.com/en-us/library/system.uri.dnssafehost(v=vs.90).aspx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/couchbase-lite-net/799)
<!-- Reviewable:end -->
