### PR TITLE
API update for replication eventing

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -275,9 +275,8 @@ namespace Couchbase.Lite.Sync
             return Modes[2 * Convert.ToInt32(active) + Convert.ToInt32(continuous)];
         }
 
-
         [MonoPInvokeCallback(typeof(C4ReplicatorDocumentEndedCallback))]
-        private static void OnDocEnded(C4Replicator* repl, bool pushing, FLSlice docID, C4Error error, bool transient, void* context)
+        private static void OnDocEnded(C4Replicator* repl, bool pushing, FLSlice docID, FLSlice revID, C4RevisionFlags flags, C4Error error, bool transient, void* context)
         {
             var replicator = GCHandle.FromIntPtr((IntPtr)context).Target as Replicator;
             var docIDStr = docID.CreateString();

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -331,13 +331,10 @@ namespace Couchbase.Lite.Sync
             return filterCallback(Config.PullFilter, docID, value, isDeleted);
         }
 
-        private bool filterCallback(Func<ReplicationFilter, bool> filterFunction, string docID, FLDict* value, bool isDeleted)
+        private bool filterCallback(Func<Document, bool, bool> filterFunction, string docID, FLDict* value, bool isDeleted)
         {
             var d = FLValueConverter.ToCouchbaseObject((FLValue*)value, Config.Database, true) as IDictionary<string, object>;
-            var filter = new ReplicationFilter();
-            filter.IsDeleted = isDeleted;
-            filter.Doc = new MutableDocument(docID, d);
-            return filterFunction(filter);
+            return filterFunction(new MutableDocument(docID, d), isDeleted);
         }
 
         private void ClearRepl()

--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
@@ -74,12 +74,6 @@ namespace Couchbase.Lite.Sync
         PerAttachment // >=2
     }
 
-    public class ReplicationFilter
-    {
-        public Document Doc { get; set; }
-        public bool IsDeleted { get; set; }
-    }
-
     /// <summary>
     /// A class representing configuration options for a <see cref="Replicator"/>
     /// </summary>
@@ -97,8 +91,8 @@ namespace Couchbase.Lite.Sync
         private Authenticator _authenticator;
         private bool _continuous;
         private ReplicatorType _replicatorType = ReplicatorType.PushAndPull;
-        private Func<ReplicationFilter, bool> _pushFilter;
-        private Func<ReplicationFilter, bool> _pullValidator;
+        private Func<Document, bool, bool> _pushFilter;
+        private Func<Document, bool, bool> _pullValidator;
         private Uri _remoteUrl;
         private Database _otherDb;
         private C4SocketFactory _socketFactory;
@@ -163,7 +157,7 @@ namespace Couchbase.Lite.Sync
         /// Document push will be allowed if output is true, othewise, Document push 
         /// will not be allowed
         /// </summary>
