### PR TITLE
Use SecurityString in password securely. 

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/BasicAuthenticator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/BasicAuthenticator.cs
@@ -50,7 +50,7 @@ namespace Couchbase.Lite.Sync
         /// <summary>
         /// [DEPRECATED] Gets the password that this object holds
         /// </summary>
-        /// [Obsolete("This property is deprecated, please use byte[] PasswordData instead.")]
+        /// [Obsolete("This property is deprecated, please use SecureString PasswordSecureString instead.")]
         [NotNull]
         public string Password { get; }
 
@@ -58,7 +58,7 @@ namespace Couchbase.Lite.Sync
         /// Gets the password that this object holds
         /// </summary>
         [NotNull]
-        internal SecureString PasswordSecureString { get; }
+        public SecureString PasswordSecureString { get; }
 
         #endregion
 
@@ -69,7 +69,7 @@ namespace Couchbase.Lite.Sync
         /// </summary>
         /// <param name="username">The username to send through HTTP Basic authentication</param>
         /// <param name="password">The password to send through HTTP Basic authentication</param>
-        /// [Obsolete("This constructor is deprecated, please use BasicAuthenticator([NotNull]string username, [NotNull]byte[] password) instead.")]
+        /// [Obsolete("This constructor is deprecated, please use BasicAuthenticator([NotNull]string username, [NotNull]SecureString password) instead.")]
         public BasicAuthenticator([NotNull]string username, [NotNull]string password)
         {
             Username = CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(username), username);
@@ -81,7 +81,7 @@ namespace Couchbase.Lite.Sync
         /// </summary>
         /// <param name="username">The username to send through HTTP Basic authentication</param>
         /// <param name="password">The password to send through HTTP Basic authentication</param>
-        internal BasicAuthenticator([NotNull]string username, [NotNull]SecureString password)
+        public BasicAuthenticator([NotNull]string username, [NotNull]SecureString password)
         {
             Username = CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(username), username);
             PasswordSecureString = CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(password), password);

--- a/src/Couchbase.Lite.Shared/API/Sync/BasicAuthenticator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/BasicAuthenticator.cs
@@ -103,7 +103,7 @@ namespace Couchbase.Lite.Sync
 
             // TODO string Password will be deprecated and replaced with byte array password
             if (String.IsNullOrEmpty(Password))
-                authDict.Password = new NetworkCredential(string.Empty, PasswordSecureString).Password;
+                authDict.PasswordSecureString = PasswordSecureString;
             else
                 authDict.Password = Password;
 

--- a/src/Couchbase.Lite.Shared/Sync/AuthOptionsDictionary.cs
+++ b/src/Couchbase.Lite.Shared/Sync/AuthOptionsDictionary.cs
@@ -77,6 +77,16 @@ namespace Couchbase.Lite.Sync
         }
 
         /// <summary>
+        /// Gets or sets the password for the credentials (not applicable in all cases)
+        /// </summary>
+        [CanBeNull]
+        public SecureString PasswordSecureString
+        {
+            get => this[PasswordKey] as SecureString;
+            set => this[PasswordKey] = value;
+        }
+
+        /// <summary>
         /// Gets or sets the type of authentication to be used
         /// </summary>
         public AuthType Type
@@ -110,6 +120,7 @@ namespace Couchbase.Lite.Sync
             Type = AuthType.HttpBasic;
             Username = String.Empty;
             Password = String.Empty;
+            PasswordSecureString = null;
         }
 
         internal AuthOptionsDictionary(Dictionary<string, object> raw) : base(raw)

--- a/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
+++ b/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
@@ -678,8 +678,10 @@ namespace Couchbase.Lite.Sync
                     var username = auth.Username;
                     var password = auth.Password;
                     var passwordSS = auth.PasswordSecureString;
-                    if (username != null && (password != null || passwordSS != null)) {
-                        _logic.Credential = new NetworkCredential(username, password ?? new NetworkCredential(string.Empty, passwordSS).Password);
+                    if (username != null && password != null) {
+                        _logic.Credential = new NetworkCredential(username, password);
+                    } else if (username != null && passwordSS != null) {
+                        _logic.Credential = new NetworkCredential(username, passwordSS);
                     }
                 }
             }

--- a/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
+++ b/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
@@ -677,8 +677,9 @@ namespace Couchbase.Lite.Sync
                 if (auth.Type == AuthType.HttpBasic) {
                     var username = auth.Username;
                     var password = auth.Password;
-                    if (username != null && password != null) {
-                        _logic.Credential = new NetworkCredential(username, password);
+                    var passwordSS = auth.PasswordSecureString;
+                    if (username != null && (password != null || passwordSS != null)) {
+                        _logic.Credential = new NetworkCredential(username, password ?? new NetworkCredential(string.Empty, passwordSS).Password);
                     }
                 }
             }

--- a/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
@@ -21,7 +21,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
 
 using Couchbase.Lite;
@@ -548,6 +550,9 @@ namespace LiteCore.Interop
                     break;
                 case Blob b:
                     b.FLEncode(enc);
+                    break;
+                case SecureString ss:
+                    new NetworkCredential(string.Empty, ss).Password.FLEncode(enc);
                     break;
                 default:
                     throw new ArgumentException($"Cannot encode {obj.GetType().FullName} to Fleece!");


### PR DESCRIPTION
Only convert the SecurityString to string in fleece encoding and password into NetworkCredential.