### PR TITLE
CBL-456 Set the level on Log.Console 

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -376,7 +376,8 @@ namespace Couchbase.Lite
 		{
             Log.Console.Level = level;
             Log.Console.Domains = domains;
-            WriteLog.To.Database.W(Tag, "Currently it will only affect the console logger and not the file logger. Please use Database.Log.Console instead if you need console logging.");
+
+            WriteLog.To.Database.W(Tag, "Currently it will only affect the console logger and not the file logger.");
 		}
         
         /// <summary>

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -370,13 +370,13 @@ namespace Couchbase.Lite
 		/// </summary>
 		/// <param name="domains">The log domain(s)</param>
 		/// <param name="level">The log level</param>
-		[Obsolete("This has been superseded by Database.Log.Console.  This function is now a no-op")]
+		[Obsolete("Currently SetLogLevel will only affect the console logger and not the file logger. Domains will be used as an on/off switch of sorts, and you can no longer set level per domain.")]
         [ExcludeFromCodeCoverage]
 		public static void SetLogLevel(LogDomain domains, LogLevel level)
         {
             Log.Console.Level = level;
             Log.Console.Domains = domains;
-            WriteLog.To.Database.W(Tag, "Currently it will only affect the console logger and not the file logger.");
+            WriteLog.To.Database.W(Tag, "Currently SetLogLevel will only affect the console logger and not the file logger. Domains will be used as an on/off switch of sorts, and you can no longer set level per domain.");
         }
 
         /// <summary>

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -373,12 +373,12 @@ namespace Couchbase.Lite
 		[Obsolete("This has been superseded by Database.Log.Console.  This function is now a no-op")]
         [ExcludeFromCodeCoverage]
 		public static void SetLogLevel(LogDomain domains, LogLevel level)
-		{
+        {
             Log.Console.Level = level;
             Log.Console.Domains = domains;
             WriteLog.To.Database.W(Tag, "Currently it will only affect the console logger and not the file logger.");
-		}
-        
+        }
+
         /// <summary>
         /// Adds a change listener for the changes that occur in this database.  Signatures
         /// are the same as += style event handlers, but the callbacks will be called using the

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -374,7 +374,9 @@ namespace Couchbase.Lite
         [ExcludeFromCodeCoverage]
 		public static void SetLogLevel(LogDomain domains, LogLevel level)
 		{
-		    WriteLog.To.Database.W(Tag, "Database.SetLogLevel is deprecated, use Database.Log.Console instead.");
+            Log.Console.Level = level;
+            Log.Console.Domains = domains;
+            WriteLog.To.Database.W(Tag, "Currently it will only affect the console logger and not the file logger. Please use Database.Log.Console instead if you need console logging.");
 		}
         
         /// <summary>

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -376,7 +376,6 @@ namespace Couchbase.Lite
 		{
             Log.Console.Level = level;
             Log.Console.Domains = domains;
-
             WriteLog.To.Database.W(Tag, "Currently it will only affect the console logger and not the file logger.");
 		}
         

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -294,15 +294,14 @@ namespace Test
         [Fact] void TestSetLogLevel()
         {
             WriteLog.To.Database.I("IGNORE", "IGNORE"); // Skip initial message
-            Database.Log.Console.Level = LogLevel.None;
-            Database.SetLogLevel(LogDomain.Database, LogLevel.None);
+            Database.SetLogLevel(LogDomain.All, LogLevel.None);
             var stringWriter = new StringWriter();
             Console.SetOut(stringWriter);
             WriteLog.To.Database.E("TEST", "TEST ERROR");
             stringWriter.Flush();
             stringWriter.ToString().Should().BeEmpty("because logging is disabled");
 
-            Database.SetLogLevel(LogDomain.Database, LogLevel.Verbose);
+            Database.SetLogLevel(LogDomain.All, LogLevel.Verbose);
             stringWriter = new StringWriter();
             Console.SetOut(stringWriter);
             WriteLog.To.Database.V("TEST", "TEST VERBOSE");
@@ -316,7 +315,7 @@ namespace Test
             var currentCount = 1;
             foreach (var level in new[] { LogLevel.Error, LogLevel.Warning,
                 LogLevel.Info}) {
-                Database.SetLogLevel(LogDomain.Database, level);
+                Database.SetLogLevel(LogDomain.All, level);
                 stringWriter = new StringWriter();
                 Console.SetOut(stringWriter);
                 WriteLog.To.Database.V("TEST", "TEST VERBOSE");
@@ -330,7 +329,7 @@ namespace Test
             }
 
             Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
-            Database.SetLogLevel(LogDomain.Database, LogLevel.Warning);
+            Database.SetLogLevel(LogDomain.All, LogLevel.Warning);
         }
 
         [Fact]

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -301,20 +301,9 @@ namespace Test
             stringWriter.Flush();
             stringWriter.ToString().Should().BeEmpty("because logging is disabled");
 
-            Database.SetLogLevel(LogDomain.All, LogLevel.Verbose);
-            stringWriter = new StringWriter();
-            Console.SetOut(stringWriter);
-            WriteLog.To.Database.V("TEST", "TEST VERBOSE");
-            WriteLog.To.Database.I("TEST", "TEST INFO");
-            WriteLog.To.Database.W("TEST", "TEST WARNING");
-            WriteLog.To.Database.E("TEST", "TEST ERROR");
-            stringWriter.Flush();
-            stringWriter.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Should()
-                .HaveCount(4, "because all levels should be logged");
-
             var currentCount = 1;
             foreach (var level in new[] { LogLevel.Error, LogLevel.Warning,
-                LogLevel.Info}) {
+                LogLevel.Info, LogLevel.Verbose}) {
                 Database.SetLogLevel(LogDomain.All, level);
                 stringWriter = new StringWriter();
                 Console.SetOut(stringWriter);

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -291,7 +291,8 @@ namespace Test
             Database.Log.Console.Level = LogLevel.Warning;
         }
 
-        [Fact] void TestSetLogLevel()
+        [Fact]
+        void TestSetLogLevel()
         {
             WriteLog.To.Database.I("IGNORE", "IGNORE"); // Skip initial message
             Database.SetLogLevel(LogDomain.All, LogLevel.None);


### PR DESCRIPTION
CBL-456 Set the level on Log.Console and then set the domains according to what is included in the passed enum.