### PR TITLE
Fixed memory leak. Fixes #912

### DIFF
--- a/src/Couchbase.Lite/API/Document/Document.cs
+++ b/src/Couchbase.Lite/API/Document/Document.cs
@@ -258,7 +258,13 @@ namespace Couchbase.Lite
                 Database.EndTransaction(success);
             }
 
+            C4Document* oldDoc = c4Doc;
+
             c4Doc = newDoc;
+
+            if (oldDoc != null) {
+                Native.c4doc_free(oldDoc);
+            }
         }
 
         [SuppressMessage("ReSharper", "AccessToDisposedClosure", Justification = "The closure is executed synchronously")]


### PR DESCRIPTION
Fixed memory leak caused when updating documents with new information.  The old lite-core document was never released from memory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/couchbase-lite-net/913)
<!-- Reviewable:end -->
