### PR TITLE
CBL-1843 Remove deprecated APIs

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -440,20 +440,6 @@ namespace Couchbase.Lite
         }
 
         /// <summary>
-        /// [DEPRECATED] Sets the log level for the given domains(s)
-        /// </summary>
-        /// <param name="domains">The log domain(s)</param>
-        /// <param name="level">The log level</param>
-        [Obsolete("Currently SetLogLevel will only affect the console logger and not the file logger. Domains will be used as an on/off switch of sorts, and you can no longer set level per domain.")]
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        public static void SetLogLevel(LogDomain domains, LogLevel level)
-        {
-            Log.Console.Level = level;
-            Log.Console.Domains = domains;
-            WriteLog.To.Database.W(Tag, "Currently SetLogLevel will only affect the console logger and not the file logger. Domains will be used as an on/off switch of sorts, and you can no longer set level per domain.");
-        }
-
-        /// <summary>
         /// Adds a change listener for the changes that occur in this database.  Signatures
         /// are the same as += style event handlers, but the callbacks will be called using the
         /// specified <see cref="TaskScheduler"/>.  If the scheduler is null, the default task

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -216,23 +216,6 @@ namespace Couchbase.Lite.Sync
         }
 
         /// <summary>
-        /// [DEPRECATED] Resets the local checkpoint of the replicator, meaning that it will read all changes since the beginning
-        /// of time from the remote database.  This can only be called when the replicator is in a stopped state.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if this method is called while the replicator is
-        /// not in a stopped state</exception>
-        [Obsolete("This method deprecated, please use Start(bool reset) to reset checkpoint when starting the replicator.")]
-        public void ResetCheckpoint()
-        {
-            if (Status.Activity != ReplicatorActivityLevel.Stopped) {
-                throw new InvalidOperationException(
-                    "Replicator is not stopped.  Resetting checkpoint is only allowed when the replicator is in the stopped state.");
-            }
-
-            Config.Options.Reset = true;
-        }
-
-        /// <summary>
         /// Starts the replication
         /// </summary>
         public void Start()

--- a/src/Couchbase.Lite.Tests.Shared/BlobTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/BlobTest.cs
@@ -237,7 +237,7 @@ namespace Test
         {
             var blob = ArrayTestBlob();
             Db.SaveBlob(blob);
-            Db.Compact();
+            Db.PerformMaintenance(MaintenanceType.Compact);
 
             var blobDict = new Dictionary<string, object>() {
                 { Blob.ContentTypeKey, blob.ContentType },

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseEncryptionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseEncryptionTest.cs
@@ -125,8 +125,8 @@ namespace Test
                     seekrit.Save(doc);
                     doc.SetInt("answer", 84);
 
-                    seekrit.Compact();
-                    
+                    seekrit.PerformMaintenance(MaintenanceType.Compact);
+
                     doc.SetInt("answer", 85);
                     seekrit.Save(doc);
                 }

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1055,8 +1055,8 @@ namespace Test
             var atts = attsDir.EnumerateFiles();
             atts.Should().HaveCount(20, "because there should be one blob per document");
 
-            Db.Compact();
-            
+            Db.PerformMaintenance(MaintenanceType.Compact);
+
             foreach (var doc in docs) {
                 var savedDoc = Db.GetDocument(doc.Id);
                 Db.Delete(savedDoc);
@@ -1064,7 +1064,7 @@ namespace Test
             }
 
             Db.Count.Should().Be(0, "because all documents were deleted");
-            Db.Compact();
+            Db.PerformMaintenance(MaintenanceType.Compact);
 
             atts = attsDir.EnumerateFiles();
             atts.Should().BeEmpty("because the blobs should be collected by the compaction");

--- a/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
@@ -2051,6 +2051,7 @@ namespace Test
             
             Db.GetDocument(docId).Should().NotBeNull("because the expiration has not been set yet");
             Db.SetDocumentExpiration(docId, DateTimeOffset.Now);
+            Thread.Sleep(5);
             Db.GetDocument(docId).Should().BeNull("because the purge should happen immediately");
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -292,37 +292,6 @@ namespace Test
         }
 
         [Fact]