-        public Func<ReplicationFilter, bool> PushFilter
+        public Func<Document, bool, bool> PushFilter
         {
             get => _pushFilter;
             set => _freezer.PerformAction(() => _pushFilter = value);
@@ -174,7 +168,7 @@ namespace Couchbase.Lite.Sync
         /// Document pull will be allowed if output is true, othewise, Document pull 
         /// will not be allowed
         /// </summary>
-        public Func<ReplicationFilter, bool> PullFilter
+        public Func<Document, bool, bool> PullFilter
         {
             get => _pullValidator;
             set => _freezer.PerformAction(() => _pullValidator = value);

--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
@@ -74,6 +74,12 @@ namespace Couchbase.Lite.Sync
         PerAttachment // >=2
     }
 
+    public class ReplicationFilter
+    {
+        public Document Doc { get; set; }
+        public bool IsDeleted { get; set; }
+    }
+
     /// <summary>
     /// A class representing configuration options for a <see cref="Replicator"/>
     /// </summary>
@@ -91,8 +97,8 @@ namespace Couchbase.Lite.Sync
         private Authenticator _authenticator;
         private bool _continuous;
         private ReplicatorType _replicatorType = ReplicatorType.PushAndPull;
-        private Func<Document, bool> _pushFilter;
-        private Func<Document, bool> _pullValidator;
+        private Func<ReplicationFilter, bool> _pushFilter;
+        private Func<ReplicationFilter, bool> _pullValidator;
         private Uri _remoteUrl;
         private Database _otherDb;
         private C4SocketFactory _socketFactory;
@@ -157,7 +163,7 @@ namespace Couchbase.Lite.Sync
         /// Document push will be allowed if output is true, othewise, Document push 
         /// will not be allowed
         /// </summary>
-        public Func<Document, bool> PushFilter
+        public Func<ReplicationFilter, bool> PushFilter
         {
             get => _pushFilter;
             set => _freezer.PerformAction(() => _pushFilter = value);
@@ -168,7 +174,7 @@ namespace Couchbase.Lite.Sync
         /// Document pull will be allowed if output is true, othewise, Document pull 
         /// will not be allowed
         /// </summary>
-        public Func<Document, bool> PullFilter
+        public Func<ReplicationFilter, bool> PullFilter
         {
             get => _pullValidator;
             set => _freezer.PerformAction(() => _pullValidator = value);

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -1023,10 +1023,10 @@ namespace Test
         }
 #endif
 
-        private bool _replicator__filterCallback(ReplicationFilter filter)
+        private bool _replicator__filterCallback(Document document, bool isDeleted)
         {
             _isFilteredCallback = true;
-            var name = filter.Doc.GetString("name");
+            var name = document.GetString("name");
             return name == "pass";
         }
 

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator.cs
@@ -34,8 +34,9 @@ namespace LiteCore.Interop
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal unsafe delegate void C4ReplicatorDocumentEndedCallback(C4Replicator* replicator,
-            [MarshalAs(UnmanagedType.U1)]bool pushing, FLSlice docID, C4Error error, 
-            [MarshalAs(UnmanagedType.U1)]bool transient, void* context);
+            [MarshalAs(UnmanagedType.U1)]bool pushing, FLSlice docID, FLSlice revID, 
+            C4RevisionFlags flags, C4Error error, [MarshalAs(UnmanagedType.U1)]bool transient, 
+            void* context);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal unsafe delegate void C4ReplicatorBlobProgressCallback(C4Replicator* replicator,

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator.cs
@@ -45,8 +45,8 @@ namespace LiteCore.Interop
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     [return: MarshalAs(UnmanagedType.U1)]
-    internal unsafe delegate bool C4ReplicatorFilterFunction(FLSlice docID, FLDict* body,
-        void* context);
+    internal unsafe delegate bool C4ReplicatorValidationFunction(FLSlice docID, 
+        C4RevisionFlags revisionFlags, FLDict* body, void* context);
 }
 
 namespace Couchbase.Lite.Interop
@@ -55,8 +55,8 @@ namespace Couchbase.Lite.Interop
     {
         private C4ReplicatorParameters _c4Params;
         private C4ReplicatorStatusChangedCallback _onStatusChanged;
-        private C4ReplicatorFilterFunction _pushFilter;
-        private C4ReplicatorFilterFunction _validation;
+        private C4ReplicatorValidationFunction _pushFilter;
+        private C4ReplicatorValidationFunction _validation;
         private C4ReplicatorDocumentEndedCallback _onDocumentEnded;
 
         public C4ReplicatorParameters C4Params => _c4Params;
@@ -98,7 +98,7 @@ namespace Couchbase.Lite.Interop
             }
         }
 
-        public C4ReplicatorFilterFunction PushFilter
+        public C4ReplicatorValidationFunction PushFilter
         {
             get => _pushFilter;
             set {
@@ -107,7 +107,7 @@ namespace Couchbase.Lite.Interop
             }
         }
 
-        public C4ReplicatorFilterFunction PullFilter
+        public C4ReplicatorValidationFunction PullFilter
         {
             get => _validation;
             set {


### PR DESCRIPTION
Replication eventing: update the document ended listener name to AddDocumentReplicationListener and use RemoveChangeListener to remove both/either ChangeListener & DocumentReplicationListener

Replication filters:  update LiteCore, update C4ReplicatorFilterFunction name to C4ReplicatorValidationFunction, add ReplicationFilter class which contains Document and IsDeleted properties, add C4RevisionFlags parameter in filter callback function, add push replication with deleted document test