### PR TITLE
CBL-1077 Null values are returned from Document GetArray method fix

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Document/MutableDictionaryObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/MutableDictionaryObject.cs
@@ -139,7 +139,7 @@ namespace Couchbase.Lite
                 _dict.Clear();
                 if (dictionary != null) {
                     foreach (var item in dictionary) {
-                        _dict.Set(item.Key, new MValue(DataOps.ToCouchbaseObject(item.Value)));
+                        _dict.Set(item.Key, new MValue(item.Value));
                     }
                 }
 

--- a/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
@@ -183,6 +183,16 @@ namespace Couchbase.Lite.Fleece
 
                 _vec.AddRange(Enumerable.Repeat(MValue.Empty, newSize - count));
             }
+
+            if (IsMutable) {
+                for (int i = 0; i < _vec.Count; i++) {
+                    var v = _vec[i];
+                    if (v.IsEmpty) {
+                        var val = Native.FLArray_Get(_flArr, (uint) i);
+                        _vec[i] = new MValue(FLSliceExtensions.ToObject(val));
+                    }
+                }
+            }
         }
 
         private void SetValue(int index, object val, bool isInserting = false)

--- a/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
@@ -162,7 +162,7 @@ namespace Couchbase.Lite.Fleece
                 var v = _vec[i];
                 if (v.IsEmpty) {
                     var val = Native.FLArray_Get(_flArr, (uint)i);
-                    _vec[i] = new MValue(FLSliceExtensions.ToObject(val));
+                    _vec[i] = new MValue(val);
                 }
             }
         }

--- a/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
@@ -162,7 +162,7 @@ namespace Couchbase.Lite.Fleece
                 var v = _vec[i];
                 if (v.IsEmpty) {
                     var val = Native.FLArray_Get(_flArr, (uint)i);
-                    _vec[i] = new MValue(val);
+                    _vec[i] = new MValue(FLSliceExtensions.ToObject(val));
                 }
             }
         }
@@ -185,13 +185,7 @@ namespace Couchbase.Lite.Fleece
             }
 
             if (IsMutable) {
-                for (int i = 0; i < _vec.Count; i++) {
-                    var v = _vec[i];
-                    if (v.IsEmpty) {
-                        var val = Native.FLArray_Get(_flArr, (uint) i);
-                        _vec[i] = new MValue(FLSliceExtensions.ToObject(val));
-                    }
-                }
+                PopulateArr();
             }
         }
 

--- a/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
@@ -183,10 +183,6 @@ namespace Couchbase.Lite.Fleece
 
                 _vec.AddRange(Enumerable.Repeat(MValue.Empty, newSize - count));
             }
-
-            if (IsMutable) {
-                PopulateArr();
-            }
         }
 
         private void SetValue(int index, object val, bool isInserting = false)
@@ -337,7 +333,7 @@ namespace Couchbase.Lite.Fleece
                     if (item.IsEmpty) {
                         Native.FLEncoder_WriteValue(enc, Native.FLArray_Get(_flArr, (uint)i));
                     } else {
-                        item.NativeObject.FLEncode(enc);
+                        item.FLEncode(enc);
                     }
                 }
 

--- a/src/Couchbase.Lite.Shared/Serialization/MValue.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/MValue.cs
@@ -127,7 +127,8 @@ namespace Couchbase.Lite.Internal.Serialization
             switch (type) {
                 case FLValueType.Array:
                     cache = true;
-                    return parent?.MutableChildren == true ? new MutableArrayObject(mv, parent) 
+                    return parent?.MutableChildren == true 
+                        ? new MutableArrayObject(mv, parent) 
                         : new ArrayObject(mv, parent);
                 case FLValueType.Dict:
                     cache = true;

--- a/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
@@ -1233,24 +1233,36 @@ namespace Test
         [Fact]
         public void TestGetArrayAfterDbSave()
         {
-            var doc = new MutableDocument("doc1");
-            var phones = new MutableArrayObject();
-            phones.AddString("650-000-0001").AddString("650-000-0002");
-            doc.SetArray("mobile", phones);
+            using (var doc = new MutableDocument("doc1")) {
+                var phones = new MutableArrayObject();
+                phones.AddString("650-000-0001").AddString("650-000-0002");
+                doc.SetArray("mobile", phones);
+                SaveDocument(doc);
+            }
 
-            SaveDocument(doc);
+            using (var doc1 = Db.GetDocument("doc1"))
+            using (var mDoc1 = doc1.ToMutable()) {
+                var phones1 = mDoc1.GetArray("mobile");
+                for (int i = 0; i < phones1.Count; i++) {
+                    if (i == 0)
+                        phones1[i].ToString().Should().Be("650-000-0001");
+                    if (i == 1)
+                        phones1[i].ToString().Should().Be("650-000-0002");
+                }
 
-            var doc1 = Db.GetDocument("doc1").ToMutable();
-            var phones1 = doc1.GetArray("mobile");
-            phones1.AddString("650-000-0003");
+                phones1.AddString("650-000-0003");
+                phones1.GetString(0).Should().Be("650-000-0001");
+                phones1.GetString(1).Should().Be("650-000-0002");
+                SaveDocument(mDoc1);
+            }
 
-            SaveDocument(doc1);
-
-            var doc2 = Db.GetDocument("doc1").ToMutable();
-            doc2.GetArray("mobile")
+            using (var doc2 = Db.GetDocument("doc1"))
+            using (var mDoc2 = doc2.ToMutable()) {
+                mDoc2.GetArray("mobile")
                 .Should()
                 .ContainInOrder(new[] { "650-000-0001", "650-000-0002", "650-000-0003" },
                     "because both arrays should receive the update");
+            }
         }
 
         [Fact]

--- a/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
@@ -1231,6 +1231,29 @@ namespace Test
         }
 
         [Fact]
+        public void TestGetArrayAfterDbSave()
+        {
+            var doc = new MutableDocument("doc1");
+            var phones = new MutableArrayObject();
+            phones.AddString("650-000-0001").AddString("650-000-0002");
+            doc.SetArray("mobile", phones);
+
+            SaveDocument(doc);
+
+            var doc1 = Db.GetDocument("doc1").ToMutable();
+            var phones1 = doc1.GetArray("mobile");
+            phones1.AddString("650-000-0003");
+
+            SaveDocument(doc1);
+
+            var doc2 = Db.GetDocument("doc1").ToMutable();
+            doc2.GetArray("mobile")
+                .Should()
+                .ContainInOrder(new[] { "650-000-0001", "650-000-0002", "650-000-0003" },
+                    "because both arrays should receive the update");
+        }
+
+        [Fact]
         public void TestCount()
         {
             var doc = new MutableDocument("doc1");


### PR DESCRIPTION
CBL-1077 Fix fleece mutable array encoding by directly encode the item.
MValue has its own FLEncode method, which checks both value and nativeValue (if value is non-null, it writes it using FLEncoder_WriteValue)