### PR TITLE
CBL-3628 Maui test project to include Android platform

### DIFF
--- a/src/Couchbase.Lite.Shared/API/DI/Service.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/Service.cs
@@ -57,7 +57,7 @@ namespace Couchbase.Lite.DI
         static Service()
         {
             // Windows 2012 doesn't define NETFRAMEWORK for some reason
-            #if (NETCOREAPP3_1_OR_GREATER || NETCOREAPP || NETFRAMEWORK || NET462) && !NET6_0_WINDOWS10_0_19041_0 && !NET6_0_ANDROID31
+            #if (NETCOREAPP3_1_OR_GREATER || NETCOREAPP || NETFRAMEWORK || NET462) && !NET6_0_WINDOWS10_0_19041_0 && !__MOBILE__
             AutoRegister(typeof(Database).GetTypeInfo().Assembly);
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {

--- a/src/Couchbase.Lite.Shared/API/DI/Service.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/Service.cs
@@ -57,7 +57,7 @@ namespace Couchbase.Lite.DI
         static Service()
         {
             // Windows 2012 doesn't define NETFRAMEWORK for some reason
-            #if (NETCOREAPP3_1_OR_GREATER || NETCOREAPP || NETFRAMEWORK || NET462) && !NET6_0_WINDOWS10_0_19041_0
+            #if (NETCOREAPP3_1_OR_GREATER || NETCOREAPP || NETFRAMEWORK || NET462) && !NET6_0_WINDOWS10_0_19041_0 && !NET6_0_ANDROID31
             AutoRegister(typeof(Database).GetTypeInfo().Assembly);
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {

--- a/src/Couchbase.Lite.Shared/Support/Android/AndroidConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/AndroidConsoleLogger.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __ANDROID__
+#if __ANDROID__ || NET6_0_ANDROID31
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Couchbase.Lite.Shared/Support/Android/AndroidConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/AndroidConsoleLogger.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __ANDROID__ || NET6_0_ANDROID31
+#if __ANDROID__
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Couchbase.Lite.Shared/Support/Android/MainThreadTaskScheduler.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/MainThreadTaskScheduler.cs
@@ -33,35 +33,35 @@ namespace Couchbase.Lite.Support
 {
     internal sealed class MainThreadTaskScheduler : TaskScheduler, IMainThreadTaskScheduler
     {
-#region Constants
+        #region Constants
 
         private const string Tag = nameof(MainThreadTaskScheduler);
 
-#endregion
+        #endregion
 
-#region Variables
+        #region Variables
 
         [NotNull]
         private static Handler _Handler;
 
-#endregion
+        #endregion
 
-#region Properties
+        #region Properties
 
         public bool IsMainThread => Looper.MainLooper == Looper.MyLooper();
 
-#endregion
+        #endregion
 
-#region Constructors
+        #region Constructors
 
         public MainThreadTaskScheduler([NotNull]Context context)
         {
             Interlocked.CompareExchange(ref _Handler, new Handler(context.MainLooper), null);
         }
 
-#endregion
+        #endregion
 
-#region Overrides
+        #region Overrides
 
         protected override IEnumerable<Task> GetScheduledTasks()
         {
@@ -87,16 +87,16 @@ namespace Couchbase.Lite.Support
             return TryExecuteTask(task);
         }
 
-#endregion
+        #endregion
 
-#region IMainThreadTaskScheduler
+        #region IMainThreadTaskScheduler
 
         public TaskScheduler AsTaskScheduler()
         {
             return this;
         }
 
-#endregion
+        #endregion
     }
 }
 #endif

--- a/src/Couchbase.Lite.Shared/Support/Android/XamarinAndroidProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/XamarinAndroidProxy.cs
@@ -53,6 +53,7 @@ namespace Couchbase.Lite.Support
 
         #endregion
 
+        #region Private Methods
         private string EncodeUrl(Uri url)
         {
             // Copied from https://github.com/xamarin/xamarin-android/blob/master/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -69,6 +70,7 @@ namespace Couchbase.Lite.Support
             // bldr.Uri.ToString () would ruin the good job UriBuilder did
             return bldr.ToString();
         }
+        #endregion
     }
 }
 #endif

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/DesktopConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/DesktopConsoleLogger.cs
@@ -22,7 +22,7 @@
 
 // Windows 2012 doesn't define the more generic variants
 
-#if (NETFRAMEWORK || NET462 || NETCOREAPP || NETCOREAPP3_1_OR_GREATER) && !NET6_0_WINDOWS10_0_19041_0
+#if (NETFRAMEWORK || NET462 || NETCOREAPP || NETCOREAPP3_1_OR_GREATER) && !NET6_0_WINDOWS10_0_19041_0 && !NET6_0_ANDROID31
 #define DEBUG
 using System;
 using System.Diagnostics;

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/DesktopConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/DesktopConsoleLogger.cs
@@ -22,7 +22,7 @@
 
 // Windows 2012 doesn't define the more generic variants
 
-#if (NETFRAMEWORK || NET462 || NETCOREAPP || NETCOREAPP3_1_OR_GREATER) && !NET6_0_WINDOWS10_0_19041_0 && !NET6_0_ANDROID31
+#if (NETFRAMEWORK || NET462 || NETCOREAPP || NETCOREAPP3_1_OR_GREATER) && !NET6_0_WINDOWS10_0_19041_0 && !__MOBILE__
 #define DEBUG
 using System;
 using System.Diagnostics;

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -53,13 +53,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Packaging\Couchbase.Lite.Support.Android.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)' == 'Debug|net6.0-android31' ">
-    <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)' == 'Release|net6.0-android31' ">
-    <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)' == 'Packaging|net6.0-android31'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0-android31' ">
     <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -1,29 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha2">
   <PropertyGroup>
