### PR TITLE
CBL-349 Catching exception thrown when conflictResolver.Resolve failed

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -934,9 +934,6 @@ namespace Couchbase.Lite
                         // ReSharper disable once AccessToDisposedClosure
                         writeSuccess = SaveResolvedDocument(resolvedDoc, localDoc, remoteDoc);
                     });
-                    
-                } catch (Exception ex) {
-                    throw ex;
                 } finally {
                     resolvedDoc?.Dispose();
                     localDoc?.Dispose();

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -935,6 +935,8 @@ namespace Couchbase.Lite
                         writeSuccess = SaveResolvedDocument(resolvedDoc, localDoc, remoteDoc);
                     });
                     
+                } catch (Exception ex) {
+                    throw ex;
                 } finally {
                     resolvedDoc?.Dispose();
                     localDoc?.Dispose();

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -1339,10 +1339,10 @@ namespace Test
                 if (resolveCnt == 0) {
                     using (var d = Db.GetDocument("doc1"))
                     using (var doc = d.ToMutable()) {
-                        d.GetString("name").Should().Be("Tiger");
+                        d.GetString("name").Should().Be("Cat");
                         doc.SetString("name", "Cougar");
                         Db.Save(doc);
-                        d.GetString("name").Should().Be("Cougar", "Because database save operation was not blocked");
+                        doc.GetString("name").Should().Be("Cougar", "Because database save operation was not blocked");
                     }
                 }
                 resolveCnt++;


### PR DESCRIPTION
Fixes CBL-349 by catching exception when running conflictResolver.Resolve failed. Also fix unit test TestNonBlockingDatabaseOperationConflictResolver.