### PR TITLE
CBL-3032 Replication Network Interface option test

### DIFF
--- a/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
+++ b/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
@@ -282,8 +282,7 @@ namespace Couchbase.Lite.Sync
             IPAddress addr, hostAddr;
             bool isRemoteHostIP = false;
 
-            try
-            {
+            try {
                 //Input NI can be IPAddress string
                 if (IPAddress.TryParse(_options.NetworkInterface, out addr)) {
                     var localEndPoint = new IPEndPoint(addr, 0);

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -924,19 +924,11 @@ namespace Test
 
         #if !__ANDROID__ && !__IOS__ //Cannot run this test in emulators
 
-        [Fact]
-        public void TestReplicatorValidNetworkInterface()
-        {
-            // valid ni and able to connect to server
-            RunReplicationNI(TestReplicatorNIType.ValidNI);
-        }
+        [Fact] // valid ni and able to connect to server
+        public void TestReplicatorValidNetworkInterface() => RunReplicationNI(TestReplicatorNIType.ValidNI);
 
-        [Fact]
-        public void TestReplicatorValidNetworkInterfaceAddr()
-        {
-            // valid address and able to connect to server
-            RunReplicationNI(TestReplicatorNIType.ValidAddress_SERVER_REACHABLE);
-        }
+        [Fact] // valid address and able to connect to server
+        public void TestReplicatorValidNetworkInterfaceAddr() =>  RunReplicationNI(TestReplicatorNIType.ValidAddress_SERVER_REACHABLE);
 
         [Fact]
         public void TestReplicatorValidAdapterNotConnectNetwork()
@@ -1062,8 +1054,7 @@ namespace Test
                     #else
                     return ni.Name; 
                     #endif
-                } else if (type == TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE &&
-                    ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+                } else if (type == TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE && ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet && ni.OperationalStatus == OperationalStatus.Up)
                     return ni.Name;
             }
 

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -1043,7 +1043,7 @@ namespace Test
                  lo      IPv6 ::1
                  enp0s3  IPv6 fe80::4e2c:5835:897b:6ec7%enp0s3
                  */
-                if (type <= TestReplicatorNIType.ValidNI && ni.OperationalStatus == OperationalStatus.Up) {
+                if (type <= TestReplicatorNIType.ValidNI && ni.NetworkInterfaceType == NetworkInterfaceType.Loopback && ni.OperationalStatus == OperationalStatus.Up) {
                     if (type == TestReplicatorNIType.ValidAddress_SERVER_REACHABLE) {
                         if (ni.Supports(NetworkInterfaceComponent.IPv6))
                             #if ANDROID

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -963,11 +963,11 @@ namespace Test
 
         [Fact]
         public void TestReplicatorInValidNetworkInterface() => RunReplicationNI(TestReplicatorNIType.InValidNI,
-            errorCode: (int)CouchbaseLiteError.UnknownHost, errorType: CouchbaseLiteErrorType.CouchbaseLite);
+            errorCode: (int)CouchbaseLiteError.UnknownInterface, errorType: CouchbaseLiteErrorType.CouchbaseLite);
 
         [Fact]
         public void TestReplicatorInValidNIIPAddress() => RunReplicationNI(TestReplicatorNIType.InValidAddress,
-            errorCode: (int)CouchbaseLiteError.UnknownHost, errorType: CouchbaseLiteErrorType.CouchbaseLite);
+            errorCode: (int)CouchbaseLiteError.UnknownInterface, errorType: CouchbaseLiteErrorType.CouchbaseLite);
 
         #endregion
 

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -936,7 +936,6 @@ namespace Test
         [Fact]
         public void TestReplicatorValidAdapterNotConnectNetwork() => TestReplicatorNI(TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE);
 
-        //mac error code is different from windows error code..
         [Fact]
         public void TestReplicatorValidNIUnreachableServer()
         {
@@ -949,19 +948,20 @@ namespace Test
 
             //unreachable server
             var targetEndpoint = new URLEndpoint(new Uri("ws://192.168.0.117:4984/app"));
-            var config = new ReplicatorConfiguration(Db, targetEndpoint)
-            {
+            var config = new ReplicatorConfiguration(Db, targetEndpoint) {
                 ReplicatorType = ReplicatorType.PushAndPull,
                 NetworkInterface = ni
             };
-            //mac's error code is CouchbaseLiteError.AddressNotAvailable
-            RunReplication(config, (int)CouchbaseLiteError.NetworkUnreachable, CouchbaseLiteErrorType.CouchbaseLite);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                RunReplication(config, (int)CouchbaseLiteError.NetworkUnreachable, CouchbaseLiteErrorType.CouchbaseLite);
+            } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                RunReplication(config, (int)CouchbaseLiteError.AddressNotAvailable, CouchbaseLiteErrorType.CouchbaseLite);
+            }
         }
 
         #endif
 
-        // Note: Mac tests will fail with db dispose failures (Infinite Taking a while for active items to stop...) if stacking below tests into one test
-        // Please note all tests below will end up with offline status by design. 
         [Fact]
         public void TestReplicatorInValidNetworkInterface() => TestReplicatorNI(TestReplicatorNIType.InValidNI);
 

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -936,9 +936,9 @@ namespace Test
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 RunReplicationNI(TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE,
                     errorCode: (int)CouchbaseLiteError.AddressNotAvailable, errorType: CouchbaseLiteErrorType.CouchbaseLite);
-            } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) { // ethernet available no cable connected, so throw CouchbaseLiteError.UnknownInterface ?
                 RunReplicationNI(TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE,
-                    errorCode: (int)CouchbaseLiteError.UnknownHost, errorType: CouchbaseLiteErrorType.CouchbaseLite);
+                    errorCode: (int)CouchbaseLiteError.UnknownInterface, errorType: CouchbaseLiteErrorType.CouchbaseLite);
             }
         }
 
@@ -1054,7 +1054,7 @@ namespace Test
                     #else
                     return ni.Name; 
                     #endif
-                } else if (type == TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE && ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet && ni.OperationalStatus == OperationalStatus.Up)
+                } else if (type == TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE && ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
                     return ni.Name;
             }
 

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -934,8 +934,17 @@ namespace Test
         }
 
         [Fact]
-        public void TestReplicatorValidAdapterNotConnectNetwork() => RunReplicationNI(TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE,
-            errorCode:(int)CouchbaseLiteError.AddressNotAvailable, errorType:CouchbaseLiteErrorType.CouchbaseLite);
+        public void TestReplicatorValidAdapterNotConnectNetwork()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                RunReplicationNI(TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE,
+                    errorCode: (int)CouchbaseLiteError.AddressNotAvailable, errorType: CouchbaseLiteErrorType.CouchbaseLite);
+            } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                RunReplicationNI(TestReplicatorNIType.ValidNI_SERVER_UNREACHABLE,
+                    errorCode: (int)CouchbaseLiteError.UnknownHost, errorType: CouchbaseLiteErrorType.CouchbaseLite);
+            }
+        }
 
         [Fact]
         public void TestReplicatorValidNIUnreachableServer()


### PR DESCRIPTION
Note in Android device testing: If uses NI "lo" or it's IPv6 address "::1" will not connect to the remote end, I have to mask them to IPv4 address in order to get the connection to work.
Note in OSX testing: ethernet "en0" is found but there is no cable connected to it will result in Invalid Network Interface when trying to connect to the remote end.

NOTE: https://github.com/couchbase/couchbase-lite-net/blob/master/src/Couchbase.Lite.Shared/Sync/Reachability.cs#L88-L109 has to be used in Valid NI check as well!!!