-        void TestSetLogLevel()
-        {
-            WriteLog.To.Database.I("IGNORE", "IGNORE"); // Skip initial message
-            Database.SetLogLevel(LogDomain.All, LogLevel.None);
-            var stringWriter = new StringWriter();
-            Console.SetOut(stringWriter);
-            WriteLog.To.Database.E("TEST", "TEST ERROR");
-            stringWriter.Flush();
-            stringWriter.ToString().Should().BeEmpty("because logging is disabled");
-
-            var currentCount = 1;
-            foreach (var level in new[] { LogLevel.Error, LogLevel.Warning,
-                LogLevel.Info, LogLevel.Verbose}) {
-                Database.SetLogLevel(LogDomain.All, level);
-                stringWriter = new StringWriter();
-                Console.SetOut(stringWriter);
-                WriteLog.To.Database.V("TEST", "TEST VERBOSE");
-                WriteLog.To.Database.I("TEST", "TEST INFO");
-                WriteLog.To.Database.W("TEST", "TEST WARNING");
-                WriteLog.To.Database.E("TEST", "TEST ERROR");
-                stringWriter.Flush();
-                stringWriter.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Should()
-                    .HaveCount(currentCount, "because {0} levels should be logged for {1}", currentCount, level);
-                currentCount++;
-            }
-
-            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
-            Database.SetLogLevel(LogDomain.All, LogLevel.Warning);
-        }
-
-        [Fact]
         public void TestConsoleLoggingDomains()
         {
             WriteLog.To.Database.I("IGNORE", "IGNORE"); // Skip initial message

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -262,6 +262,7 @@ namespace Test
             }
             
             Db.SetDocumentExpiration(docId, DateTimeOffset.Now);
+            Thread.Sleep(5);
 
             using (var doc2 = new MutableDocument("doc2")) {
                 doc2.SetString("expire_me", "never");

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Database_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Database_native.cs
@@ -1,7 +1,7 @@
 //
 // C4Database_native.cs
 //
-// Copyright (c) 2020 Couchbase, Inc All rights reserved.
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,7 +93,8 @@ namespace LiteCore.Interop
         public static extern long c4db_nextDocExpiration(C4Database* database);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern long c4db_purgeExpiredDocs(C4Database* db, C4Error* outError);
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static extern bool c4db_startHousekeeping(C4Database* db);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern uint c4db_getMaxRevTreeDepth(C4Database* database);

--- a/src/LiteCore/test/LiteCore.Tests.Shared/DatabaseTest.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/DatabaseTest.cs
@@ -156,7 +156,6 @@ namespace LiteCore.Tests
                 Native.c4doc_setExpiration(Db, docID, 0, &err).Should().BeTrue();
                 Native.c4doc_getExpiration(Db, docID, null).Should().Be(0);
                 Native.c4db_nextDocExpiration(Db).Should().Be(0);
-                Native.c4db_purgeExpiredDocs(Db, &err).Should().Be(0);
             });
         }
 
@@ -381,7 +380,6 @@ namespace LiteCore.Tests
             {
                 C4Error err;
                 Native.c4db_nextDocExpiration(Db).Should().Be(0L);
-                Native.c4db_purgeExpiredDocs(Db, &err).Should().Be(0L);
 
                 var docID = "expire_me";
                 CreateRev(docID, RevID, FleeceBody);
@@ -424,13 +422,8 @@ namespace LiteCore.Tests
                 Thread.Sleep(TimeSpan.FromSeconds(2));
                 Native.c4_now().Should().BeGreaterOrEqualTo(expire);
 
-                WriteLine("--- Purge expired docs");
-                Native.c4db_purgeExpiredDocs(Db, &err).Should().Be(2, "because there are two expired documents");
 
-                Native.c4db_nextDocExpiration(Db).Should().Be(expire + 100_000);
 
-                WriteLine("--- Purge expired docs (again)");
-                Native.c4db_purgeExpiredDocs(Db, &err).Should().Be(0, "because there are no expired documents");
             });
         }
 


### PR DESCRIPTION
CBL-1843 Remove deprecated ResetCheckpoint()
Replace c4db_purgeExpiredDocs with c4db_startHousekeeping (Note: Set doc expired now actually delayed a little compare with old API call)
Remove SetLogLevel and Compact deprecated methods from Database. Update tests.