### PR TITLE
Override ToString method in ReplicatedDocument class.

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorProgress.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorProgress.cs
@@ -106,5 +106,15 @@ namespace Couchbase.Lite.Sync
         {
             return new ReplicatedDocument(Id, IsAccessRemoved, IsDeleted, new C4Error(), IsTransient);
         }
+
+        public override string ToString()
+        {
+            return $"ReplicatedDocument[ Doc ID: {Id}; " +
+                   $"IsDeleted: { IsDeleted }; " +
+                   $"IsAccessRemoved: { IsAccessRemoved }; " +
+                   $"Error domain: { Error.Domain }; " +
+                   $"Error code: { Error.Error }; " +
+                   $"IsTransient: { IsTransient } ]";
+        }
     }
 }


### PR DESCRIPTION
#1100 Override ToString method in ReplicatedDocument class. This will help QA to print out the debug info easily.