### PR TITLE
CBL-3334 Get Collection update & Enable the tests that were disabled awaiting for the LiteCore fixes that now are in

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -85,6 +85,9 @@ namespace Couchbase.Lite
         // Must be called inside self lock
         private bool IsClosed => c4Db == null || _c4coll == IntPtr.Zero || !Native.c4coll_isValid((C4Collection*)_c4coll);
 
+        // Must be called inside self lock
+        internal bool IsValid => _c4coll != IntPtr.Zero && Native.c4coll_isValid((C4Collection*)_c4coll);
+
         internal C4Database* c4Db => Database.c4db;
 
         internal C4Collection* c4coll

--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -83,7 +83,7 @@ namespace Couchbase.Lite
         #region Properties
 
         // Must be called inside self lock
-        private bool IsClosed => c4Db == null || _c4coll == IntPtr.Zero || !Native.c4coll_isValid((C4Collection*)_c4coll);
+        internal bool IsClosed => c4Db == null || _c4coll == IntPtr.Zero || !Native.c4coll_isValid((C4Collection*)_c4coll);
 
         // Must be called inside self lock
         internal bool IsValid => _c4coll != IntPtr.Zero && Native.c4coll_isValid((C4Collection*)_c4coll);
@@ -545,7 +545,7 @@ namespace Couchbase.Lite
                     throw new CouchbaseLiteException(C4ErrorCode.UnexpectedError);
                 }
 
-                var indexesInfo = FLValueConverter.ToCouchbaseObject(val, this, true) as IList<object>;
+                var indexesInfo = FLValueConverter.ToCouchbaseObject(val, Database, true) as IList<object>;
                 foreach (var a in indexesInfo) {
                     var indexInfo = a as Dictionary<string, object>;
                     retVal.Add((string)indexInfo["name"]);

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -272,7 +272,7 @@ namespace Couchbase.Lite
         {
             get {
                 GetDefaultCollection();
-                if (_defaultCollectionIsDeleted || _defaultCollection.IsClosed == true)
+                if (_defaultCollectionIsDeleted || ThreadSafety.DoLocked(() => _defaultCollection?.IsClosed) == true)
                     throw new InvalidOperationException($"Default Collection is deleted from the database {ToString()}.");
 
                 return _defaultCollection;

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -268,10 +268,16 @@ namespace Couchbase.Lite
             }
         }
 
-        internal Collection DefaultCollection => _defaultCollectionIsDeleted || 
-                ThreadSafety.DoLocked(() => _defaultCollection?.IsClosed) == true ?
-            throw new InvalidOperationException($"Default Collection is deleted from the database {ToString()}.") :
-            GetDefaultCollection();
+        internal Collection DefaultCollection
+        {
+            get {
+                GetDefaultCollection();
+                if (_defaultCollectionIsDeleted || _defaultCollection.IsClosed == true)
+                    throw new InvalidOperationException($"Default Collection is deleted from the database {ToString()}.");
+
+                return _defaultCollection;
+            }
+        }
 
         private bool IsShell { get; } //this object is borrowing the C4Database from somewhere else, so don't free C4Database at the end if isshell
 

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -274,7 +274,7 @@ namespace Couchbase.Lite
                 if(_defaultCollection == null && !_defaultCollectionIsDeleted)
                     _defaultCollection = GetDefaultCollection();
 
-                if (_defaultCollectionIsDeleted || _defaultCollection.IsClosed == true)
+                if (_defaultCollectionIsDeleted || ThreadSafety.DoLocked(() => _defaultCollection.IsClosed) == true)
                     throw new InvalidOperationException($"Default Collection is deleted from the database {ToString()}.");
 
                 return _defaultCollection;

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -268,18 +268,10 @@ namespace Couchbase.Lite
             }
         }
 
