### PR TITLE
CBL-3342 Update LiteCore and bindings for replicator in scopes collections

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -78,6 +78,7 @@ namespace Couchbase.Lite.Sync
         private C4ReplicatorStatus _rawStatus;
         private IReachability _reachability;
         private C4Replicator* _repl;
+        private C4CollectionSpec _c4collSpec; //TODO New param for c4repl_getPendingDocIDs & c4repl_isDocumentPending
         private ConcurrentDictionary<Task, int> _conflictTasks = new ConcurrentDictionary<Task, int>();
         private IImmutableSet<string> _pendingDocIds;
 
@@ -320,7 +321,7 @@ namespace Couchbase.Lite.Sync
 
             byte[] pendingDocIds = LiteCoreBridge.Check(err =>
             {
-                return Native.c4repl_getPendingDocIDs(_repl, err);
+                return Native.c4repl_getPendingDocIDs(_repl, _c4collSpec, err);
             });
             
             if (pendingDocIds != null) {
@@ -371,7 +372,7 @@ namespace Couchbase.Lite.Sync
 
             LiteCoreBridge.Check(err => 
             {
-                isDocPending = Native.c4repl_isDocumentPending(_repl, documentID, err);
+                isDocPending = Native.c4repl_isDocumentPending(_repl, documentID, _c4collSpec, err);
                 return isDocPending;
             });
 
@@ -476,6 +477,7 @@ namespace Couchbase.Lite.Sync
             }
 
             var docIDStr = docID.CreateString();
+            //TODO Getting empty slice for both collection and scope names, alter to use default for now...
             var collName = collectionSpec.name.CreateString();
             var scope = collectionSpec.scope.CreateString();
             if (docIDStr == null) {
@@ -483,8 +485,8 @@ namespace Couchbase.Lite.Sync
                 return false;
             }
 
-            var flags = revisionFlags.ToDocumentFlags();
-            return replicator.PullValidateCallback(collName, scope, docIDStr, revID.CreateString(), dict, flags);
+            var flags = revisionFlags.ToDocumentFlags();//TODO Getting empty slice for both collection and scope names, alter to use default for now...
+            return replicator.PullValidateCallback(collName ??= Database._defaultCollectionName, scope ??= Database._defaultScopeName, docIDStr, revID.CreateString(), dict, flags);
         }
 
         #if __IOS__
@@ -500,15 +502,16 @@ namespace Couchbase.Lite.Sync
             }
 
             var docIDStr = docID.CreateString();
-            var collName = collectionSpec.name.CreateString();
+            //TODO Getting empty slice for both collection and scope names, alter to use default for now...
+            var collName = collectionSpec.name.CreateString() ;
             var scope = collectionSpec.scope.CreateString();
             if (docIDStr == null) {
                 WriteLog.To.Database.E(Tag, "Null document ID received in push filter, rejecting...");
                 return false;
             }
 
-            var flags = revisionFlags.ToDocumentFlags();
-            return replicator.PushFilterCallback(collName, scope, docIDStr, revID.CreateString(), dict, flags);
+            var flags = revisionFlags.ToDocumentFlags(); //TODO Getting empty slice for both collection and scope names, alter to use default for now...
+            return replicator.PushFilterCallback(collName??= Database._defaultCollectionName, scope ??= Database._defaultScopeName, docIDStr, revID.CreateString(), dict, flags);
         }
 
         #if __IOS__

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -486,7 +486,7 @@ namespace Couchbase.Lite.Sync
             }
 
             var flags = revisionFlags.ToDocumentFlags();//TODO Getting empty slice for both collection and scope names, alter to use default for now...
-            return replicator.PullValidateCallback(collName ??= Database._defaultCollectionName, scope ??= Database._defaultScopeName, docIDStr, revID.CreateString(), dict, flags);
+            return replicator.PullValidateCallback(collName ?? Database._defaultCollectionName, scope ?? Database._defaultScopeName, docIDStr, revID.CreateString(), dict, flags);
         }
 
         #if __IOS__
@@ -511,7 +511,7 @@ namespace Couchbase.Lite.Sync
             }
 
             var flags = revisionFlags.ToDocumentFlags(); //TODO Getting empty slice for both collection and scope names, alter to use default for now...
-            return replicator.PushFilterCallback(collName??= Database._defaultCollectionName, scope ??= Database._defaultScopeName, docIDStr, revID.CreateString(), dict, flags);
+            return replicator.PushFilterCallback(collName ?? Database._defaultCollectionName, scope ?? Database._defaultScopeName, docIDStr, revID.CreateString(), dict, flags);
         }
 
         #if __IOS__