-	  <Configurations>Debug;Release;Packaging</Configurations>
-	  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-	  <TargetFrameworks>net6.0-android31;monoandroid90</TargetFrameworks>
-	  <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6'))">22</SupportedOSPlatformVersion>
-	  <TargetFrameworkVersion Condition="!$(TargetFramework.StartsWith('net6'))">v9.0</TargetFrameworkVersion>
+    <Configurations>Debug;Release;Packaging</Configurations>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <TargetFrameworks>net6.0-android31;monoandroid90</TargetFrameworks>
+    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6'))">22</SupportedOSPlatformVersion>
+    <TargetFrameworkVersion Condition="!$(TargetFramework.StartsWith('net6'))">v9.0</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.Android</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.Android</AssemblyName>
     <FileAlignment>512</FileAlignment>
-	  <UseMicrosoftAndroidSdk>true</UseMicrosoftAndroidSdk>
-	  <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-	  <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-	  <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-	  <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-	  <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-	  <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	  <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-	  <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-	  <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-	  <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-	  <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-	  <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseMicrosoftAndroidSdk>true</UseMicrosoftAndroidSdk>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,12 +47,20 @@
     <OutputPath>bin\Packaging\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-	  <OutputPath>bin\Packaging\</OutputPath>
     <NoStdLib>true</NoStdLib>
     <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Packaging\Couchbase.Lite.Support.Android.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)' == 'Debug|net6.0-android31' ">
+    <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)' == 'Release|net6.0-android31' ">
+    <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)' == 'Packaging|net6.0-android31'">
+    <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Couchbase.Lite\Properties\DynamicAssemblyInfo.cs">

--- a/src/Couchbase.Lite.Support.Android/Properties/AssemblyInfo.cs
+++ b/src/Couchbase.Lite.Support.Android/Properties/AssemblyInfo.cs
@@ -17,3 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("Couchbase.Lite")]
+
+[assembly: InternalsVisibleTo("Couchbase.Lite.Tests.Maui")]

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -51,7 +51,7 @@ namespace Test
 #endif
     public sealed class LogTest
     {
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10
+#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
         static LogTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
@@ -471,7 +471,7 @@ namespace Test
             }
         }
 
