### PR TITLE
CBL-1793 Change to QueryBuilder API

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Query/FullTextExpression.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/FullTextExpression.cs
@@ -25,19 +25,21 @@ using JetBrains.Annotations;
 namespace Couchbase.Lite.Query
 {
     /// <summary>
-    /// A class that generates expressions that operate on the results of full-text searching
+    /// [DEPRECATED] A class that generates expressions that operate on the results of full-text searching
     /// </summary>
+    [Obsolete("This class deprecated, please use FullTextFunction.")]
     public static class FullTextExpression
     {
         #region Public Methods
 
         /// <summary>
-        /// Generates a query expression that will check for matches against a
+        /// [DEPRECATED] Generates a query expression that will check for matches against a
         /// given full text index name
         /// </summary>
         /// <param name="name">The name of the full-text index to perform the
         /// check against</param>
         /// <returns>The generated query expression</returns>
+        [Obsolete("This class deprecated, please use Match(string indexName, string query) in FullTextFunction class.")]
         [NotNull]
         public static IFullTextExpression Index(string name) =>
             new QueryCompoundExpression("MATCH()", Expression.String(name), Expression.String(String.Empty));

--- a/src/Couchbase.Lite.Shared/API/Query/FullTextFunction.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/FullTextFunction.cs
@@ -28,6 +28,18 @@ namespace Couchbase.Lite.Query
     public static class FullTextFunction
     {
         /// <summary>
+        /// Create a full-text matching function that will check for matches between given 
+        /// full text index name and the given query expression
+        /// </summary>
+        /// <param name="indexName">The name of the full-text index to perform the
+        /// check against</param>
+        /// <param name="query">The query expression to perform the check against</param>
+        /// <returns>A function that will perform the matching</returns>
+        [NotNull]
+        public static IExpression Match(string indexName, string query) =>
+            new QueryCompoundExpression("MATCH()", Expression.String(indexName), Expression.String(query));
+
+        /// <summary>
         /// Creates a full-text ranking value function indicating how well the current
         /// query result matches the full-text query when performing the match comparison.
         /// </summary>

--- a/src/Couchbase.Lite.Shared/API/Query/IExpression.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/IExpression.cs
@@ -18,6 +18,7 @@
 
 
 using JetBrains.Annotations;
+using System;
 
 namespace Couchbase.Lite.Query
 {
@@ -129,12 +130,27 @@ namespace Couchbase.Lite.Query
         IExpression IsNot([NotNull]IExpression expression);
 
         /// <summary>
-        /// Gets an expression representing if the current expression is null
+        /// [DEPRECATED] Gets an expression representing if the current expression is null
         /// or missing (i.e. does not have a value)
         /// </summary>
         /// <returns>The expression representing the new operation</returns>
+        [Obsolete("This query expression deprecated, please use IsNotValued().")]
         [NotNull]
         IExpression IsNullOrMissing();
+
+        /// <summary>
+        /// Gets an expression representing if the current expression has a value
+        /// </summary>
+        /// <returns>The expression representing the new operation</returns>
+        [NotNull]
+        IExpression IsValued();
+
+        /// <summary>
+        /// Gets an expression representing if the current expression does not have a value
+        /// </summary>
+        /// <returns>The expression representing the new operation</returns>
+        [NotNull]
+        IExpression IsNotValued();
 
         /// <summary>
         /// Returns an expression that will evaluate whether or not the given
@@ -191,10 +207,11 @@ namespace Couchbase.Lite.Query
         IExpression NotEqualTo([NotNull]IExpression expression);
 
         /// <summary>
-        /// Gets an expression representing if the current expression is neither null
+        /// [DEPRECATED] Gets an expression representing if the current expression is neither null
         /// nor missing (i.e. has a value)
         /// </summary>
         /// <returns>The expression representing the new operation</returns>
+        [Obsolete("This query expression deprecated, please use IsValued().")]
         [NotNull]
         IExpression NotNullOrMissing();
 

--- a/src/Couchbase.Lite.Shared/API/Query/IFullTextExpression.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/IFullTextExpression.cs
@@ -21,13 +21,13 @@ using JetBrains.Annotations;
 namespace Couchbase.Lite.Query
 {
     /// <summary>
-    /// An interface that represents an expression that is eligible to receive
+    /// [DEPRECATED] An interface that represents an expression that is eligible to receive
     /// full-text related query clauses
     /// </summary>
     public interface IFullTextExpression
     {
         /// <summary>
-        /// Returns an expression that will evaluate whether or not the given
+        /// [DEPRECATED] Returns an expression that will evaluate whether or not the given
         /// expression full text matches the current one
         /// </summary>
         /// <param name="query">The text to use for the match operation</param>

--- a/src/Couchbase.Lite.Shared/Query/QueryExpression.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryExpression.cs
@@ -207,10 +207,11 @@ namespace Couchbase.Lite.Internal.Query
 
         public IExpression IsNot([NotNull]IExpression expression) => 
             GetOperator(BinaryOpType.IsNot, CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(expression), expression));
-
+        [Obsolete("This query expression deprecated, please use IsNotValued().")]
         public IExpression IsNullOrMissing() => new QueryUnaryExpression(this, UnaryOpType.Null)
             .Or(new QueryUnaryExpression(this, UnaryOpType.Missing));
-
+        public IExpression IsNotValued() => Expression.Not(IsValued());
+        public IExpression IsValued() => new QueryUnaryExpression(this, UnaryOpType.Valued);
         public IExpression LessThan([NotNull]IExpression expression) => 
             GetOperator(BinaryOpType.LessThan, CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(expression), expression));
 
@@ -224,6 +225,7 @@ namespace Couchbase.Lite.Internal.Query
             GetOperator(BinaryOpType.Multiply, CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(expression), expression));
         public IExpression NotEqualTo([NotNull]IExpression expression) => 
             GetOperator(BinaryOpType.NotEqualTo, CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(expression), expression));
+        [Obsolete("This query expression deprecated, please use IsValued().")]
         public IExpression NotNullOrMissing() => Expression.Not(IsNullOrMissing());
         public IExpression Or([NotNull]IExpression expression) => 
             new QueryCompoundExpression("OR", this, CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(expression), expression));

--- a/src/Couchbase.Lite.Shared/Query/QueryUnaryExpression.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryUnaryExpression.cs
@@ -28,7 +28,9 @@ namespace Couchbase.Lite.Internal.Query
         Missing,
         NotMissing,
         NotNull,
-        Null
+        Null,
+        Valued,
+        NotValued
     }
 
     internal sealed class QueryUnaryExpression : QueryExpression
