### PR TITLE
CBD-4039, switch to check for vs 2019 installation.

### DIFF
--- a/src/build/do_build.ps1
+++ b/src/build/do_build.ps1
@@ -1,12 +1,11 @@
 Push-Location $PSScriptRoot\..\Couchbase.Lite
 
-$VSRegistryKey = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7"
-$VSInstall = (Get-ItemProperty -Path $VSRegistryKey -Name "15.0") | Select-Object -ExpandProperty "15.0"
+$VSInstall = (Get-CimInstance MSFT_VSInstance).InstallLocation
 if(-Not $VSInstall) {
-    throw "Unable to locate VS2017 installation"
+    throw "Unable to locate VS2019 installation"
 }
 
-$MSBuild = "$VSInstall\MSBuild\15.0\Bin\MSBuild.exe"
+$MSBuild = "$VSInstall\MSBuild\Current\Bin\MSBuild.exe"
 
 Write-Host
 Write-Host *** TRANSFORMING TEMPLATES ***


### PR DESCRIPTION
VS 2019 no longer has the same reg key entry as VS2017.  We should use "Get-CimInstance MSFT_VSInstance" instead.

-Ming Ho