### PR TITLE
#1090 TTL purge timer issue: stop timer, dispose timer, and set timer…

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1412,6 +1412,13 @@ namespace Couchbase.Lite
             SchedulePurgeExpired(TimeSpan.FromSeconds(1));
         }
 
+        private void StopExpirePurgeTimer()
+        {
+            bool? success = _expirePurgeTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _expirePurgeTimer?.Dispose();
+            _expirePurgeTimer = null;
+        }
+
         #endregion
 
         /// <inheritdoc />
@@ -1441,7 +1448,7 @@ namespace Couchbase.Lite
         public void Dispose()
         {
             GC.SuppressFinalize(this);
-            _expirePurgeTimer.Dispose();
+            StopExpirePurgeTimer();
             ThreadSafety.DoLocked(() =>
             {
                 ThrowIfActiveItems();

--- a/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
@@ -1955,6 +1955,7 @@ namespace Test
 
             Thread.Sleep(5000);
             var doc = Db.GetDocument("doc_to_expired").Should().NotBeNull();
+            Db.Delete();
         }
 
         [Fact]


### PR DESCRIPTION
#1090 TTL purge timer issue: 
stop timer, dispose timer, and set timer object to null. Forcefully stop the database after set document expiration complete to see if test will still pass. Before the fix, forcefully stop the database after set document expiration complete will fail the test. After the fix, the test is passed.