### PR TITLE
CBL-1790 Create Query Index with N1QL string array

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -630,7 +630,7 @@ namespace Couchbase.Lite
                     // For some reason a "using" statement here causes a compiler error
                     try
                     {
-                        return Native.c4db_createIndex2(c4db, name, indexConfig.ToN1QL(), C4QueryLanguage.N1QLQuery, indexConfig.IndexType, &internalOpts, err);
+                        return Native.c4db_createIndex2(c4db, name, indexConfig.ToN1QL(), indexConfig.QueryLanguage, indexConfig.IndexType, &internalOpts, err);
                     }
                     finally
                     {

--- a/src/Couchbase.Lite.Shared/API/Query/FullTextIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/FullTextIndexConfiguration.cs
@@ -1,0 +1,87 @@
+﻿// 
+// FullTextIndexConfiguration.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using Couchbase.Lite.Internal.Query;
+using LiteCore.Interop;
+using System.Globalization;
+
+namespace Couchbase.Lite.Query
+{
+    /// <summary>
+    /// An class for an index based on full text searching
+    /// </summary>
+    public sealed class FullTextIndexConfiguration : IndexConfiguration
+    {
+        #region Variables
+
+        private bool _ignoreAccents;
+        private string _locale = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets whether or not to ignore accents when performing 
+        /// the full text search
+        /// </summary>
+        public bool IgnoreAccents => _ignoreAccents;
+
+        /// <summary>
+        /// Gets the locale to use when performing full text searching
+        /// </summary>
+        public string Language => _locale;
+
+        internal override C4IndexOptions Options => new C4IndexOptions {
+            ignoreDiacritics = _ignoreAccents,
+            language = _locale
+        };
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Starts the creation of an index based on a full text search
+        /// </summary>
+        /// <param name="expressions">The expressions to use to create the index</param>
+        /// <param name="ignoreAccents">The boolean value to ignore accents when performing the full text search</param>
+        /// <param name="locale">The locale to use when performing full text searching</param>
+        /// <returns>The beginning of an FTS based index</returns>
+        public FullTextIndexConfiguration(string[] expressions, bool ignoreAccents = false, 
+            string locale = null)
+            : base(C4IndexType.FullTextIndex, expressions)
+        {
+            _ignoreAccents = ignoreAccents;
+            if (!string.IsNullOrEmpty(locale)) {
+                _locale = locale;
+            }
+        }
+
+        /// <summary>
+        /// Starts the creation of an index based on a full text search
+        /// </summary>
+        /// <param name="expressions">The expressions to use to create the index</param>
+        /// <returns>The beginning of an FTS based index</returns>
+        public FullTextIndexConfiguration(params string[] expressions)
+            : base(C4IndexType.FullTextIndex, expressions)
+        {
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.Lite.Shared/API/Query/FullTextIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/FullTextIndexConfiguration.cs
@@ -27,29 +27,22 @@ namespace Couchbase.Lite.Query
     /// </summary>
     public sealed class FullTextIndexConfiguration : IndexConfiguration
     {
-        #region Variables
-
-        private bool _ignoreAccents;
-        private string _locale = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
-
-        #endregion
-
         #region Properties
 
         /// <summary>
         /// Gets whether or not to ignore accents when performing 
         /// the full text search
         /// </summary>
-        public bool IgnoreAccents => _ignoreAccents;
+        public bool IgnoreAccents { get; }
 
         /// <summary>
         /// Gets the locale to use when performing full text searching
         /// </summary>
-        public string Language => _locale;
+        public string Language { get; } = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
 
         internal override C4IndexOptions Options => new C4IndexOptions {
-            ignoreDiacritics = _ignoreAccents,
-            language = _locale
+            ignoreDiacritics = IgnoreAccents,
+            language = Language
         };
         #endregion
 
@@ -66,9 +59,9 @@ namespace Couchbase.Lite.Query
             string locale = null)
             : base(C4IndexType.FullTextIndex, expressions)
         {
-            _ignoreAccents = ignoreAccents;
+            IgnoreAccents = ignoreAccents;
             if (!string.IsNullOrEmpty(locale)) {
-                _locale = locale;
+                Language = locale;
             }
         }
 

--- a/src/Couchbase.Lite.Shared/API/Query/ValueIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/ValueIndexConfiguration.cs
@@ -1,0 +1,46 @@
+﻿// 
+// ValueIndexConfiguration.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using Couchbase.Lite.Internal.Query;
+using LiteCore.Interop;
+
+namespace Couchbase.Lite.Query
+{
+    /// <summary>
+    /// An class for an index based on a simple property value
+    /// </summary>
+    public sealed class ValueIndexConfiguration : IndexConfiguration
+    {
+        #region Properties
+        internal override C4IndexOptions Options => new C4IndexOptions();
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Starts the creation of an index based on a simple property
+        /// </summary>
+        /// <param name="expressions">The expressions to use to create the index</param>
+        /// <returns>The beginning of a value based index</returns>
+        public ValueIndexConfiguration(params string[] expressions)
+            : base(C4IndexType.FullTextIndex, expressions)
+        {
+        }
+        #endregion
+    }
+}

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -52,6 +52,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\Expression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\FullTextExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\FullTextFunction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)API\Query\FullTextIndexConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\Function.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\IArrayExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\ICollation.cs" />
@@ -90,6 +91,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\QueryBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\Result.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Query\SelectResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)API\Query\ValueIndexConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\RuntimeException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Sync\Authenticator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Sync\BasicAuthenticator.cs" />
@@ -111,6 +113,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\IJSON.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Document\InMemoryDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Document\MRoot.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\IndexConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\FleeceMutableArray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linq\IDocumentModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linq\ISelectResultContainer.cs" />

--- a/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
@@ -25,7 +25,10 @@ namespace Couchbase.Lite.Internal.Query
     {
         #region Properties
 
-        protected string[] Expression { get; }
+        /// <summary>
+        /// Gets the expressions to use to create the index
+        /// </summary>
+        public string[] Expression { get; }
 
         internal C4QueryLanguage QueryLanguage { get; }
 

--- a/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
@@ -28,7 +28,7 @@ namespace Couchbase.Lite.Internal.Query
         /// <summary>
         /// Gets the expressions to use to create the index
         /// </summary>
-        public string[] Expression { get; }
+        public string[] Expressions { get; }
 
         internal C4QueryLanguage QueryLanguage { get; }
 
@@ -43,7 +43,7 @@ namespace Couchbase.Lite.Internal.Query
         internal IndexConfiguration(C4IndexType indexType, params string[] items)
             : this(indexType, C4QueryLanguage.N1QLQuery)
         {
-            Expression = items;
+            Expressions = items;
         }
 
         internal IndexConfiguration(C4IndexType indexType, C4QueryLanguage queryLanguage)
@@ -58,10 +58,10 @@ namespace Couchbase.Lite.Internal.Query
 
         internal string ToN1QL()
         {
-            if (Expression.Length == 1)
-                return Expression[0];
+            if (Expressions.Length == 1)
+                return Expressions[0];
 
-            return String.Join(",", Expression);
+            return String.Join(",", Expressions);
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
@@ -1,0 +1,66 @@
+﻿// 
+// IndexConfiguration.cs
+// 
+// Copyright (c) 2021 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using LiteCore.Interop;
+using System;
+
+namespace Couchbase.Lite.Internal.Query
+{
+    public abstract class IndexConfiguration
+    {
+        #region Properties
+
+        protected string[] Expression { get; }
+
+        internal C4QueryLanguage QueryLanguage { get; }
+
+        internal C4IndexType IndexType { get; }
+
+        internal abstract C4IndexOptions Options { get; }
+
+        #endregion
+
+        #region Constructor
+
+        internal IndexConfiguration(C4IndexType indexType, params string[] items)
+            : this(indexType, C4QueryLanguage.N1QLQuery)
+        {
+            Expression = items;
+        }
+
+        internal IndexConfiguration(C4IndexType indexType, C4QueryLanguage queryLanguage)
+        {
+            IndexType = indexType;
+            QueryLanguage = queryLanguage;
+        }
+
+        #endregion
+
+        #region Internal Methods
+
+        internal string ToN1QL()
+        {
+            if (Expression.Length == 1)
+                return Expression[0];
+
+            return String.Join(",", Expression);
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1284,6 +1284,27 @@ namespace Test
         }
 
         [Fact]
+        public void TestCreateN1QLQueryIndex()
+        {
+            Db.GetIndexes().Should().BeEmpty();
+
+            var index1 = new ValueIndexConfiguration(new string[] { "firstName", "lastName" });
+            Db.CreateIndex("index1", index1);
+
+            var index2 = new FullTextIndexConfiguration("detail");
+            Db.CreateIndex("index2", index2);
+
+            // '-' in "es-detail" caused Couchbase.Lite.CouchbaseLiteException : CouchbaseLiteException (LiteCoreDomain / 23): Invalid N1QL in index expression.
+            // Basically '-' is the minus sign in N1QL expression. So needs to escape the expression string.
+            // But I just couldn't get it to work...
+            // var index3 = new FullTextIndexConfiguration(new string[]{ "es"+@"\-"+"detail" }, true, "es");
+            var index3 = new FullTextIndexConfiguration(new string[] { "es_detail" }, true, "es");
+            Db.CreateIndex("index3", index3);
+
+            Db.GetIndexes().Should().BeEquivalentTo(new[] { "index1", "index2", "index3" });
+        }
+
+        [Fact]
         public void TestCreateIndex()
         {
             Db.GetIndexes().Should().BeEmpty();

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Index_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Index_native.cs
@@ -27,11 +27,11 @@ namespace LiteCore.Interop
 
     internal unsafe static partial class Native
     {
-        public static bool c4db_createIndex(C4Database* database, string name, string indexSpecJSON, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError)
+        public static bool c4db_createIndex2(C4Database* database, string name, string indexSpec, C4QueryLanguage queryLanguage, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError)
         {
             using(var name_ = new C4String(name))
-            using(var indexSpecJSON_ = new C4String(indexSpecJSON)) {
-                return NativeRaw.c4db_createIndex(database, name_.AsFLSlice(), indexSpecJSON_.AsFLSlice(), indexType, indexOptions, outError);
+            using(var indexSpec_ = new C4String(indexSpec)) {
+                return NativeRaw.c4db_createIndex2(database, name_.AsFLSlice(), indexSpec_.AsFLSlice(), queryLanguage, indexType, indexOptions, outError);
             }
         }
 
@@ -56,7 +56,7 @@ namespace LiteCore.Interop
     {
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool c4db_createIndex(C4Database* database, FLSlice name, FLSlice indexSpecJSON, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError);
+        public static extern bool c4db_createIndex2(C4Database* database, FLSlice name, FLSlice indexSpec, C4QueryLanguage queryLanguage, C4IndexType indexType, C4IndexOptions* indexOptions, C4Error* outError);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]

--- a/src/LiteCore/test/LiteCore.Tests.Shared/QueryTest.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/QueryTest.cs
@@ -149,7 +149,7 @@ namespace LiteCore.Tests
         public void TestDBQueryExpressionIndex()
         {
             RunTestVariants(() => {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "test", Json5("[['length()', ['.name.first']]]"), 
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "test", Json5("[['length()', ['.name.first']]]"), C4QueryLanguage.JSONQuery, 
                     C4IndexType.ValueIndex, null, err));
                 Compile(Json5("['=', ['length()', ['.name.first']], 9]"));
                 Run().Should().Equal(new[] { "0000015", "0000099" }, "because otherwise the query returned incorrect results");
@@ -160,7 +160,7 @@ namespace LiteCore.Tests
         public void TestDeleteIndexedDoc()
         {
             RunTestVariants(() => {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "test", Json5("[['length()', ['.name.first']]]"), 
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "test", Json5("[['length()', ['.name.first']]]"), C4QueryLanguage.JSONQuery, 
                     C4IndexType.ValueIndex, null, err));
                 
                 // Delete doc "0000015":
@@ -196,7 +196,7 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5("['MATCH()', 'byStreet', 'Hwy']"));
 
@@ -223,7 +223,7 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byAddress", "[[\".contact.address.street\"],[\".contact.address.city\"],[\".contact.address.state\"]]", 
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byAddress", "[[\".contact.address.street\"],[\".contact.address.city\"],[\".contact.address.state\"]]", C4QueryLanguage.JSONQuery, 
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5("['MATCH()', 'byAddress', 'Santa']"));
                 var expected = new[]
@@ -293,9 +293,9 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byCity", "[[\".contact.address.city\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byCity", "[[\".contact.address.city\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5("['AND', ['MATCH()', 'byStreet', 'Hwy'],['MATCH()', 'byCity', 'Santa']]"));
                 var results = RunFTS();
@@ -309,9 +309,9 @@ namespace LiteCore.Tests
         {
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byCity", "[[\".contact.address.city\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byCity", "[[\".contact.address.city\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 Compile(Json5(
                     "['AND', ['AND', ['=', ['.gender'], 'male'],['MATCH()', 'byCity', 'Santa']],['=',['.name.first'], 'Cleveland']]"));
@@ -328,7 +328,7 @@ namespace LiteCore.Tests
             // You can't query the same FTS index multiple times in a query (says SQLite)
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 C4Error error;
                 _query = Native.c4query_new(Db,
@@ -347,7 +347,7 @@ namespace LiteCore.Tests
             // You can't put an FTS match inside an expression other than a top-level AND (says SQLite)
             RunTestVariants(() =>
             {
-                LiteCoreBridge.Check(err => Native.c4db_createIndex(Db, "byStreet", "[[\".contact.address.street\"]]",
+                LiteCoreBridge.Check(err => Native.c4db_createIndex2(Db, "byStreet", "[[\".contact.address.street\"]]", C4QueryLanguage.JSONQuery,
                     C4IndexType.FullTextIndex, null, err));
                 C4Error error;
                 _query = Native.c4query_new(Db,


### PR DESCRIPTION
- Use new c4db_createIndex2 instead of c4db_createIndex
- Add CreateIndex method takes IndexConfiguration as parameter in Database class
- Add ValueIndexConfiguration class and FullTextIndexConfiguration
- Update LiteCore to Commit: 63d918b967dbf9170c970381a3eacd9f4eef2a33 [63d918b] (Add the capability of createIndex to take index expression in N1QL)