### PR TITLE
Fixes CBL-326 by adding SocketError.NetworkDown case

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -370,20 +370,31 @@ namespace Couchbase.Lite.Sync
         private static void StatusChangedCallback(C4Replicator* repl, C4ReplicatorStatus status, void* context)
         {
             var replicator = GCHandle.FromIntPtr((IntPtr)context).Target as Replicator;
+            if (replicator == null)
+                return;
+
+            WaitPendingConflictTasks(replicator, status);
+            replicator?.DispatchQueue.DispatchSync(() =>
+            {
+                replicator.StatusChangedCallback(status);
+            });
+        }
+
+        private static void WaitPendingConflictTasks(Replicator replicator, C4ReplicatorStatus status)
+        {
+            if (status.error.code == 0 && status.error.domain == 0)
+                return;
+
             bool transient;
-            if ((replicator != null && (status.error.code > 0 && status.error.domain > 0 
-                && replicator.IsPermanentError(status.error, out transient)))
-                && status.level == C4ReplicatorActivityLevel.Stopped) {
+            if (!replicator.IsPermanentError(status.error, out transient))
+                return;
+
+            if (status.level == C4ReplicatorActivityLevel.Stopped) {
                 var array = replicator?._conflictTasks?.Keys?.ToArray();
                 if (array != null) {
                     Task.WaitAll(array);
                 }
             }
-               
-            replicator?.DispatchQueue.DispatchSync(() =>
-            {
-                replicator.StatusChangedCallback(status);
-            });
         }
 
         private void ClearRepl()

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -371,7 +371,8 @@ namespace Couchbase.Lite.Sync
         {
             var replicator = GCHandle.FromIntPtr((IntPtr)context).Target as Replicator;
             bool transient;
-            if ((replicator != null && replicator.IsPermanentError(status.error, out transient)) 
+            if ((replicator != null && (status.error.code > 0 && status.error.domain > 0 
+                && replicator.IsPermanentError(status.error, out transient)))
                 && status.level == C4ReplicatorActivityLevel.Stopped) {
                 var array = replicator?._conflictTasks?.Keys?.ToArray();
                 if (array != null) {

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -373,24 +373,24 @@ namespace Couchbase.Lite.Sync
             if (replicator == null)
                 return;
 
-            replicator.WaitPendingConflictTasks(replicator, status);
-            replicator?.DispatchQueue.DispatchSync(() =>
+            replicator.WaitPendingConflictTasks(status);
+            replicator.DispatchQueue.DispatchSync(() =>
             {
                 replicator.StatusChangedCallback(status);
             });
         }
 
-        private void WaitPendingConflictTasks(Replicator replicator, C4ReplicatorStatus status)
+        private void WaitPendingConflictTasks(C4ReplicatorStatus status)
         {
             if (status.error.code == 0 && status.error.domain == 0)
                 return;
 
             bool transient;
-            if (!replicator.IsPermanentError(status.error, out transient))
+            if (!IsPermanentError(status.error, out transient))
                 return;
 
             if (status.level == C4ReplicatorActivityLevel.Stopped) {
-                var array = replicator?._conflictTasks?.Keys?.ToArray();
+                var array = _conflictTasks?.Keys?.ToArray();
                 if (array != null) {
                     Task.WaitAll(array);
                 }

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -373,14 +373,14 @@ namespace Couchbase.Lite.Sync
             if (replicator == null)
                 return;
 
-            WaitPendingConflictTasks(replicator, status);
+            replicator.WaitPendingConflictTasks(replicator, status);
             replicator?.DispatchQueue.DispatchSync(() =>
             {
                 replicator.StatusChangedCallback(status);
             });
         }
 
-        private static void WaitPendingConflictTasks(Replicator replicator, C4ReplicatorStatus status)
+        private void WaitPendingConflictTasks(Replicator replicator, C4ReplicatorStatus status)
         {
             if (status.error.code == 0 && status.error.domain == 0)
                 return;

--- a/src/Couchbase.Lite.Shared/Support/Status.cs
+++ b/src/Couchbase.Lite.Shared/Support/Status.cs
@@ -89,6 +89,11 @@ namespace Couchbase.Lite
                                 c4err.domain = C4ErrorDomain.POSIXDomain;
                                 c4err.code = PosixBase.GetCode(nameof(PosixWindows.ECONNREFUSED));
                                 break;
+                            case SocketError.NetworkDown:
+                                message = se.Message;
+                                c4err.domain = C4ErrorDomain.POSIXDomain;
+                                c4err.code = PosixBase.GetCode(nameof(PosixWindows.ENETDOWN));
+                                break;
                         }
 
                         break;


### PR DESCRIPTION
Fixes CBL-326 by adding SocketError.NetworkDown case in ConvertNetworkError method so it can be translated into what LiteCore expects. Also add an error check before go into IsPermanentError to save some process time.