### PR TITLE
CBL-951 Add database delete/close tests in URL Endpoint Listener, TestClientCertAuthRootCertsError, and code clean up.

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -291,7 +291,7 @@ namespace Couchbase.Lite
             get {
                 return ThreadSafety.DoLocked(() =>
                 {
-                    return ActiveStoppables.Count == 0;// && ActiveLiveQueries.Count == 0;
+                    return ActiveStoppables.Count == 0;
                 });
             }
         }

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -633,11 +633,7 @@ namespace Couchbase.Lite.Sync
 
             DispatchQueue.DispatchAsync(() =>
             {
-                if (_repl == null && e.Status == NetworkReachabilityStatus.Reachable) {
-                    WriteLog.To.Sync.I(Tag, $"{this}: Server may now be reachable; retrying...");
-                }
-
-                if (_repl != null && _reachability != null) {
+                if (_repl != null /* just to be safe */) {
                     Native.c4repl_setHostReachable(_repl, e.Status == NetworkReachabilityStatus.Reachable);
                 }
             });

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -672,7 +672,7 @@ namespace Test
 
             repl1.Start();
             repl2.Start();
-            WaitHandle.WaitAll(new[] {wait1.WaitHandle, wait2.WaitHandle}, _timeout)
+            WaitHandle.WaitAll(new[] {wait1.WaitHandle, wait2.WaitHandle}, TimeSpan.FromSeconds(20))
                 .Should().BeTrue();
 
             repl1.RemoveChangeListener(token1);
@@ -682,13 +682,15 @@ namespace Test
             OtherDb.Count.Should().Be(3, "because otherwise not all docs were received into OtherDb");
             urlepTestDb.Count.Should().Be(3, "because otherwise not all docs were received into urlepTestDb");
             
-            urlepTestDb.Dispose();
             repl1.Dispose();
             repl2.Dispose();
             wait1.Dispose();
             wait2.Dispose();
+            urlepTestDb.Delete();
 
             _listener.Stop();
+
+            Thread.Sleep(500); // wait for everything to stop
         }
 
         [Fact]
@@ -901,13 +903,15 @@ namespace Test
             OtherDb.IsClosedLocked.Should().Be(true);
             db2.IsClosedLocked.Should().Be(true);
 
-            WaitHandle.WaitAll(new[] { waitStoppedAssert1.WaitHandle, waitStoppedAssert2.WaitHandle }, _timeout)
+            WaitHandle.WaitAll(new[] { waitStoppedAssert1.WaitHandle, waitStoppedAssert2.WaitHandle }, TimeSpan.FromSeconds(20))
                 .Should().BeTrue();
 
             waitIdleAssert1.Dispose();
             waitIdleAssert2.Dispose();
             waitStoppedAssert1.Dispose();
             waitStoppedAssert2.Dispose();
+
+            Thread.Sleep(500);
         }
 
         // Two replicators, replicates docs to the listener; validates connection status

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -776,6 +776,10 @@ namespace Test
 
         private void WithActiveReplicatorAndURLEndpointListeners(bool isCloseNotDelete)
         {
+            Db.Delete();
+            ReopenDB();
+
+            ReopenOtherDb();
             WaitAssert waitIdleAssert1 = new WaitAssert();
             WaitAssert waitStoppedAssert1 = new WaitAssert();
 

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -851,14 +851,14 @@ namespace Test
             var config1 = CreateConfig(target, ReplicatorType.PushAndPull, true, sourceDb: OtherDb);
             var repl1 = new Replicator(config1);
 
-            Database.Delete("db2", Directory);
-            var db2 = OpenDB("db2");
+            Database.Delete("urlepTestDb", Directory);
+            var urlepTestDb = OpenDB("urlepTestDb");
             using (var doc2 = new MutableDocument()) {
-                db2.Save(doc2);
+                urlepTestDb.Save(doc2);
             }
 
             var config2 = CreateConfig(_listener.LocalEndpoint(), ReplicatorType.PushAndPull, true,
-                serverCert: _listener.TlsIdentity.Certs[0], sourceDb: db2);
+                serverCert: _listener.TlsIdentity.Certs[0], sourceDb: urlepTestDb);
             var repl2 = new Replicator(config2);
 
             EventHandler<ReplicatorStatusChangedEventArgs> changeListener = (sender, args) =>
