### PR TITLE
CBL-1790 Create Query Index with N1QL string array

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Query/IIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/IIndexConfiguration.cs
@@ -1,0 +1,57 @@
+﻿// 
+// IIndexConfiguration.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using JetBrains.Annotations;
+
+namespace Couchbase.Lite.Query
+{
+    public interface IIndexConfiguration
+    {
+    }
+
+    /// <summary>
+    /// An interface for an index based on a simple property value
+    /// </summary>
+    public interface IValueIndexConfiguration : IIndexConfiguration
+    {
+
+    }
+
+    /// <summary>
+    /// An interface for an index based on full text searching
+    /// </summary>
+    public interface IFullTextIndexConfiguration : IIndexConfiguration
+    {
+        /// <summary>
+        /// Sets whether or not to ignore accents when performing 
+        /// the full text search
+        /// </summary>
+        /// <param name="ignoreAccents">Whether or not to ignore accents</param>
+        /// <returns>The index for further processing</returns>
+        [NotNull]
+        IFullTextIndexConfiguration IgnoreAccents(bool ignoreAccents);
+
+        /// <summary>
+        /// Sets the locale to use when performing full text searching
+        /// </summary>
+        /// <param name="language">The language code in the form of ISO-639 language code</param>
+        /// <returns>The index for further processing</returns>
+        [NotNull]
+        IFullTextIndexConfiguration SetLanguage(string language);
+    }
+}

--- a/src/Couchbase.Lite.Shared/API/Query/IndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/IndexConfiguration.cs
@@ -1,0 +1,52 @@
+﻿// 
+// IndexConfiguration.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using Couchbase.Lite.Internal.Logging;
+using Couchbase.Lite.Internal.Query;
+using Couchbase.Lite.Util;
+using JetBrains.Annotations;
+
+namespace Couchbase.Lite.Query
+{
+    public static class IndexConfiguration
+    {
+        #region Constants
+
+        private const string Tag = nameof(IndexConfiguration);
+
+        #endregion
+
+        /// <summary>
+        /// Starts the creation of an index based on a simple property
+        /// </summary>
+        /// <param name="items">The items to use to create the index</param>
+        /// <returns>The beginning of a value based index</returns>
+        [NotNull]
+        public static IValueIndexConfiguration ValueIndex([ItemNotNull] params string[] items) =>
+            new ValueIndexConfiguration((string[])CBDebug.ItemsMustNotBeNull(WriteLog.To.Query, Tag, nameof(items), items));
+
+        /// <summary>
+        /// Starts the creation of an index based on a full text search
+        /// </summary>
+        /// <param name="items">The items to use to create the index</param>
+        /// <returns>The beginning of an FTS based index</returns>
+        [NotNull]
+        public static IFullTextIndexConfiguration FullTextIndex([ItemNotNull] params string[] items) =>
+            new FullTextIndexConfiguration((string[])CBDebug.ItemsMustNotBeNull(WriteLog.To.Query, Tag, nameof(items), items));
+    }
+}

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -65,6 +65,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IHaving.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IHavingRouter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IIndex.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)API\Query\IIndexConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IIndexItem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IJoin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IJoinRouter.cs" />
@@ -72,6 +73,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\ILimitRouter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IMetaExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IndexBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)API\Query\IndexConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IndexItem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IOrderBy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IOrderByRouter.cs" />
@@ -111,6 +113,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\IJSON.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Document\InMemoryDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Document\MRoot.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\IndexConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\IndexDescriptor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\FleeceMutableArray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linq\IDocumentModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linq\ISelectResultContainer.cs" />

