### PR TITLE
CBL-3417 Update message for C4ErrorCode.NotOpen

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -881,12 +881,13 @@ namespace Couchbase.Lite
             ThreadSafety.DoLocked(() =>
             {
                 if (c4Db == null) {
-                    throw new CouchbaseLiteException(C4ErrorCode.NotOpen, CouchbaseLiteErrorMessage.DBClosed);
+                    throw new CouchbaseLiteException(C4ErrorCode.NotOpen, CouchbaseLiteErrorMessage.DBClosedOrCollectionDeleted,
+                        new CouchbaseLiteException(C4ErrorCode.NotOpen, CouchbaseLiteErrorMessage.DBClosed));
                 }
 
                 if (_c4coll == IntPtr.Zero || !Native.c4coll_isValid((C4Collection*)_c4coll)) {
-                    throw new CouchbaseLiteException(C4ErrorCode.NotOpen, String.Format(CouchbaseLiteErrorMessage.CollectionNotAvailable,
-                                ToString()));
+                    throw new CouchbaseLiteException(C4ErrorCode.NotOpen, CouchbaseLiteErrorMessage.DBClosedOrCollectionDeleted,
+                        new CouchbaseLiteException(C4ErrorCode.NotOpen, String.Format(CouchbaseLiteErrorMessage.CollectionNotAvailable, ToString())));
                 }
             });
         }

--- a/src/Couchbase.Lite.Shared/API/Database/Scope.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Scope.cs
@@ -54,7 +54,8 @@ namespace Couchbase.Lite
         {
             get {
                 if (Database.c4db == null)
-                    throw new CouchbaseLiteException(C4ErrorCode.NotOpen, String.Format(CouchbaseLiteErrorMessage.DBClosed));
+                    throw new CouchbaseLiteException(C4ErrorCode.NotOpen, CouchbaseLiteErrorMessage.DBClosedOrCollectionDeleted,
+                        new CouchbaseLiteException(C4ErrorCode.NotOpen, CouchbaseLiteErrorMessage.DBClosed));
                 return Database.c4db;
             }
         }

--- a/src/Couchbase.Lite.Shared/API/Error/CouchbaseLiteErrorMessage.cs
+++ b/src/Couchbase.Lite.Shared/API/Error/CouchbaseLiteErrorMessage.cs
@@ -35,6 +35,7 @@ namespace Couchbase.Lite
         internal const string ResolvedDocContainsNull = "Resolved document has a null body.";
         internal const string ResolvedDocFailedLiteCore = "LiteCore failed resolving conflict.";
         internal const string ResolvedDocWrongDb = "Resolved document's database {0} is different from expected database {1}.";
+        internal const string DBClosedOrCollectionDeleted = "Attempt to perform an operation on a closed database or a deleted collection.";
         internal const string DBClosed = "Attempt to perform an operation on a closed database.";
         internal const string CollectionNotAvailable = "Attempt to perform an operation on an unavailable collection {0}.";
         internal const string NoDocumentRevision = "No revision data on the document!";


### PR DESCRIPTION
Platforms decided to have the same error message for C4ErrorCode.NotOpen. I want to add an inner exception with a more detailed error message for the reason of getting C4ErrorCode.NotOpen.