### PR TITLE
CBL-2102 Fix memory leak during MutableArrayObject.AddBlob while the Blob Content is large in size

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
@@ -33,7 +33,7 @@ namespace Couchbase.Lite
     /// <summary>
     /// A class representing a readonly ordered collection of objects
     /// </summary>
-    public class ArrayObject : IArray, IJSON, IDisposable
+    public class ArrayObject : IArray, IJSON
     {
         #region Variables
 
@@ -229,15 +229,6 @@ namespace Couchbase.Lite
             }
 
             return _array.ToJSON();
-        }
-
-        #endregion
-
-        #region IDisposable
-
-        public void Dispose()
-        {
-            _array.Dispose();
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
@@ -24,7 +24,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Couchbase.Lite.Internal.Doc;
 using System.Diagnostics;
 
 namespace Couchbase.Lite.Fleece
@@ -74,14 +73,12 @@ namespace Couchbase.Lite.Fleece
         [NotNull]
         public MValue Get(int index)
         {
-            if (index < 0 || index >= _vec.Count)
-            {
+            if (index < 0 || index >= _vec.Count) {
                 return MValue.Empty;
             }
 
             var val = _vec[index];
-            if (val.IsEmpty)
-            {
+            if (val.IsEmpty) {
                 val = new MValue(Native.FLArray_Get(BaseArray, (uint)index));
                 _vec[index] = val;
             }
@@ -97,7 +94,7 @@ namespace Couchbase.Lite.Fleece
         public void RemoveRange(int start, int count = 1)
         {
             if (!IsMutable) {
-                throw new InvalidOperationException("Cannot remove items from a non-mutable FleeceMutableArray");
+                throw new InvalidOperationException(CouchbaseLiteErrorMessage.CannotRemoveItemsFromNonMutableMArray);
             }
 
             var end = start + count;
@@ -106,15 +103,15 @@ namespace Couchbase.Lite.Fleece
             }
 
             if (start < 0) {
-                throw new ArgumentOutOfRangeException($"Cannot remove starting from an index less than 0 (got {start})");
+                throw new ArgumentOutOfRangeException(String.Format(CouchbaseLiteErrorMessage.CannotRemoveStartingFromIndexLessThan, start));
             }
 
             if (end < start) {
-                throw new ArgumentOutOfRangeException($"Cannot remove a range that ends before it starts (got start={start}, count = {count})");
+                throw new ArgumentOutOfRangeException(String.Format(CouchbaseLiteErrorMessage.CannotRemoveRangeEndsBeforeItStarts, start, count));
             }
 
             if (end > _vec.Count) {
-                throw new ArgumentOutOfRangeException($"Range end for remove exceeds the length of the array (got start={start}, count = {count})");
+                throw new ArgumentOutOfRangeException(String.Format(CouchbaseLiteErrorMessage.RangeEndForRemoveExceedsArrayLength, start, count));
             }
 
             if (end < Count) {
@@ -128,7 +125,7 @@ namespace Couchbase.Lite.Fleece
         public void Set(int index, object val)
         {
             if (!IsMutable) {
-                throw new InvalidOperationException("Cannot set items in a non-mutable FleeceMutableArray");
+                throw new InvalidOperationException(CouchbaseLiteErrorMessage.CannotSetItemsInNonMutableMArray);
             }
 
             if (index < 0 || index >= Count) {
@@ -203,7 +200,7 @@ namespace Couchbase.Lite.Fleece
         public void Clear()
         {
             if (!IsMutable) {
-                throw new InvalidOperationException("Cannot clear a non-mutable FleeceMutableArray");
+                throw new InvalidOperationException(CouchbaseLiteErrorMessage.CannotClearNonMutableMArray);
             }
 
             if (!_vec.Any()) {

--- a/src/Couchbase.Lite.Tests.Shared/BlobTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/BlobTest.cs
@@ -294,8 +294,8 @@ namespace Test
             }};
 
             var listContainsBlobJson = JsonConvert.SerializeObject(blobDict);
-            using(var md = new MutableDocument("doc1"))
-            using (var ma = new MutableArrayObject(listContainsBlobJson)) {
+            using (var md = new MutableDocument("doc1")) {
+                var ma = new MutableArrayObject(listContainsBlobJson);
                 var blobInMa = (MutableDictionaryObject)ma.GetValue(0);
                 var blobInMD = new Blob(blobInMa.ToDictionary());
                 blobInMD.Content.Should().BeNull(CouchbaseLiteErrorMessage.BlobDbNull);


### PR DESCRIPTION
Revert using FLSlotSet in FleeceMutableArray to prevent memory leak when calling MutableArrayObject.AddBlob while the Blob Content is large in size.