### PR TITLE
Don't send the client certificate data to LiteCore

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -532,6 +532,7 @@ namespace Couchbase.Lite.Sync
 
                 if (!finalizing) {
                     _nativeParams?.Dispose();
+                    Config.Options.Dispose();
                     if (Status.Activity != ReplicatorActivityLevel.Stopped) {
                         var newStatus = new ReplicatorStatus(ReplicatorActivityLevel.Stopped, Status.Progress, null);
                         _statusChanged.Fire(this, new ReplicatorStatusChangedEventArgs(newStatus));


### PR DESCRIPTION
Instead just send a token for it to claim later.  This avoids logging sensitive information as well because all that will be logged is a memory address pointing to a handle to a .NET object.