### PR TITLE
CBL-1192 Fix some flaky logic in MockConnection

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/P2PTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/P2PTest.cs
@@ -70,7 +70,7 @@ namespace Test
             //Database.Log.Console.Level = LogLevel.Debug;
         }
         
-        /*[Fact]
+        [Fact]
         public void TestShortP2P()
         {
             //var testNo = 1;
@@ -173,7 +173,7 @@ namespace Test
         [Fact]
         public void TestP2PRecoverableFailureDuringSend() => TestP2PError(MockConnectionLifecycleLocation.Send, true);
 
-        //[Fact]
+        [Fact]
         public void TestP2PRecoverableFailureDuringReceive() => TestP2PError(MockConnectionLifecycleLocation.Receive, true);
 
         [Fact]
@@ -241,7 +241,7 @@ namespace Test
 
 //        Exception thrown at 0x00007FFE3090A799 in dotnet.exe: Microsoft C++ exception: EEFileLoadException at memory location 0x000000C288E79D88.
 //Exception thrown at 0x00007FFE3090A799 in dotnet.exe: Microsoft C++ exception: [rethrow] at memory location 0x0000000000000000.
-        //[Fact]
+        [Fact]
         public void TestP2PPassiveCloseAll()
         {
             using (var doc = new MutableDocument("test")) {
@@ -355,7 +355,7 @@ namespace Test
             awaiter.Validate();
 
             statuses.Count.Should().Be(0);
-        }*/
+        }
 
         private ReplicatorConfiguration CreateFailureP2PConfiguration(ProtocolType protocolType, MockConnectionLifecycleLocation location, bool recoverable)
         {


### PR DESCRIPTION
CBL-1192
This was causing P2P test hanging because the new Core behavior performs the start logic asynchronously, meaning that the mock side needs to wait for both sides to be finished opening before doing anything else.