### PR TITLE
CBL-489 Throw posix error and code instead of .Net error code

### DIFF
--- a/src/Couchbase.Lite.Shared/Support/Status.cs
+++ b/src/Couchbase.Lite.Shared/Support/Status.cs
@@ -109,8 +109,8 @@ namespace Couchbase.Lite
                         //case SslStatus.ClosedAbort:
                         //  throw new IOException("Connection closed.");
                         message = ie.Message;
-                            c4err.domain = C4ErrorDomain.NetworkDomain;
-                            c4err.code = (int)SocketError.ConnectionAborted;
+                            c4err.domain = C4ErrorDomain.POSIXDomain;
+                            c4err.code = PosixBase.GetCode(nameof(PosixWindows.ECONNRESET));
                         }
                     #endif
                         break;


### PR DESCRIPTION
CBL-489 Instead of throwing .Net Error code, throw posix error and code in order to get the correct transient behavior...