### PR TITLE
CBL-2251 Database.GetDocument("") returns null

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -715,6 +715,11 @@ namespace Couchbase.Lite
         public Document GetDocument([@NotNull]string id)
         {
             CBDebug.MustNotBeNull(WriteLog.To.Database, Tag, nameof(id), id);
+            if (id.Equals("")) {
+                WriteLog.To.Database.W(Tag, "The doc id should not be an empty string.");
+                return null;
+            }
+
             return ThreadSafety.DoLocked(() => GetDocumentInternal(id));
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -163,6 +163,12 @@ namespace Test
         }
 
         [Fact]
+        public void TestGetDocumentWithEmptyStringId()
+        {
+            Db.GetDocument("").Should().BeNull();
+        }
+
+        [Fact]
         public void TestGetNonExistingDocWithID()
         {
             Db.GetDocument("non-exist").Should().BeNull("because it doesn't exist");


### PR DESCRIPTION
Return null when user pass an empty string doc id into Database.GetDocument(id)