--- a/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
@@ -1,0 +1,87 @@
+﻿// 
+// IndexConfiguration.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using Couchbase.Lite.Query;
+using JetBrains.Annotations;
+using LiteCore.Interop;
+using System;
+
+namespace Couchbase.Lite.Internal.Query
+{
+    internal class IndexConfigurationBase : IndexDescriptor, IValueIndexConfiguration, IFullTextIndexConfiguration
+    {
+        [CanBeNull]
+        private string[] _expression;
+
+        protected IndexConfigurationBase(C4IndexType indexType, params string[] items)
+            :base(indexType, C4QueryLanguage.N1QLQuery)
+        {
+            _expression = items;
+        }
+
+        #region Internal Methods
+
+        internal string ToN1QL()
+        {
+            if (_expression.Length == 1)
+                return _expression[0];
+
+            return String.Join(",", _expression);
+        }
+
+        #endregion
+
+        #region IFullTextIndexConfiguration
+
+        public new IFullTextIndexConfiguration IgnoreAccents(bool ignoreAccents)
+        {
+            base.IgnoreAccents(ignoreAccents);
+            return this;
+        }
+
+        public new IFullTextIndexConfiguration SetLanguage(string language)
+        {
+            base.SetLanguage(language);
+            return this;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// An class for an index based on a simple property value
+    /// </summary>
+    internal class ValueIndexConfiguration : IndexConfigurationBase
+    {
+        public ValueIndexConfiguration(params string[] expressions)
+            : base(C4IndexType.ValueIndex, expressions)
+        {
+        }
+    }
+
+    /// <summary>
+    /// An class for an index based on full text searching
+    /// </summary>
+    internal class FullTextIndexConfiguration : IndexConfigurationBase
+    {
+        public FullTextIndexConfiguration(params string[] expressions)
+            : base(C4IndexType.FullTextIndex, expressions)
+        {
+        }
+    }
+}

--- a/src/Couchbase.Lite.Shared/Query/IndexDescriptor.cs
+++ b/src/Couchbase.Lite.Shared/Query/IndexDescriptor.cs
@@ -1,0 +1,83 @@
+﻿// 
+// IndexDescriptor.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using LiteCore.Interop;
+using System.Globalization;
+
+namespace Couchbase.Lite.Internal.Query
+{
+    internal class IndexDescriptor
+    {
+        #region Variables
+
+        private bool _ignoreAccents;
+        private string _locale = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+
+        #endregion
+
+        #region Properties
+
+        protected C4QueryLanguage QueryLanguage { get; }
+
+        internal C4IndexType IndexType { get; }
+
+        internal C4IndexOptions Options
+        {
+            get
+            {
+                if (IndexType == C4IndexType.FullTextIndex) {
+                    return new C4IndexOptions
+                    {
+                        ignoreDiacritics = _ignoreAccents,
+                        language = _locale
+                    };
+                }
+
+                return new C4IndexOptions();
+            }
+        }
+
+        #endregion
+
+        #region Constructor
+
+        protected IndexDescriptor(C4IndexType indexType, C4QueryLanguage queryLanguage)
+        {
+            IndexType = indexType;
+            QueryLanguage = queryLanguage;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public IndexDescriptor IgnoreAccents(bool ignoreAccents)
+        {
+            _ignoreAccents = ignoreAccents;
+            return this;
+        }
+
+        public IndexDescriptor SetLanguage(string language)
+        {
+            _locale = language;
+            return this;
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.Lite.Shared/Query/QueryIndex.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryIndex.cs
@@ -33,9 +33,9 @@ namespace Couchbase.Lite.Internal.Query
         private readonly IFullTextIndexItem[] _ftsItems;
         private readonly IValueIndexItem[] _valueItems;
 
-#if COUCHBASE_ENTERPRISE
+        #if COUCHBASE_ENTERPRISE
         private readonly string[] _predictiveItems;
-#endif
+        #endif
 
         #endregion
 
@@ -44,13 +44,10 @@ namespace Couchbase.Lite.Internal.Query
         internal virtual object ToJSON()
         {
             object jsonObj = null;
-            if (_ftsItems != null)
-            {
+            if (_ftsItems != null) {
                 jsonObj = QueryExpression.EncodeToJSON(_ftsItems.OfType<QueryIndexItem>().Select(x => x.Expression)
                     .ToList());
-            }
-            else if (_valueItems != null)
-            {
+            } else if (_valueItems != null) {
                 jsonObj = QueryExpression.EncodeToJSON(_valueItems.OfType<QueryIndexItem>().Select(x => x.Expression)
                     .ToList());
             }
@@ -99,11 +96,11 @@ namespace Couchbase.Lite.Internal.Query
         #endregion
     }
 
-#if !COUCHBASE_ENTERPRISE
+    #if !COUCHBASE_ENTERPRISE
 
     internal sealed class QueryIndex : QueryIndexBase
     {
-    #region Constructors
+        #region Constructors
 
         internal QueryIndex([ItemNotNull]params IFullTextIndexItem[] items)
             : base(items)
@@ -117,8 +114,8 @@ namespace Couchbase.Lite.Internal.Query
             Debug.Assert(items.All(x => x != null));
         }
 
-    #endregion
+        #endregion
     }
 
-#endif
+    #endif
 }

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1284,6 +1284,25 @@ namespace Test
         }
 
         [Fact]
+        public void TestCreateN1QLQueryIndex()
+        {
+            Db.GetIndexes().Should().BeEmpty();
+
+            var index1 = IndexConfiguration.ValueIndex("firstName", "lastName");
+            Db.CreateIndex("index1", index1);
+
+            var index2 = IndexConfiguration.FullTextIndex("detail");
+            Db.CreateIndex("index2", index2);
+
+            // '-' in "es-detail" caused Couchbase.Lite.CouchbaseLiteException : CouchbaseLiteException (LiteCoreDomain / 23): Invalid N1QL in index expression.
+            //var index3 = IndexConfiguration.FullTextIndex("es-detail").IgnoreAccents(true).SetLanguage("es");
+            var index3 = IndexConfiguration.FullTextIndex("es_detail").IgnoreAccents(true).SetLanguage("es");
+            Db.CreateIndex("index3", index3);
+
+            Db.GetIndexes().Should().BeEquivalentTo(new[] { "index1", "index2", "index3" });
+        }
+
+        [Fact]
         public void TestCreateIndex()
         {
             Db.GetIndexes().Should().BeEmpty();

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Index_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Index_native.cs
@@ -1,7 +1,7 @@
 //
 // C4Index_native.cs
 //
-// Copyright (c) 2020 Couchbase, Inc All rights reserved.
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,11 +27,19 @@ namespace LiteCore.Interop
 
     internal unsafe static partial class Native
     {
-        public static bool c4db_createIndex(C4Database* database, string name, string indexSpecJSON, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError)
+        public static bool c4db_createIndex2(C4Database* database, string name, string indexSpec, C4QueryLanguage queryLanguage, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError)
         {
             using(var name_ = new C4String(name))
-            using(var indexSpecJSON_ = new C4String(indexSpecJSON)) {
-                return NativeRaw.c4db_createIndex(database, name_.AsFLSlice(), indexSpecJSON_.AsFLSlice(), indexType, indexOptions, outError);
+            using(var indexSpec_ = new C4String(indexSpec)) {
+                return NativeRaw.c4db_createIndex2(database, name_.AsFLSlice(), indexSpec_.AsFLSlice(), queryLanguage, indexType, indexOptions, outError);
+            }
+        }
+
+        public static byte[] c4db_getIndexes(C4Database* database, C4Error* outError)
+        {
+            using (var retVal = NativeRaw.c4db_getIndexes(database, outError))
+            {
+                return ((FLSlice)retVal).ToArrayFast();
             }
         }
 
@@ -42,28 +50,20 @@ namespace LiteCore.Interop
             }
         }
 
-        public static byte[] c4db_getIndexes(C4Database* database, C4Error* outError)
-        {
-            using(var retVal = NativeRaw.c4db_getIndexes(database, outError)) {
-                return ((FLSlice)retVal).ToArrayFast();
-            }
-        }
-
-
     }
 
     internal unsafe static partial class NativeRaw
     {
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool c4db_createIndex(C4Database* database, FLSlice name, FLSlice indexSpecJSON, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError);
+        public static extern bool c4db_createIndex2(C4Database* database, FLSlice name, FLSlice indexSpec, C4QueryLanguage queryLanguage, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError);
+
+        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern FLSliceResult c4db_getIndexes(C4Database* database, C4Error* outError);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool c4db_deleteIndex(C4Database* database, FLSlice name, C4Error* outError);
-
-        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern FLSliceResult c4db_getIndexes(C4Database* database, C4Error* outError);
 
 
     }

--- a/src/LiteCore/test/LiteCore.Tests.Shared/QueryTest.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/QueryTest.cs
@@ -149,7 +149,7 @@ namespace LiteCore.Tests
         public void TestDBQueryExpressionIndex()
         {
             RunTestVariants(() => {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "test", Json5("[['length()', ['.name.first']]]"), 
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "test", Json5("[['length()', ['.name.first']]]"), C4QueryLanguage.JSONQuery,
                     C4IndexType.ValueIndex, null, err));
                 Compile(Json5("['=', ['length()', ['.name.first']], 9]"));
                 Run().Should().Equal(new[] { "0000015", "0000099" }, "because otherwise the query returned incorrect results");
@@ -160,7 +160,7 @@ namespace LiteCore.Tests
         public void TestDeleteIndexedDoc()
         {
             RunTestVariants(() => {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "test", Json5("[['length()', ['.name.first']]]"), 
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "test", Json5("[['length()', ['.name.first']]]"), C4QueryLanguage.JSONQuery, 
                     C4IndexType.ValueIndex, null, err));
                 
                 // Delete doc "0000015":
@@ -196,7 +196,7 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5("['MATCH()', 'byStreet', 'Hwy']"));
 
@@ -223,7 +223,7 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byAddress", "[[\".contact.address.street\"],[\".contact.address.city\"],[\".contact.address.state\"]]", 
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byAddress", "[[\".contact.address.street\"],[\".contact.address.city\"],[\".contact.address.state\"]]", C4QueryLanguage.JSONQuery, 
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5("['MATCH()', 'byAddress', 'Santa']"));
                 var expected = new[]
@@ -293,9 +293,9 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byCity", "[[\".contact.address.city\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byCity", "[[\".contact.address.city\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5("['AND', ['MATCH()', 'byStreet', 'Hwy'],['MATCH()', 'byCity', 'Santa']]"));
                 var results = RunFTS();
@@ -309,9 +309,9 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byCity", "[[\".contact.address.city\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byCity", "[[\".contact.address.city\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5(
                     "['AND', ['AND', ['=', ['.gender'], 'male'],['MATCH()', 'byCity', 'Santa']],['=',['.name.first'], 'Cleveland']]"));
@@ -328,7 +328,7 @@ namespace LiteCore.Tests
             // You can't query the same FTS index multiple times in a query (says SQLite)
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 C4Error error;
                 _query = Native.c4query_new(Db,
@@ -347,7 +347,7 @@ namespace LiteCore.Tests
             // You can't put an FTS match inside an expression other than a top-level AND (says SQLite)
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 C4Error error;
                 _query = Native.c4query_new(Db,


### PR DESCRIPTION
- Use new c4db_createIndex2 instead of c4db_createIndex
- Add CreateIndex method takes IndexConfiguration as parameter in Database class
- Add IndexConfiguration class with value index and full-text index creation