--- a/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
+++ b/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
@@ -24,6 +24,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)LogTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MigrationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NotificationTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)P2PTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReplicationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScopeCollectionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScopesCollections.QueryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TLSIdentityTest.cs" />
@@ -32,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)QueryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TunesPerfTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)URLEndpointListenerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\Benchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\ForIssueAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\IMockConnectionErrorLogic.cs" />

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -587,7 +587,7 @@ Ensure that the created collection is visible to the database instance B by usin
 
         // Test that using the Collection APIs on the deleted collection which is deleted from the different database instance
         // returns the result as expected based on section 6.2.
-        //[Fact] wait CBL-3298
+        [Fact]
         public void TestUseCollectionAPIOnDeletedCollectionDeletedFromDifferentDBInstance()
         {
             using (var colA = Db.CreateCollection("colA", "scopeA")) {
@@ -598,12 +598,10 @@ Ensure that the created collection is visible to the database instance B by usin
             }
 
             using (var otherDB = OpenDB(Db.Name)) {
-                // CBL-3298 hasScope() returns false
-                otherDB.GetCollection("colA", "scopeA").GetDocument("doc").GetString("str").Should().Be("string");
+                var colA1 = otherDB.GetCollection("colA", "scopeA");
+                colA1.GetDocument("doc").GetString("str").Should().Be("string");
 
                 otherDB.DeleteCollection("colA", "scopeA");
-
-                var colA1 = otherDB.GetCollection("colA", "scopeA");
 
                 colA1.Invoking(d => d.GetDocument("doc"))
                     .Should().Throw<CouchbaseLiteException>("Because GetDocument after collection colA is deleted from the other db.");
@@ -755,7 +753,7 @@ Ensure that the created collection is visible to the database instance B by usin
         // Test that after all collections in the scope are deleted from a different database instance, calling the scope APIS
         // returns the result as expected based on section 6.5. To test this, get and retain the scope object before deleting
         // all collections.
-        //[Fact] CBL-3298
+        [Fact]
         public void TestUseScopeAPIAfterDeletingAllCollectionsFromDifferentDBInstance()
         {
             //6.5 Get Collections from The Scope Having No Collections

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -23,8 +23,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+#if !WINDOWS_UWP
 using Xunit;
 using Xunit.Abstractions;
+#else
+using Fact = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+#endif
 
 namespace Test
 {

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4ReplicatorTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4ReplicatorTypes_defs.cs
@@ -129,6 +129,8 @@ namespace LiteCore.Interop
         public IntPtr onPropertyDecryption;
         public void* callbackContext;
         public C4SocketFactory* socketFactory;
+        public C4ReplicationCollection collections;
+        public IntPtr collectionCount;
     }
 
 }

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native.cs
@@ -59,17 +59,17 @@ namespace LiteCore.Interop
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern C4ReplicatorStatus c4repl_getStatus(C4Replicator* repl);
 
-        public static byte[] c4repl_getPendingDocIDs(C4Replicator* repl, C4Error* outErr)
+        public static byte[] c4repl_getPendingDocIDs(C4Replicator* repl, C4CollectionSpec spec, C4Error* outErr)
         {
-            using(var retVal = NativeRaw.c4repl_getPendingDocIDs(repl, outErr)) {
+            using(var retVal = NativeRaw.c4repl_getPendingDocIDs(repl, spec, outErr)) {
                 return ((FLSlice)retVal).ToArrayFast();
             }
         }
 
-        public static bool c4repl_isDocumentPending(C4Replicator* repl, string docID, C4Error* outErr)
+        public static bool c4repl_isDocumentPending(C4Replicator* repl, string docID, C4CollectionSpec spec, C4Error* outErr)
         {
             using(var docID_ = new C4String(docID)) {
-                return NativeRaw.c4repl_isDocumentPending(repl, docID_.AsFLSlice(), outErr);
+                return NativeRaw.c4repl_isDocumentPending(repl, docID_.AsFLSlice(), spec, outErr);
             }
         }
 
@@ -106,11 +106,11 @@ namespace LiteCore.Interop
         public static extern void c4repl_setOptions(C4Replicator* repl, FLSlice optionsDictFleece);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern FLSliceResult c4repl_getPendingDocIDs(C4Replicator* repl, C4Error* outErr);
+        public static extern FLSliceResult c4repl_getPendingDocIDs(C4Replicator* repl, C4CollectionSpec spec, C4Error* outErr);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool c4repl_isDocumentPending(C4Replicator* repl, FLSlice docID, C4Error* outErr);
+        public static extern bool c4repl_isDocumentPending(C4Replicator* repl, FLSlice docID, C4CollectionSpec spec, C4Error* outErr);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]


### PR DESCRIPTION
- Update LiteCore to Commit: 7956e05736408e28d0116ecd2eb37f06c3a0a6a9 [7956e05] (CBL-3349 : getPendingDocIDs and isDocumentPending to have collection as argument)
- Update C# LiteCore bindings for replicator in scopes collections
- Add back Replicator, P2P, and URLEndpointListener tests which all should work with default collection(s) now