### PR TITLE
CBL-1476 Add DNS support in proxy server address

### DIFF
--- a/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
+++ b/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
@@ -306,14 +306,9 @@ namespace Couchbase.Lite.Sync
                 }
 
                 _logic.HasProxy = true;
-                //create remote endpoint
-                IPAddress add;
-                //connect remote proxy endpoint
-                if (!IPAddress.TryParse(proxyServer.Address.Host, out add)) {
-                    await _client.ConnectAsync(proxyServer.Address.Host, proxyServer.Address.Port).ConfigureAwait(false);
-                } else {
-                    await _client.ConnectAsync(add, proxyServer.Address.Port).ConfigureAwait(false);
-                }
+
+                //create remote endpoint (proxyServer.Address.Host can be either IPAddress or DNS)
+                await _client.ConnectAsync(proxyServer.Address.Host, proxyServer.Address.Port).ConfigureAwait(false);
 
                 NetworkStream = _client.GetStream();
                 var proxyRequest = _logic.ProxyRequest();

--- a/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
+++ b/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
@@ -307,9 +307,14 @@ namespace Couchbase.Lite.Sync
 
                 _logic.HasProxy = true;
                 //create remote endpoint
-                IPAddress add = IPAddress.Parse(proxyServer.Address.Host);
+                IPAddress add;
                 //connect remote proxy endpoint
-                await _client.ConnectAsync(add, proxyServer.Address.Port).ConfigureAwait(false);
+                if (!IPAddress.TryParse(proxyServer.Address.Host, out add)) {
+                    await _client.ConnectAsync(proxyServer.Address.Host, proxyServer.Address.Port).ConfigureAwait(false);
+                } else {
+                    await _client.ConnectAsync(add, proxyServer.Address.Port).ConfigureAwait(false);
+                }
+
                 NetworkStream = _client.GetStream();
                 var proxyRequest = _logic.ProxyRequest();
                 NetworkStream.Write(proxyRequest, 0, proxyRequest.Length);


### PR DESCRIPTION
CBL-1476 Check if proxy server address is not IPAddress, then just past server host string into client connect async method.