@@ -888,20 +888,20 @@ namespace Test
                 .Should().BeTrue();
 
             OtherDb.ActiveStoppables.Count.Should().Be(2);
-            db2.ActiveStoppables.Count.Should().Be(1);
+            urlepTestDb.ActiveStoppables.Count.Should().Be(1);
 
             if (isCloseNotDelete) {
-                db2.Close();
+                urlepTestDb.Close();
                 OtherDb.Close();
             } else {
-                db2.Delete();
+                urlepTestDb.Delete();
                 OtherDb.Delete();
             }
 
             OtherDb.ActiveStoppables.Count.Should().Be(0);
-            db2.ActiveStoppables.Count.Should().Be(0);
+            urlepTestDb.ActiveStoppables.Count.Should().Be(0);
             OtherDb.IsClosedLocked.Should().Be(true);
-            db2.IsClosedLocked.Should().Be(true);
+            urlepTestDb.IsClosedLocked.Should().Be(true);
 
             WaitHandle.WaitAll(new[] { waitStoppedAssert1.WaitHandle, waitStoppedAssert2.WaitHandle }, TimeSpan.FromSeconds(20))
                 .Should().BeTrue();

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -829,10 +829,6 @@ namespace Test
 
         private void WithActiveReplicationsAndURLEndpointListener(bool isCloseNotDelete)
         {
-            Db.Delete();
-            ReopenDB();
-
-            ReopenOtherDb();
             var waitIdleAssert1 = new ManualResetEventSlim();
             var waitIdleAssert2 = new ManualResetEventSlim();
             var waitStoppedAssert1 = new ManualResetEventSlim();

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -441,50 +441,6 @@ namespace Test
         }
 
         [Fact]
-        public void TestListenerWithImportIdentity()
-        {
-            byte[] serverData = null;
-            using (var stream = typeof(URLEndpointListenerTest).Assembly.GetManifestResourceStream("client.p12"))
-            using (var reader = new BinaryReader(stream)) {
-                serverData = reader.ReadBytes((int) stream.Length);
-            }
-
-            // Cleanup
-            TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
-
-            // Import identity
-            var id = TLSIdentity.ImportIdentity(_store, serverData, "123", ServerCertLabel, null);
-
-            // Create listener and start
-            var config = CreateListenerConfig(true, true, null, id);
-            _listener = Listen(config);
-
-            _listener.TlsIdentity.Should().NotBeNull();
-
-            using (var doc1 = new MutableDocument("doc1")) {
-                doc1.SetString("name", "Sam");
-                Db.Save(doc1);
-            }
-
-            OtherDb.Count.Should().Be(0);
-
-            RunReplication(
-                _listener.LocalEndpoint(),
-                ReplicatorType.PushAndPull,
-                false,
-                null, //authenticator
-                false, //accept only self signed server cert
-                _listener.TlsIdentity.Certs[0], //server cert
-                0,
-                0
-            );
-
-            OtherDb.Count.Should().Be(1);
-
-            _listener.Stop();
-        }
-
-        [Fact]
         public void TestAcceptSelfSignedCertWithPinnedCertificate()
         {
             _listener = CreateListener();

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -440,7 +440,7 @@ namespace Test
             _listener.Stop();
         }
 
-        //[Fact]
+        [Fact]
         public void TestListenerWithImportIdentity()
         {
             byte[] serverData = null;


### PR DESCRIPTION
CBL-951 Add close/delete database tests in url endpoint listener. Also add unit test case that is added in iOS.