### PR TITLE
Update link to official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the source repo of Couchbase Lite C#.  The main supported platforms are 
 
 ## Documentation Overview
 
-* [Official Documentation](https://developer.couchbase.com/documentation/mobile/2.0/guides/couchbase-lite/index.html)
+* [Official Documentation](https://docs.couchbase.com/couchbase-lite/current/index.html)
 * API References - See the release notes for each release on this repo
 
 ## Getting Couchbase Lite


### PR DESCRIPTION
When I clicked the link to the official documentation, it took me to this page:

* https://docs.couchbase.com/couchbase-lite/2.0/index.html

... which notifies the user that a newer version of the document is available.
![image](https://user-images.githubusercontent.com/1051245/78192421-ba8f4500-743d-11ea-83f9-32da7b0eef0a.png)


---

This PR replaces the old link with the newer link:
* https://docs.couchbase.com/couchbase-lite/current/index.html