@@ -66,6 +68,12 @@ namespace Couchbase.Lite.Internal.Query
                 case UnaryOpType.NotNull:
                     obj.Add("IS NOT");
                     obj.Add(_type == UnaryOpType.NotNull ? null : MissingValue );
+                    break;
+                case UnaryOpType.Valued:
+                    obj.Add("IS VALUED");
+                    break;
+                case UnaryOpType.NotValued:
+                    obj.Add("IS NOT VALUED");
                     break;
             }
 

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseEncryptionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseEncryptionTest.cs
@@ -217,7 +217,8 @@ namespace Test
 
                 using (var q = QueryBuilder.Select(SelectResult.Property("seq"))
                     .From(DataSource.Database(seekrit))
-                    .Where(Expression.Property("seq").NotNullOrMissing())
+                    //.Where(Expression.Property("seq").NotNullOrMissing()) //deprecated
+                    .Where(Expression.Property("seq").IsValued())
                     .OrderBy(Ordering.Property("seq"))) {
                     var rs = q.Execute();
                     var i = 0;

--- a/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
@@ -502,7 +502,8 @@ namespace Test
             using (var q = QueryBuilder.Select(SelectResult.Expression(prediction),
                     SelectResult.Expression(prediction.Property("sum")))
                 .From(DataSource.Database(Db))
-                .Where(prediction.NotNullOrMissing())) {
+                //.Where(prediction.NotNullOrMissing())) { //deprecated
+                .Where(prediction.IsValued())) {
                 var explain = q.Explain();
                 var rows = VerifyQuery(q, (n, result) =>
                 {

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -405,42 +405,6 @@ namespace Test
         [Fact]
         public void TestReplicatorOneMaxAttempts() => ReplicatorMaxAttempts(1);
 
-        //[Fact]
-        public void TestReplicatorMaxAttemptsNoneContinuous()
-        {
-            // If this IP address happens to exist, then change it.  It needs to be an address that does not
-            // exist on the LAN
-            var targetEndpoint = new URLEndpoint(new Uri("ws://192.168.0.11:4984/app"));
-            var config = new ReplicatorConfiguration(Db, targetEndpoint)
-            {
-                MaxAttemptsWaitTime = TimeSpan.FromSeconds(1)
-            };
-
-            var count = 0;
-            var repl = new Replicator(config);
-            var waitAssert = new WaitAssert();
-            var token = repl.AddChangeListener((sender, args) =>
-            {
-                waitAssert.RunConditionalAssert(() =>
-                {
-                    if (args.Status.Activity == ReplicatorActivityLevel.Offline) {
-                        count++;
-                    }
-
-                    return args.Status.Activity == ReplicatorActivityLevel.Stopped;
-                });
-            });
-
-            repl.Start();
-
-            // Wait for the replicator to be stopped
-            waitAssert.WaitForResult(TimeSpan.FromSeconds(60));
-            repl.RemoveChangeListener(token);
-
-            count.Should().Be(10 - 1);
-            repl.Dispose();
-        }
-
         [Fact]
         public void TestReadOnlyConfiguration()
         {

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -405,7 +405,7 @@ namespace Test
         [Fact]
         public void TestReplicatorOneMaxAttempts() => ReplicatorMaxAttempts(1);
 
-        [Fact]
+        //[Fact]
         public void TestReplicatorMaxAttemptsNoneContinuous()
         {
             // If this IP address happens to exist, then change it.  It needs to be an address that does not

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -406,6 +406,42 @@ namespace Test
         public void TestReplicatorOneMaxAttempts() => ReplicatorMaxAttempts(1);
 
         [Fact]
+        public void TestReplicatorMaxAttemptsNoneContinuous()
+        {
+            // If this IP address happens to exist, then change it.  It needs to be an address that does not
+            // exist on the LAN
+            var targetEndpoint = new URLEndpoint(new Uri("ws://192.168.0.11:4984/app"));
+            var config = new ReplicatorConfiguration(Db, targetEndpoint)
+            {
+                MaxAttemptsWaitTime = TimeSpan.FromSeconds(1)
+            };
+
+            var count = 0;
+            var repl = new Replicator(config);
+            var waitAssert = new WaitAssert();
+            var token = repl.AddChangeListener((sender, args) =>
+            {
+                waitAssert.RunConditionalAssert(() =>
+                {
+                    if (args.Status.Activity == ReplicatorActivityLevel.Offline) {
+                        count++;
+                    }
+
+                    return args.Status.Activity == ReplicatorActivityLevel.Stopped;
+                });
+            });
+
+            repl.Start();
+
+            // Wait for the replicator to be stopped
+            waitAssert.WaitForResult(TimeSpan.FromSeconds(60));
+            repl.RemoveChangeListener(token);
+
+            count.Should().Be(10 - 1);
+            repl.Dispose();
+        }
+
+        [Fact]
         public void TestReadOnlyConfiguration()
         {
             var config = CreateConfig(true, false, false);


### PR DESCRIPTION
1. FTS Match Functions
- Deprecate FullTextExpression class and it's Index Match full text expression,  IFullTextExpression.
- Add Index name Match query expression function in FullTextFunction class.
- Update tests
2. isValued and isNotValued operator
- Deprecate IsNullOrMissing and NotNullOrMissing from QueryExpression and IExpression.
- Add IsValued and IsNotValued in QueryExpression and IExpression.
- Update tests