-        internal Collection DefaultCollection
-        {
-            get {
-                if(_defaultCollection == null && !_defaultCollectionIsDeleted)
-                    _defaultCollection = GetDefaultCollection();
-
-                if (_defaultCollectionIsDeleted || ThreadSafety.DoLocked(() => _defaultCollection.IsClosed) == true)
-                    throw new InvalidOperationException($"Default Collection is deleted from the database {ToString()}.");
-
-                return _defaultCollection;
-            }
-        }
+        internal Collection DefaultCollection => _defaultCollectionIsDeleted || 
+                ThreadSafety.DoLocked(() => _defaultCollection?.IsClosed) == true ?
+            throw new InvalidOperationException($"Default Collection is deleted from the database {ToString()}.") :
+            GetDefaultCollection();
 
         private bool IsShell { get; } //this object is borrowing the C4Database from somewhere else, so don't free C4Database at the end if isshell
 

--- a/src/Couchbase.Lite.Shared/API/Database/Scope.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Scope.cs
@@ -189,15 +189,15 @@ namespace Couchbase.Lite
             });
         }
 
-        internal bool DeleteCollection(Collection collection)
+        internal bool DeleteCollection(string name, string scope)
         {
             bool deleteSuccessful = false;
             ThreadSafety.DoLocked(() =>
             {
                 CheckOpen();
-                using (var collName_ = new C4String(collection.Name))
-                using (var scopeName_ = new C4String(collection.Scope?.Name)) {
-                    var collectionSpec = new C4CollectionSpec() 
+                using (var collName_ = new C4String(name))
+                using (var scopeName_ = new C4String(scope)) {
+                    var collectionSpec = new C4CollectionSpec()
                     {
                         name = collName_.AsFLSlice(),
                         scope = scopeName_.AsFLSlice()
@@ -209,7 +209,7 @@ namespace Couchbase.Lite
                     });
 
                     if (deleteSuccessful) {
-                        if (_collections.TryRemove(collection.Name, out var co)) {
+                        if (_collections.TryRemove(name, out var co)) {
                             co?.Dispose();
                         }
                     }
@@ -345,7 +345,6 @@ namespace Couchbase.Lite
                 }
 
                 _collections.Clear();
-                _collections = null;
             });
         }
 

--- a/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
@@ -153,12 +153,12 @@ namespace Couchbase.Lite
         [NotNull]
         private ThreadSafety SetupThreadSafety()
         {
-            Collection coll = null;
+            Database db = null;
             if (_array.Context != null && _array.Context != MContext.Null) {
-                coll = (_array.Context as DocContext)?.Collection;
+                db = (_array.Context as DocContext)?.Db;
             }
 
-            return coll?.ThreadSafety ?? new ThreadSafety();
+            return db?.ThreadSafety ?? new ThreadSafety();
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/API/Document/DictionaryObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/DictionaryObject.cs
@@ -195,12 +195,12 @@ namespace Couchbase.Lite
         [NotNull]
         private ThreadSafety SetupThreadSafety()
         {
-            Collection coll = null;
+            Database db = null;
             if (_dict.Context != null && _dict.Context != MContext.Null) {
-                coll = (_dict.Context as DocContext)?.Collection;
+                db = (_dict.Context as DocContext)?.Db;
             }
 
-            return coll?.ThreadSafety ?? new ThreadSafety();
+            return db?.ThreadSafety ?? new ThreadSafety();
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/API/Document/Document.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/Document.cs
@@ -284,7 +284,7 @@ namespace Couchbase.Lite
         {
             if (Data != null) {
                 Misc.SafeSwap(ref _root,
-                    new MRoot(new DocContext(Collection, _c4Doc), (FLValue*) Data, IsMutable));
+                    new MRoot(new DocContext(Database, _c4Doc), (FLValue*) Data, IsMutable));
                 Collection.ThreadSafety.DoLocked(() => _dict = (DictionaryObject) _root.AsObject());
             } else {
                 Misc.SafeSwap(ref _root, null);

--- a/src/Couchbase.Lite.Shared/Document/DocContext.cs
+++ b/src/Couchbase.Lite.Shared/Document/DocContext.cs
@@ -26,14 +26,7 @@ namespace Couchbase.Lite.Internal.Doc
     {
         #region Properties
 
-        public Database Db
-        {
-            get {
-                return Collection.Database;
-            }
-        }
-
-        public Collection Collection { get; }
+        public Database Db { get; }
 
         public C4DocumentWrapper Doc { get; }
 
@@ -41,10 +34,10 @@ namespace Couchbase.Lite.Internal.Doc
 
         #region Constructors
 
-        public DocContext(Collection collection, C4DocumentWrapper doc)
+        public DocContext(Database database, C4DocumentWrapper doc)
             : base(new FLSlice())
         {
-            Collection = collection;
+            Db = database;
             Doc = doc?.Retain<C4DocumentWrapper>();
         }
 
@@ -54,7 +47,7 @@ namespace Couchbase.Lite.Internal.Doc
 
         public object ToObject(FLValue* value, bool dotNetType)
         {
-            return FLValueConverter.ToCouchbaseObject(value, Collection, dotNetType);
+            return FLValueConverter.ToCouchbaseObject(value, Db, dotNetType);
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Query/QueryResultContext.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryResultContext.cs
@@ -31,8 +31,8 @@ namespace Couchbase.Lite.Internal.Query
 
         #region Constructors
 
-        public QueryResultContext(Collection coll, C4QueryEnumerator* enumerator)
-            : base(coll, null)
+        public QueryResultContext(Database db, C4QueryEnumerator* enumerator)
+            : base(db, null)
         {
             _enumerator = enumerator;
         }

--- a/src/Couchbase.Lite.Shared/Query/QueryResultSet.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryResultSet.cs
@@ -85,7 +85,7 @@ namespace Couchbase.Lite.Internal.Query
             _c4Enum = e;
             ColumnNames = columnNames;
             _threadSafety = threadSafety;
-            _context = new QueryResultContext(query?.Collection, e);
+            _context = new QueryResultContext(query?.Database, e);
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Serialization/FLValueConverter.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FLValueConverter.cs
@@ -48,12 +48,12 @@ namespace Couchbase.Lite.Internal.Serialization
 
         #region Public Methods
 
-        public static object ToCouchbaseObject(FLValue* value, Collection collection, bool dotNetTypes, Type hintType1 = null)
+        public static object ToCouchbaseObject(FLValue* value, Database db, bool dotNetTypes, Type hintType1 = null)
         {
             switch (Native.FLValue_GetType(value)) {
                 case FLValueType.Array: {
                         if (dotNetTypes) {
-                            return ToObject(value, collection, 0, hintType1);
+                            return ToObject(value, db, 0, hintType1);
                         }
 
                         var array = new ArrayObject(new FleeceMutableArray(new MValue(value), null), false);
@@ -66,12 +66,12 @@ namespace Couchbase.Lite.Internal.Serialization
                             return new DictionaryObject(new MDict(new MValue(value), null), false);
                         }
 
-                        return ToObject(value, collection, 0, hintType1);
+                        return ToObject(value, db, 0, hintType1);
                     }
                 case FLValueType.Undefined:
                     return null;
                 default:
-                    return ToObject(value, collection);
+                    return ToObject(value, db);
             }
         }
 
@@ -124,7 +124,7 @@ namespace Couchbase.Lite.Internal.Serialization
             return dict;
         }
 
-        private static object ToObject(FLValue* value, Collection collection, int level = 0, Type hintType1 = null)
+        private static object ToObject(FLValue* value, Database db, int level = 0, Type hintType1 = null)
         {
             if (value == null) {
                 return null;
@@ -146,7 +146,7 @@ namespace Couchbase.Lite.Internal.Serialization
                     var i = default(FLArrayIterator);
                     Native.FLArrayIterator_Begin(arr, &i);
                     do {
-                        retVal.Add(ToObject(Native.FLArrayIterator_GetValue(&i), collection, level + 1, hintType1));
+                        retVal.Add(ToObject(Native.FLArrayIterator_GetValue(&i), db, level + 1, hintType1));
                     } while (Native.FLArrayIterator_Next(&i));
 
                     return retVal;
@@ -169,10 +169,10 @@ namespace Couchbase.Lite.Internal.Serialization
                     Native.FLDictIterator_Begin(dict, &i);
                     do {
                         var key = Native.FLDictIterator_GetKeyString(&i);
-                        retVal[key] = ToObject(Native.FLDictIterator_GetValue(&i), collection, level + 1, hintType1);
+                        retVal[key] = ToObject(Native.FLDictIterator_GetValue(&i), db, level + 1, hintType1);
                     } while (Native.FLDictIterator_Next(&i));
 
-                    return ConvertDictionary(retVal as IDictionary<string, object>, collection.Database) ?? retVal;
+                    return ConvertDictionary(retVal as IDictionary<string, object>, db) ?? retVal;
                 }
                 case FLValueType.Null:
                     return null;

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -111,7 +111,7 @@ namespace Test
             });
 
             try {
-                var context = new DocContext(Collection, null);
+                var context = new DocContext(Db, null);
                 using (var mRoot = new MRoot(context)) {
                     mRoot.Context.Should().BeSameAs(context);
                     FLDoc* fleeceDoc = Native.FLDoc_FromResultData(flData,
@@ -205,7 +205,7 @@ namespace Test
             });
 
             try {
-                var context = new DocContext(Collection, null);
+                var context = new DocContext(Db, null);
                 using (var mRoot = new MRoot(context)) {
                     mRoot.Context.Should().BeSameAs(context);
                     FLDoc* fleeceDoc = Native.FLDoc_FromResultData(flData,
@@ -329,7 +329,7 @@ Transfer-Encoding: chunked";
             {
                 using (var flData = masterList.FLEncode()) {
                     retrieved =
-                        FLValueConverter.ToCouchbaseObject(NativeRaw.FLValue_FromData((FLSlice) flData, FLTrust.Trusted), Collection,
+                        FLValueConverter.ToCouchbaseObject(NativeRaw.FLValue_FromData((FLSlice) flData, FLTrust.Trusted), Db,
                                 true, typeof(Dictionary<,>).MakeGenericType(typeof(string), typeof(object))) as
                             List<Dictionary<string, object>>;
                 }

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -226,7 +226,7 @@ namespace Test
             }
         }
 
-        //[Fact] CBL-3235
+        [Fact]
         public void TestGetDocFromClosedDB()
         {
             using(var doc = GenerateDocument("doc1")) {
@@ -234,9 +234,7 @@ namespace Test
                 Db.Close();
 
                 Db.Invoking(d => d.GetDocument("doc1"))
-                    .Should().Throw<InvalidOperationException>()
-                    .WithMessage("Attempt to perform an operation on a closed database.",
-                        "because this operation is invalid");
+                    .Should().Throw<InvalidOperationException>();
             }
         }
 
@@ -626,28 +624,24 @@ namespace Test
             Db.Count.Should().Be(0, "because all documents were deleted");
         }
 
-        //[Fact] CBL-3235
+        [Fact]
         public void TestDeleteDocOnClosedDB()
         {
             var doc = GenerateDocument("doc1");
 
             Db.Close();
             Db.Invoking(d => d.Delete(doc))
-                .Should().Throw<InvalidOperationException>()
-                .WithMessage("Attempt to perform an operation on a closed database.",
-                    "because this operation is invalid");
+                .Should().Throw<InvalidOperationException>();
         }
 
-        //[Fact] CBL-3235
+        [Fact]
         public void TestDeleteDocOnDeletedDB()
         {
             var doc = GenerateDocument("doc1");
 
             DeleteDB(Db);
             Db.Invoking(d => d.Delete(doc))
-                .Should().Throw<InvalidOperationException>()
-                .WithMessage("Attempt to perform an operation on a closed database.",
-                    "because this operation is invalid");
+                .Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -750,28 +744,24 @@ namespace Test
             Db.Count.Should().Be(0, "because all documents were purged");
         }
 
-        //[Fact] CBL-3235
+        [Fact]
         public void TestPurgeDocOnClosedDB()
         {
             var doc = GenerateDocument("doc1");
 
             Db.Close();
             Db.Invoking(d => d.Purge(doc))
-                .Should().Throw<InvalidOperationException>()
-                .WithMessage("Attempt to perform an operation on a closed database.",
-                    "because this operation is invalid");
+                .Should().Throw<InvalidOperationException>();
         }
 
-        //[Fact] CBL-3235
+        [Fact]
         public void TestPurgeDocOnDeletedDB()
         {
             var doc = GenerateDocument("doc1");
 
             DeleteDB(Db);
             Db.Invoking(d => d.Purge(doc))
-                .Should().Throw<InvalidOperationException>()
-                .WithMessage("Attempt to perform an operation on a closed database.",
-                    "because this operation is invalid");
+                .Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -1421,7 +1411,7 @@ namespace Test
             Db.DeleteIndex("index3");
         }
 
-        //[Fact] CBL-3235
+        [Fact]
         public void TestGetDocFromDeletedDB()
         {
             using(var doc = GenerateDocument("doc1")) {
@@ -1429,9 +1419,7 @@ namespace Test
                 Db.Delete();
 
                 Db.Invoking(d => d.GetDocument("doc1"))
-                    .Should().Throw<InvalidOperationException>()
-                    .WithMessage("Attempt to perform an operation on a closed database.",
-                        "because this operation is invalid");
+                    .Should().Throw<InvalidOperationException>();
             }
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
@@ -308,7 +308,7 @@ namespace Test
             }
         }
 
-        //[Fact] CBL-3079
+        [Fact]
         public void TestQueryWithBlobProperty()
         {
             var texts = new[]

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -2100,7 +2100,7 @@ namespace Test
             parameters.GetValue("name").As<string>().Should().Be("Jim");
         }
 
-        //[Fact] CBL-3079
+        [Fact]
         public void TestQueryResultTypes()
         {
             var blobContent = Encoding.ASCII.GetBytes("The keys to the kingdom");
@@ -2592,7 +2592,7 @@ namespace Test
             }
         }
 
-        //[Fact] CBL-3079
+        [Fact]
         public void TestQueryResultTypesInDictionaryToJSON()
         {
             var dic = PopulateDictData();

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -77,7 +77,7 @@ namespace Test
             defaultColl.Should().BeNull("default collection cannot be recreated, so the value is still null");
         }
 
-        //[Fact] wait for LiteCore update with CBL-3257 fix
+        [Fact]
         public void TestGetDefaultScopeAfterDeleteDefaultCollection()
         {
             Db.DeleteCollection(Database._defaultCollectionName);
@@ -587,7 +587,7 @@ Ensure that the created collection is visible to the database instance B by usin
 
         // Test that using the Collection APIs on the deleted collection which is deleted from the different database instance
         // returns the result as expected based on section 6.2.
-        //[Fact] TODO CBL-3198
+        //[Fact] wait CBL-3298
         public void TestUseCollectionAPIOnDeletedCollectionDeletedFromDifferentDBInstance()
         {
             using (var colA = Db.CreateCollection("colA", "scopeA")) {
@@ -684,7 +684,7 @@ Ensure that the created collection is visible to the database instance B by usin
                 Db.DeleteCollection(Database._defaultCollectionName);
 
                 Db.Invoking(d => d.GetDocument("doc"))
-                    .Should().Throw<CouchbaseLiteException>("Because GetDocument after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because GetDocument after default collection is deleted.");
 
                 var dto30 = DateTimeOffset.UtcNow.AddSeconds(30);
                 using (var doc1 = new MutableDocument("doc1")) {
@@ -693,19 +693,19 @@ Ensure that the created collection is visible to the database instance B by usin
                     Db.Count.Should().Be(0);
 
                     Db.Invoking(d => d.Save(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Save after default collection is deleted.");
+                        .Should().Throw<InvalidOperationException>("Because Save after default collection is deleted.");
 
                     Db.Invoking(d => d.Delete(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Delete after default collection is deleted.");
+                        .Should().Throw<InvalidOperationException>("Because Delete after default collection is deleted.");
 
                     Db.Invoking(d => d.Purge(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Purge after default collection is deleted.");
+                        .Should().Throw<InvalidOperationException>("Because Purge after default collection is deleted.");
 
                     Db.Invoking(d => d.SetDocumentExpiration("doc", dto30))
-                        .Should().Throw<CouchbaseLiteException>("Because SetDocumentExpiration after default collection is deleted.");
+                        .Should().Throw<InvalidOperationException>("Because SetDocumentExpiration after default collection is deleted.");
 
                     Db.Invoking(d => d.GetDocumentExpiration("doc"))
-                        .Should().Throw<CouchbaseLiteException>("Because GetDocumentExpiration after default collection is deleted.");
+                        .Should().Throw<InvalidOperationException>("Because GetDocumentExpiration after default collection is deleted.");
                 }
 
                 Db.Invoking(d => d.CreateQuery($"SELECT firstName, lastName FROM *"))
@@ -713,22 +713,22 @@ Ensure that the created collection is visible to the database instance B by usin
 
                 var index1 = new ValueIndexConfiguration(new string[] { "firstName", "lastName" });
                 Db.Invoking(d => d.CreateIndex("index1", index1))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because CreateIndex after default collection is deleted.");
 
                 Db.Invoking(d => d.GetIndexes())
-                    .Should().Throw<CouchbaseLiteException>("Because GetIndexes after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because GetIndexes after default collection is deleted.");
 
                 Db.Invoking(d => d.DeleteIndex("index1"))
-                    .Should().Throw<CouchbaseLiteException>("Because DeleteIndex after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because DeleteIndex after default collection is deleted.");
 
                 Db.Invoking(d => d.AddChangeListener(null, (sender, args) => { } ))
-                    .Should().Throw<CouchbaseLiteException>("Because AddChangeListener after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because AddChangeListener after default collection is deleted.");
 
                 Db.Invoking(d => d.AddDocumentChangeListener("doc1", (sender, args) => { }))
-                    .Should().Throw<CouchbaseLiteException>("Because AddDocumentChangeListener after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because AddDocumentChangeListener after default collection is deleted.");
 
                 Db.Invoking(d => d.RemoveChangeListener(d.AddDocumentChangeListener("doc1", (sender, args) => { })))
-                    .Should().Throw<CouchbaseLiteException>("Because RemoveChangeListener after default collection is deleted.");
+                    .Should().Throw<InvalidOperationException>("Because RemoveChangeListener after default collection is deleted.");
             }
         }
 
@@ -744,8 +744,7 @@ Ensure that the created collection is visible to the database instance B by usin
             using (var colA = Db.CreateCollection("colA", "scopeA")) {
                 var scopeA = Db.GetScope("scopeA");//colA.Scope;
 
-                scopeA.DeleteCollection(colA);
-                //Db.DeleteCollection("colA", "scopeA"); scopeA.GetCollections() is null
+                Db.DeleteCollection("colA", "scopeA");
 
                 scopeA.GetCollection("colA").Should().BeNull("Because GetCollection after all collections are deleted.");
                 scopeA.GetCollections().Count.Should().Be(0, "Because GetCollections after all collections are deleted.");
@@ -767,7 +766,7 @@ Ensure that the created collection is visible to the database instance B by usin
                     otherDB.DeleteCollection("colA", "scopeA");
 
                     scopeA.GetCollection("colA").Should().BeNull("Because GetCollection after collection colA is deleted from the other db.");
-                    scopeA.GetCollections()?.Count.Should().Be(0, "Because GetCollections after collection colA is deleted from the other db.");
+                    scopeA.GetCollections().Count.Should().Be(0, "Because GetCollections after collection colA is deleted from the other db.");
                 }
             }
         }

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -690,7 +690,8 @@ Ensure that the created collection is visible to the database instance B by usin
                 using (var doc1 = new MutableDocument("doc1")) {
                     doc1.SetString("str", "string");
 
-                    Db.Count.Should().Be(0);
+                    Db.Invoking(d => Db.Count)
+                        .Should().Throw<InvalidOperationException>("Because Save after default collection is deleted.");
 
                     Db.Invoking(d => d.Save(doc1))
                         .Should().Throw<InvalidOperationException>("Because Save after default collection is deleted.");


### PR DESCRIPTION
- Optimize the get collection logic to use cache and collection is valid LiteCore check.
- Return get collection null instead of throw in case of collection is not valid base on API spec.
- Remove has collection LiteCore check since it's replaced with collection is valid which is less expensive.
- Enable the tests that were disabled awaiting for the LiteCore fixes that now are in
- Revert the source change to take database as parameter instead of collection for query related items.
