### PR TITLE
Added object mapping in Couchbase.Lite

### DIFF
--- a/src/Couchbase.Lite/API/Document/Document.cs
+++ b/src/Couchbase.Lite/API/Document/Document.cs
@@ -27,6 +27,7 @@ using Couchbase.Lite.Logging;
 using LiteCore;
 using LiteCore.Interop;
 using LiteCore.Util;
+using Couchbase.Lite.Util;
 
 namespace Couchbase.Lite
 {
@@ -103,7 +104,7 @@ namespace Couchbase.Lite
         {
             Set(dictionary);
         }
-
+        
         /// <summary>
         /// Creates a document with the given ID and properties
         /// </summary>
@@ -123,6 +124,24 @@ namespace Couchbase.Lite
         }
 
         #endregion
+        #region Public Methods
+
+        /// <summary>
+        /// Creates a document from a given object based on a class
+        /// </summary>
+        /// <typeparam name="T">The type of your object</typeparam>
+        /// <param name="Object">Your object</param>
+        public void MapObject<T>(object Object)
+        {
+            
+            
+            IDictionary<string, object> GeneratedDic = ((T)Object).ToDictionary();
+            Set(GeneratedDic);
+
+        }
+
+        #endregion
+
 
         #region Internal Methods
 

--- a/src/Couchbase.Lite/Util/Extensions.cs
+++ b/src/Couchbase.Lite/Util/Extensions.cs
@@ -22,6 +22,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Reflection;
+using System.Linq;
 
 namespace Couchbase.Lite.Util
 {
@@ -31,6 +33,21 @@ namespace Couchbase.Lite.Util
     public static class Extensions
     {
         #region Public Methods
+
+
+        public static Dictionary<string, object> ToDictionary(this object myObj)
+        {
+            return myObj.GetType().GetTypeInfo().DeclaredProperties
+                .Select(pi => new { Name = pi.Name, Value = pi.GetValue(myObj, null) })
+                .Union(
+                    myObj.GetType().GetTypeInfo().DeclaredFields
+                    
+                    .Select(fi => new { Name = fi.Name, Value = fi.GetValue(myObj) })
+                 )
+                .ToDictionary(ks => ks.Name, vs => vs.Value);
+        }
+
+
 
         /// <summary>
         /// Attempts to cast an object to a given type, and returning a default value if not successful
@@ -48,6 +65,7 @@ namespace Couchbase.Lite.Util
 
             return defaultVal;
         }
+
 
         /// <summary>
         /// Attempts to cast an object to a given type, and returning a compiler default value if not successful


### PR DESCRIPTION
Dear,
I added a public method in Document class which maps a class to an object.
It works like this : 
 
```
var _doc = new Document();
_doc.MapObject<MyClass>(TheObject);
DB.Save(_doc);
```


Also added a .ToDictionary() extension method in util.
It works like this:

`Object.ToDictionary()`

Due to build problems, It's not fully tested. But it worked in my own UWP project with system.Reflection APIs of UWP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/couchbase-lite-net/866)
<!-- Reviewable:end -->
