### PR TITLE
LiteCore updates 

### DIFF
--- a/src/LiteCore/parse/templates_c4/C4ReplicatorParameters.cs
+++ b/src/LiteCore/parse/templates_c4/C4ReplicatorParameters.cs
@@ -10,4 +10,14 @@
         public IntPtr onBlobProgress;
         public void* callbackContext;
         public C4SocketFactory* socketFactory;
+        private byte _dontStart;
+        public bool dontStart
+        {
+            get {
+                return Convert.ToBoolean(_dontStart);
+            }
+            set {
+                _dontStart = Convert.ToByte(value);
+            }
+        }
     }

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_defs.cs
@@ -92,6 +92,16 @@ namespace LiteCore.Interop
         public IntPtr onBlobProgress;
         public void* callbackContext;
         public C4SocketFactory* socketFactory;
+        private byte _dontStart;
+        public bool dontStart
+        {
+            get {
+                return Convert.ToBoolean(_dontStart);
+            }
+            set {
+                _dontStart = Convert.ToByte(value);
+            }
+        }
     }
 
 }

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native.cs
@@ -37,6 +37,9 @@ namespace LiteCore.Interop
         public static extern void c4repl_free(C4Replicator* repl);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void c4repl_start(C4Replicator* repl);
+
+        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void c4repl_stop(C4Replicator* repl);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
LiteCore added a new Boolean variable dontStart in C4ReplicatorParameters and c4repl_start method, so updated bindings and generated the bindings in .Net. And update LiteCore.