-        private void TestWithConfiguration(LogLevel level, LogFileConfiguration config, [NotNull]Action a)
+        private void TestWithConfiguration(LogLevel level, LogFileConfiguration config, Action a)
         {
             var old = Database.Log.File.Config;
             Database.Log.File.Config = config;
@@ -484,7 +484,6 @@ namespace Test
             }
         }
 
-        [NotNull]
         private static string EmptyDirectory(string path)
         {
             if (String.IsNullOrEmpty(path)) {
@@ -524,7 +523,6 @@ namespace Test
 
         private class LogTestLogger : ILogger
         {
-            [NotNull]
             private readonly List<string> _lines = new List<string>();
 
             public IReadOnlyList<string> Lines => _lines;

--- a/src/Couchbase.Lite.Tests.Shared/MigrationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/MigrationTest.cs
@@ -15,7 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if !CBL_NO_EXTERN_FILES
+#if !CBL_NO_EXTERN_FILES && !__ANDROID__
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -65,6 +65,11 @@ namespace Test
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
         }
+#elif NET6_0_ANDROID
+        static PerfTest()
+        {
+            Couchbase.Lite.Support.Droid.CheckVersion();
+        }
 #endif
 
 #if !WINDOWS_UWP

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -59,15 +59,10 @@ namespace Test
 
         public Database Db { get; private set; }
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__MOBILE__
+#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !NET6_0_ANDROID
         static PerfTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
-        }
-#elif NET6_0_ANDROID
-        static PerfTest()
-        {
-            Couchbase.Lite.Support.Droid.CheckVersion();
         }
 #endif
 

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -60,7 +60,7 @@ namespace Test
 
         public Database Db { get; private set; }
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10
+#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
         static PerfTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -23,7 +23,6 @@ using System.IO;
 using System.Text;
 using Couchbase.Lite;
 using Couchbase.Lite.Logging;
-using Couchbase.Lite.Support;
 using FluentAssertions;
 using Test.Util;
 #if !WINDOWS_UWP
@@ -60,7 +59,7 @@ namespace Test
 
         public Database Db { get; private set; }
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
+#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__MOBILE__
         static PerfTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();

--- a/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
@@ -1092,7 +1092,6 @@ namespace Test
     {
         #region Public Methods
 
-        [NotNull]
         public static IExpression CreateInput(string propertyName)
         {
             return Expression.Dictionary(new Dictionary<string, object>

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -96,11 +96,6 @@ namespace Test
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
         }
-#elif NET6_0_ANDROID
-        static TestCase()
-        {
-            Couchbase.Lite.Support.Droid.CheckVersion();
-        }
 #endif
 
 

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -68,9 +68,9 @@ namespace Test
         internal static readonly ISelectResult RevID = SelectResult.Expression(Meta.RevisionID);
 
         protected static int _counter;
-#if !WINDOWS_UWP
+        #if !WINDOWS_UWP
         protected readonly ITestOutputHelper _output;
-#else
+        #else
         private TestContext _testContext;
         public TestContext TestContext
         {
@@ -80,7 +80,7 @@ namespace Test
                 Database.Log.Custom = new MSTestLogger(_testContext) { Level = LogLevel.Info };
             }
         }
-#endif
+        #endif
 
         protected Database Db { get; private set; }
 
@@ -91,24 +91,24 @@ namespace Test
         protected static string Directory => Path.Combine(Path.GetTempPath().Replace("cache", "files"), "CouchbaseLite");
 
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__MOBILE__
+        #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__MOBILE__
         static TestCase()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
         }
-#endif
+        #endif
 
 
 
-#if !WINDOWS_UWP
+        #if !WINDOWS_UWP
         public TestCase(ITestOutputHelper output)
         {
             Database.Log.Custom = new XunitLogger(output) { Level = LogLevel.Info };
             _output = output;
-#else
+        #else
         public TestCase()
         { 
-#endif
+        #endif
             var nextCounter = Interlocked.Increment(ref _counter);
             Database.Delete($"{DatabaseName}{nextCounter}", Directory);
             OpenDB(nextCounter);
@@ -116,11 +116,11 @@ namespace Test
 
         protected void WriteLine(string line)
         {
-#if !WINDOWS_UWP
+            #if !WINDOWS_UWP
             _output.WriteLine(line ?? "<null>");
-#else
+            #else
             TestContext.WriteLine(line ?? "<null>");
-#endif
+            #endif
         }
 
 
@@ -646,7 +646,7 @@ namespace Test
 
         internal static bool ReadFileByLines(string path, Func<string, bool> callback)
         {
-#if WINDOWS_UWP || NET6_0_WINDOWS10
+            #if WINDOWS_UWP || NET6_0_WINDOWS10
             var url = $"ms-appx:///Assets/{path}";
                 var file = Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri(url))
                     .AsTask()
@@ -656,7 +656,7 @@ namespace Test
 
                 var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
                 foreach(var line in lines) {
-#elif __ANDROID__ 
+            #elif __ANDROID__ 
             Android.Content.Context ctx = null;
             #if !NET6_0_ANDROID
             ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
@@ -665,31 +665,31 @@ namespace Test
             #endif
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
-                while ((line = tr.ReadLine()) != null) {  
-#elif __IOS__
+                while ((line = tr.ReadLine()) != null) {
+            #elif __IOS__
 			var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
 			using (var tr = new StreamReader(File.Open(bundlePath, FileMode.Open, FileAccess.Read))) {
 				string line;
 				while ((line = tr.ReadLine()) != null) {
-#else
+            #else
             using (var tr = new StreamReader(typeof(TestCase).GetTypeInfo().Assembly.GetManifestResourceStream(path.Replace("C/tests/data/", "")))) {
-                        string line;
-                        while ((line = tr.ReadLine()) != null) {
-#endif
+				string line;
+				while ((line = tr.ReadLine()) != null) {
+            #endif
                     if (!callback(line)) {
-						return false;
-					}
+                        return false;
+                    }
 				}
-#if !WINDOWS_UWP &&  !NET6_0_WINDOWS10
+        #if !WINDOWS_UWP &&  !NET6_0_WINDOWS10
         }
-#endif
+        #endif
 
             return true;
         }
 
         internal Stream GetTestAsset(string path)
         {
-#if WINDOWS_UWP || NET6_0_WINDOWS10
+            #if WINDOWS_UWP || NET6_0_WINDOWS10
             var url = $"ms-appx:///Assets/{path}";
                 var file = Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri(url))
                     .AsTask()
@@ -698,21 +698,21 @@ namespace Test
                     .GetResult();
 
                 return file.OpenStreamForReadAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-#elif __ANDROID__ && !NET6_0_ANDROID
+            #elif __ANDROID__ && !NET6_0_ANDROID
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
             return ctx.Assets.Open(path);
-#elif NET6_0_ANDROID
+            #elif NET6_0_ANDROID
             var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
             return ctx.Assets.Open(path);
-#elif __IOS__
+            #elif __IOS__
             var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
 			return File.Open(bundlePath, FileMode.Open, FileAccess.Read);
-#else
+            #else
             return File.Open(path, FileMode.Open, FileAccess.Read);
-#endif
+            #endif
 
         }
-#endif
+        #endif
 
         public void Dispose()
         {

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -91,7 +91,7 @@ namespace Test
         protected static string Directory => Path.Combine(Path.GetTempPath().Replace("cache", "files"), "CouchbaseLite");
 
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
+#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__MOBILE__
         static TestCase()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
@@ -661,16 +661,16 @@ namespace Test
 
                 var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
                 foreach(var line in lines) {
-#elif __ANDROID__ && !NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+#elif __ANDROID__ 
+            Android.Content.Context ctx = null;
+            #if !NET6_0_ANDROID
+            ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #elif NET6_0_ANDROID
+            ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #endif
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
-                while ((line = tr.ReadLine()) != null) {
-#elif NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
-            using (var tr = new StreamReader(ctx.Assets.Open(path))) {
-                string line;
-                while ((line = tr.ReadLine()) != null) {     
+                while ((line = tr.ReadLine()) != null) {  
 #elif __IOS__
 			var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
 			using (var tr = new StreamReader(File.Open(bundlePath, FileMode.Open, FileAccess.Read))) {

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -91,7 +91,7 @@ namespace Test
         protected static string Directory => Path.Combine(Path.GetTempPath().Replace("cache", "files"), "CouchbaseLite");
 
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10
+#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
         static TestCase()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
@@ -657,7 +657,11 @@ namespace Test
                 var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
                 foreach(var line in lines) {
 #elif __ANDROID__
+            #if NET6_0_ANDROID
+            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #else
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #endif
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
                 while ((line = tr.ReadLine()) != null) {
@@ -694,7 +698,11 @@ namespace Test
 
                 return file.OpenStreamForReadAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 #elif __ANDROID__
+            #if NET6_0_ANDROID
+            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #else
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #endif
             return ctx.Assets.Open(path);
 #elif __IOS__
             var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));

--- a/src/Couchbase.Lite.Tests.Shared/Util/ZipFileExtensions.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/ZipFileExtensions.cs
@@ -185,12 +185,14 @@ namespace System.IO.Compression
 
                     Directory.CreateDirectory(fileDestinationPath);
                 }
+                #if !__ANDROID__
                 else {
                     // If it is a file:
                     // Create containing directory:
                     Directory.CreateDirectory(Path.GetDirectoryName(fileDestinationPath));
                     entry.ExtractToFile(fileDestinationPath, overwrite: overwrite);
                 }
+                #endif
             }
         }
 

--- a/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
@@ -91,6 +91,8 @@ namespace LiteCore.Tests
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
             #elif NET6_0_WINDOWS10
             Couchbase.Lite.Support.WinUI.CheckVersion();
+            #elif NET6_0_ANDROID
+            Couchbase.Lite.Support.Droid.CheckVersion();
             #endif
             var enc = Native.FLEncoder_New();
             Native.FLEncoder_BeginDict(enc, 1);
@@ -279,12 +281,13 @@ namespace LiteCore.Tests
 
             var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
             foreach(var line in lines) {
-#elif __ANDROID__
-            #if NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
-            #else
+#elif __ANDROID__ && !NET6_0_ANDROID
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
-            #endif
+            using (var tr = new StreamReader(ctx.Assets.Open(path))) {
+                string line;
+                while((line = tr.ReadLine()) != null) {
+#elif NET6_0_ANDROID
+            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
                 while((line = tr.ReadLine()) != null) { 
@@ -300,7 +303,7 @@ namespace LiteCore.Tests
                 string line;
                 while((line = tr.ReadLine()) != null) {
 #endif
-					using(var c4 = new C4String(line)) {
+                    using (var c4 = new C4String(line)) {
                         if(!callback((FLSlice)c4.AsFLSlice())) {
                             return false;
                         }
@@ -479,15 +482,20 @@ namespace LiteCore.Tests
             var buffer = Windows.Storage.FileIO.ReadBufferAsync(file).AsTask().ConfigureAwait(false).GetAwaiter()
                 .GetResult();
             var jsonData = System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeBufferExtensions.ToArray(buffer);
-#elif __ANDROID__
-            #if NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
-            #else
+#elif __ANDROID__ && !NET6_0_ANDROID
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
-            #endif
             byte[] jsonData;
             using (var stream = ctx.Assets.Open(path))
             using (var ms = new MemoryStream()) {
+                stream.CopyTo(ms);
+                jsonData = ms.ToArray();
+            }
+#elif NET6_0_ANDROID
+            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            byte[] jsonData;
+            using (var stream = ctx.Assets.Open(path))
+            using (var ms = new MemoryStream())
+            {
                 stream.CopyTo(ms);
                 jsonData = ms.ToArray();
             }

--- a/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
@@ -87,7 +87,7 @@ namespace LiteCore.Tests
 
         static Test()
         {
-            #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
+            #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__MOBILE__
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
             #elif NET6_0_WINDOWS10
             Couchbase.Lite.Support.WinUI.CheckVersion();
@@ -281,16 +281,16 @@ namespace LiteCore.Tests
 
             var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
             foreach(var line in lines) {
-#elif __ANDROID__ && !NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+#elif __ANDROID__
+            Android.Content.Context ctx = null;
+            #if !NET6_0_ANDROID
+            ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #elif NET6_0_ANDROID
+            ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #endif
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
                 while((line = tr.ReadLine()) != null) {
-#elif NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
-            using (var tr = new StreamReader(ctx.Assets.Open(path))) {
-                string line;
-                while((line = tr.ReadLine()) != null) { 
 #elif __IOS__
 			var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
 			using (var tr = new StreamReader(File.Open(bundlePath, FileMode.Open, FileAccess.Read)))
@@ -482,20 +482,16 @@ namespace LiteCore.Tests
             var buffer = Windows.Storage.FileIO.ReadBufferAsync(file).AsTask().ConfigureAwait(false).GetAwaiter()
                 .GetResult();
             var jsonData = System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeBufferExtensions.ToArray(buffer);
-#elif __ANDROID__ && !NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+#elif __ANDROID__ 
+            Android.Content.Context ctx = null;
+            #if !NET6_0_ANDROID
+            ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #elif NET6_0_ANDROID
+            ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #endif
             byte[] jsonData;
             using (var stream = ctx.Assets.Open(path))
             using (var ms = new MemoryStream()) {
-                stream.CopyTo(ms);
-                jsonData = ms.ToArray();
-            }
-#elif NET6_0_ANDROID
-            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
-            byte[] jsonData;
-            using (var stream = ctx.Assets.Open(path))
-            using (var ms = new MemoryStream())
-            {
                 stream.CopyTo(ms);
                 jsonData = ms.ToArray();
             }

--- a/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
@@ -42,15 +42,15 @@ namespace LiteCore.Tests
 #endif
     public unsafe class Test : TestBase
     {
-#if __ANDROID__
+        #if __ANDROID__
         public static readonly string TestDir = System.Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-#elif false
+        #elif false
         public static readonly string TestDir = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
-#elif __IOS__
+        #elif __IOS__
         public static readonly string TestDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "..", "tmp");
-#else
+        #else
         public static readonly string TestDir = Path.GetTempPath();
-#endif
+        #endif
 
         internal static readonly FLSlice FleeceBody;
 
@@ -101,12 +101,12 @@ namespace LiteCore.Tests
             FleeceBody = (FLSlice)result;
         }
 
-#if !WINDOWS_UWP
+        #if !WINDOWS_UWP
         public Test(ITestOutputHelper output) : base(output)
         {
 
         }
-#endif
+        #endif
 
         internal static C4Document* c4enum_nextDocument(C4DocEnumerator* e, C4Error* outError)
         {
@@ -269,7 +269,7 @@ namespace LiteCore.Tests
         #if !CBL_NO_EXTERN_FILES
         internal bool ReadFileByLines(string path, Func<FLSlice, bool> callback)
         {
-#if WINDOWS_UWP || NET6_0_WINDOWS10
+            #if WINDOWS_UWP || NET6_0_WINDOWS10
             var url = $"ms-appx:///Assets/{path}";
             var file = Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri(url))
                 .AsTask()
@@ -279,7 +279,7 @@ namespace LiteCore.Tests
 
             var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
             foreach(var line in lines) {
-#elif __ANDROID__
+            #elif __ANDROID__
             Android.Content.Context ctx = null;
             #if !NET6_0_ANDROID
             ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
@@ -289,27 +289,27 @@ namespace LiteCore.Tests
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
                 while((line = tr.ReadLine()) != null) {
-#elif __IOS__
+            #elif __IOS__
 			var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
 			using (var tr = new StreamReader(File.Open(bundlePath, FileMode.Open, FileAccess.Read)))
 			{
 				string line;
 				while ((line = tr.ReadLine()) != null)
 				{
-#else
+            #else
             using(var tr = new StreamReader(File.Open(path, FileMode.Open))) {
                 string line;
                 while((line = tr.ReadLine()) != null) {
-#endif
+            #endif
                     using (var c4 = new C4String(line)) {
                         if(!callback((FLSlice)c4.AsFLSlice())) {
                             return false;
                         }
                     }
                 }
-#if !WINDOWS_UWP && !NET6_0_WINDOWS10
+        #if !WINDOWS_UWP && !NET6_0_WINDOWS10
         }
-#endif
+        #endif
 
             return true;
         }
@@ -382,7 +382,7 @@ namespace LiteCore.Tests
 
             return numDocs;
         }
-#endif
+        #endif
 
         protected void ReopenDB()
         {
@@ -469,7 +469,7 @@ namespace LiteCore.Tests
         {
             WriteLine($"Reading {path} ...");
             var st = Stopwatch.StartNew();
-#if WINDOWS_UWP || NET6_0_WINDOWS10
+            #if WINDOWS_UWP || NET6_0_WINDOWS10
             var url = $"ms-appx:///Assets/{path}";
             var file = Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri(url))
                 .AsTask()
@@ -480,7 +480,7 @@ namespace LiteCore.Tests
             var buffer = Windows.Storage.FileIO.ReadBufferAsync(file).AsTask().ConfigureAwait(false).GetAwaiter()
                 .GetResult();
             var jsonData = System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeBufferExtensions.ToArray(buffer);
-#elif __ANDROID__ 
+            #elif __ANDROID__ 
             Android.Content.Context ctx = null;
             #if !NET6_0_ANDROID
             ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
@@ -493,17 +493,17 @@ namespace LiteCore.Tests
                 stream.CopyTo(ms);
                 jsonData = ms.ToArray();
             }
-#elif __IOS__
-			var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
-			byte[] jsonData;
+            #elif __IOS__
+            var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
+            byte[] jsonData;
             using (var stream = File.Open(bundlePath, FileMode.Open, FileAccess.Read))
             using (var ms = new MemoryStream()) {
                 stream.CopyTo(ms);
                 jsonData = ms.ToArray();
             }
-#else
+            #else
             var jsonData = File.ReadAllBytes(path);
-#endif
+            #endif
 
             FLError error;
             FLSliceResult fleeceData;

--- a/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
@@ -87,7 +87,7 @@ namespace LiteCore.Tests
 
         static Test()
         {
-            #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10
+            #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
             #elif NET6_0_WINDOWS10
             Couchbase.Lite.Support.WinUI.CheckVersion();
@@ -280,7 +280,11 @@ namespace LiteCore.Tests
             var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
             foreach(var line in lines) {
 #elif __ANDROID__
+            #if NET6_0_ANDROID
+            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #else
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #endif
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
                 while((line = tr.ReadLine()) != null) { 
@@ -476,7 +480,11 @@ namespace LiteCore.Tests
                 .GetResult();
             var jsonData = System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeBufferExtensions.ToArray(buffer);
 #elif __ANDROID__
+            #if NET6_0_ANDROID
+            var ctx = global::Couchbase.Lite.Tests.Maui.MainActivity.ActivityContext;
+            #else
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
+            #endif
             byte[] jsonData;
             using (var stream = ctx.Assets.Open(path))
             using (var ms = new MemoryStream()) {
@@ -492,7 +500,7 @@ namespace LiteCore.Tests
                 jsonData = ms.ToArray();
             }
 #else
-			var jsonData = File.ReadAllBytes(path);
+            var jsonData = File.ReadAllBytes(path);
 #endif
 
             FLError error;

--- a/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/Test.cs
@@ -91,8 +91,6 @@ namespace LiteCore.Tests
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
             #elif NET6_0_WINDOWS10
             Couchbase.Lite.Support.WinUI.CheckVersion();
-            #elif NET6_0_ANDROID
-            Couchbase.Lite.Support.Droid.CheckVersion();
             #endif
             var enc = Native.FLEncoder_New();
             Native.FLEncoder_BeginDict(enc, 1);


### PR DESCRIPTION
All the changes in this PR is to make the Maui android test project build and able to use CBL libraries.
Some methods use in the tests are disabled due to incompatibility with .Net 6 Android/Maui Android and it requires time to research and investigate.
[CBL-3711](https://issues.couchbase.com/browse/CBL-3711) is created for the job.
And there also some indentation update in this PR.
