### PR TITLE
Fix spacing in exception message

### DIFF
--- a/src/Couchbase.Lite.Shared/Document/DataOps.cs
+++ b/src/Couchbase.Lite.Shared/Document/DataOps.cs
@@ -145,8 +145,8 @@ namespace Couchbase.Lite.Internal.Doc
                 case Blob blob:
                     return value;
                 default:
-                    throw new ArgumentException($"{value.GetType().Name} is not a valid type.  " +
-                                                "You may only pass byte, sbyte, short, ushort, int, uint, long, ulong, float, double, bool, DateTimeOffset, Blob" +
+                    throw new ArgumentException($"{value.GetType().Name} is not a valid type. " +
+                                                "You may only pass byte, sbyte, short, ushort, int, uint, long, ulong, float, double, bool, DateTimeOffset, Blob, " +
                                                 "or one-dimensional arrays or dictionaries containing the above types");
             }
         }


### PR DESCRIPTION
- "Blob or" currently displays as "Blobor"
- Add oxford coma after "Blob"
- Remove extra space after end of first sentence