### PR TITLE
CBL-1217 Check database is open in the beginning of pending doc id API

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1084,6 +1084,14 @@ namespace Couchbase.Lite
             }
         }
 
+        internal void CheckOpenLocked()
+        {
+            ThreadSafety.DoLocked(() =>
+            {
+                CheckOpen();
+            });
+        }
+
         #endregion
 
         #region Private Methods
@@ -1137,7 +1145,7 @@ namespace Couchbase.Lite
         }
 
         // Must be called inside self lock
-        internal void CheckOpen()
+        private void CheckOpen()
         {
             if (IsClosed) {
                 throw new InvalidOperationException(CouchbaseLiteErrorMessage.DBClosed);

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1137,7 +1137,7 @@ namespace Couchbase.Lite
         }
 
         // Must be called inside self lock
-        private void CheckOpen()
+        internal void CheckOpen()
         {
             if (IsClosed) {
                 throw new InvalidOperationException(CouchbaseLiteErrorMessage.DBClosed);

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -305,6 +305,8 @@ namespace Couchbase.Lite.Sync
         [NotNull]
         public IImmutableSet<string> GetPendingDocumentIDs()
         {
+            CheckDbOpen();
+
             var result = new HashSet<string>();
             if (!IsPushing()) {
                 CBDebug.LogAndThrow(WriteLog.To.Sync,
@@ -355,6 +357,8 @@ namespace Couchbase.Lite.Sync
         public bool IsDocumentPending([NotNull]string documentID)
         {
             CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(documentID), documentID);
+            CheckDbOpen();
+
             bool isDocPending = false;
 
             if (!IsPushing()) {
@@ -716,6 +720,11 @@ namespace Couchbase.Lite.Sync
             host.Dispose();
 
             return err;
+        }
+
+        private void CheckDbOpen()
+        {
+            Config.Database.CheckOpen();
         }
 
         private void StartReachabilityObserver()

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -355,7 +355,6 @@ namespace Couchbase.Lite.Sync
         public bool IsDocumentPending([NotNull]string documentID)
         {
             CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(documentID), documentID);
-
             bool isDocPending = false;
 
             if (!IsPushing()) {

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -639,7 +639,7 @@ namespace Couchbase.Lite.Sync
 
         private C4Error SetupC4Replicator()
         {
-            Config.Database.CheckOpen();
+            Config.Database.CheckOpenLocked();
             C4Error err = new C4Error();
             if (_repl != null) {
                 Native.c4repl_setOptions(_repl, ((FLSlice) Config.Options.FLEncode()).ToArrayFast());
@@ -667,7 +667,7 @@ namespace Couchbase.Lite.Sync
                 addr.port = (ushort) remoteUrl.Port;
                 addr.path = path.AsFLSlice();
             } else {
-                Config.OtherDB?.CheckOpen();
+                Config.OtherDB?.CheckOpenLocked();
                 otherDB = Config.OtherDB;
             }
 

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -305,8 +305,6 @@ namespace Couchbase.Lite.Sync
         [NotNull]
         public IImmutableSet<string> GetPendingDocumentIDs()
         {
-            CheckDbOpen();
-
             var result = new HashSet<string>();
             if (!IsPushing()) {
                 CBDebug.LogAndThrow(WriteLog.To.Sync,
@@ -357,7 +355,6 @@ namespace Couchbase.Lite.Sync
         public bool IsDocumentPending([NotNull]string documentID)
         {
             CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(documentID), documentID);
-            CheckDbOpen();
 
             bool isDocPending = false;
 
@@ -643,6 +640,7 @@ namespace Couchbase.Lite.Sync
 
         private C4Error SetupC4Replicator()
         {
+            Config.Database.CheckOpen();
             C4Error err = new C4Error();
             if (_repl != null) {
                 Native.c4repl_setOptions(_repl, ((FLSlice) Config.Options.FLEncode()).ToArrayFast());
@@ -670,6 +668,7 @@ namespace Couchbase.Lite.Sync
                 addr.port = (ushort) remoteUrl.Port;
                 addr.path = path.AsFLSlice();
             } else {
+                Config.OtherDB?.CheckOpen();
                 otherDB = Config.OtherDB;
             }
 
@@ -720,11 +719,6 @@ namespace Couchbase.Lite.Sync
             host.Dispose();
 
             return err;
-        }
-
-        private void CheckDbOpen()
-        {
-            Config.Database.CheckOpen();
         }
 
         private void StartReachabilityObserver()

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -1588,28 +1588,16 @@ namespace Test
         //end conflict resolveing tests
 
         [Fact]
-        public void TestCloseWithActiveReplications()
-        {
-            WithActiveReplications(true);
-        }
+        public void TestCloseWithActiveReplications() => WithActiveReplications(true);
 
         [Fact]
-        public void TestDeleteWithActiveReplications()
-        {
-            WithActiveReplications(false);
-        }
+        public void TestDeleteWithActiveReplications() => WithActiveReplications(false);
 
         [Fact]
-        public void TestCloseWithActiveReplicationAndQuery()
-        {
-            WithActiveReplicationAndQuery(true);
-        }
+        public void TestCloseWithActiveReplicationAndQuery() => WithActiveReplicationAndQuery(true);
 
         [Fact]
-        public void TestDeleteWithActiveReplicationAndQuery()
-        {
-            WithActiveReplicationAndQuery(false);
-        }
+        public void TestDeleteWithActiveReplicationAndQuery() => WithActiveReplicationAndQuery(false);
 
         // Pending Doc Ids unit tests
 
@@ -1726,6 +1714,13 @@ namespace Test
                 Action badAct = () => replicator.GetPendingDocumentIDs();
                 badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
             }
+
+            ReopenDB();
+            using (var replicator = new Replicator(config)) {
+                OtherDb.Close();
+                Action badAct = () => replicator.GetPendingDocumentIDs();
+                badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
+            }
         }
 
         [Fact]
@@ -1734,6 +1729,13 @@ namespace Test
             var config = CreateConfig(true, false, false);
             using (var replicator = new Replicator(config)) {
                 Db.Close();
+                Action badAct = () => replicator.IsDocumentPending("doc1");
+                badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
+            }
+
+            ReopenDB();
+            using (var replicator = new Replicator(config)) {
+                OtherDb.Close();
                 Action badAct = () => replicator.IsDocumentPending("doc1");
                 badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
             }

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -1717,6 +1717,28 @@ namespace Test
         [Fact]
         public void TestIsDocumentPendingWithFilter() => ValidateIsDocumentPending(PENDING_DOC_ID_SEL.FILTER);
 
+        [Fact]
+        public void TestGetPendingDocIdsWithCloseDb()
+        {
+            var config = CreateConfig(true, false, false);
+            using (var replicator = new Replicator(config)) {
+                Db.Close();
+                Action badAct = () => replicator.GetPendingDocumentIDs();
+                badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
+            }
+        }
+
+        [Fact]
+        public void TestIsDocumentPendingWithCloseDb()
+        {
+            var config = CreateConfig(true, false, false);
+            using (var replicator = new Replicator(config)) {
+                Db.Close();
+                Action badAct = () => replicator.IsDocumentPending("doc1");
+                badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
+            }
+        }
+
         //end pending doc id tests
 
 #endif


### PR DESCRIPTION
CBL-1217 Check Database is open before proceeding getting pending doc ids and check is doc pending. Add unit tests to verify.