### PR TITLE
Add AddTargetPlatformVersion attributes in Couchbase Lite, Support Android and Support iOS projects

### DIFF
--- a/packaging/nuget/couchbase-lite-support-android.nuspec
+++ b/packaging/nuget/couchbase-lite-support-android.nuspec
@@ -23,9 +23,9 @@
   <files>
     <file target="" src="packaging\nuget\LICENSE.txt" />
     <file target="logo.png" src="packaging\nuget\logo.png" />
-    <file target="lib\net6.0-android\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android\Couchbase.Lite.Support.Android.dll" />
-    <file target="lib\net6.0-android\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android\Couchbase.Lite.Support.Android.pdb" />
-    <file target="lib\net6.0-android\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android\Couchbase.Lite.Support.Android.xml" />
+    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.dll" />
+    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.pdb" />
+    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.xml" />
     <file target="lib\monoandroid\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\monoandroid90\Couchbase.Lite.Support.Android.dll" />
     <file target="lib\monoandroid\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\monoandroid90\Couchbase.Lite.Support.Android.pdb" />
     <file target="lib\monoandroid\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\monoandroid90\Couchbase.Lite.Support.Android.xml" />

--- a/packaging/nuget/couchbase-lite-support-ios.nuspec
+++ b/packaging/nuget/couchbase-lite-support-ios.nuspec
@@ -23,16 +23,16 @@
   <files>
     <file target="" src="packaging\nuget\LICENSE.txt" />
 	<file target="logo.png" src="packaging\nuget\logo.png" />
-    <file target="lib\net6.0-maccatalyst\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst\Couchbase.Lite.Support.iOS.dll" />
-    <file target="lib\net6.0-maccatalyst\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst\Couchbase.Lite.Support.iOS.pdb" />
-    <file target="lib\net6.0-maccatalyst\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst\Couchbase.Lite.Support.iOS.xml" />
-    <file target="build\net6.0-maccatalyst\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst\ios.targets" />
-    <file target="build\net6.0-maccatalyst\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
-    <file target="lib\net6.0-ios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios\Couchbase.Lite.Support.iOS.dll" />
-    <file target="lib\net6.0-ios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios\Couchbase.Lite.Support.iOS.pdb" />
-    <file target="lib\net6.0-ios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios\Couchbase.Lite.Support.iOS.xml" />
-    <file target="build\net6.0-ios\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios\ios.targets" />
-    <file target="build\net6.0-ios\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
+    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.dll" />
+    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.pdb" />
+    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.xml" />
+    <file target="build\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\ios.targets" />
+    <file target="build\net6.0-maccatalyst14.2\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
+    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.dll" />
+    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.pdb" />
+    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.xml" />
+    <file target="build\net6.0-ios14.2\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\ios.targets" />
+    <file target="build\net6.0-ios14.2\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.xml" />

--- a/packaging/nuget/couchbase-lite.nuspec
+++ b/packaging/nuget/couchbase-lite.nuspec
@@ -55,7 +55,7 @@
 		<dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.UWP" version="[$version$]" />
       </group>
-      <group targetFramework="net6.0-android">
+      <group targetFramework="net6.0-android31">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
 		<dependency id="System.Collections.Immutable" version="6.0.0" />
@@ -69,14 +69,14 @@
 		<dependency id="System.Collections.Immutable" version="6.0.0" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
       </group>
-      <group targetFramework="net6.0-ios">
+      <group targetFramework="net6.0-ios14.2">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
 		<dependency id="System.Collections.Immutable" version="6.0.0" />
 		<dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>
-      <group targetFramework="net6.0-maccatalyst">
+      <group targetFramework="net6.0-maccatalyst14.2">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
 		<dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
@@ -107,9 +107,9 @@
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.dll" />
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.pdb" />
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.xml" />
-    <file target="lib\net6.0-android\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android\Couchbase.Lite.dll" />
-    <file target="lib\net6.0-android\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android\Couchbase.Lite.pdb" />
-    <file target="lib\net6.0-android\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android\Couchbase.Lite.xml" />
+    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android31\Couchbase.Lite.dll" />
+    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android31\Couchbase.Lite.pdb" />
+    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android31\Couchbase.Lite.xml" />
     <file target="lib\monoandroid\" src="src\Couchbase.Lite\bin\Packaging\monoandroid90\Couchbase.Lite.dll" />
     <file target="lib\monoandroid\" src="src\Couchbase.Lite\bin\Packaging\monoandroid90\Couchbase.Lite.pdb" />
     <file target="lib\monoandroid\" src="src\Couchbase.Lite\bin\Packaging\monoandroid90\Couchbase.Lite.xml" />
@@ -120,12 +120,12 @@
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite\bin\Packaging\uap10.0.19041\Couchbase.Lite.pdb" />
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite\bin\Packaging\uap10.0.19041\Couchbase.Lite.xml" />
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite\bin\Packaging\uap10.0.19041\Couchbase.Lite.pri" />
-    <file target="lib\net6.0-maccatalyst\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst\Couchbase.Lite.dll" />
-    <file target="lib\net6.0-maccatalyst\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst\Couchbase.Lite.pdb" />
-    <file target="lib\net6.0-maccatalyst\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst\Couchbase.Lite.xml" />
-    <file target="lib\net6.0-ios\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios\Couchbase.Lite.dll" />
-    <file target="lib\net6.0-ios\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios\Couchbase.Lite.pdb" />
-    <file target="lib\net6.0-ios\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios\Couchbase.Lite.xml" />
+    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.dll" />
+    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.pdb" />
+    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.xml" />
+    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.dll" />
+    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.pdb" />
+    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.xml" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite\bin\Packaging\xamarin.ios10\Couchbase.Lite.dll" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite\bin\Packaging\xamarin.ios10\Couchbase.Lite.pdb" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite\bin\Packaging\xamarin.ios10\Couchbase.Lite.xml" />

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging</Configurations>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworks>net6.0-android;monoandroid90</TargetFrameworks>
+    <TargetFrameworks>net6.0-android31;monoandroid90</TargetFrameworks>
     <SupportedOSPlatformVersion>22.0</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6'))">31.0</TargetPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.Android</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.Android</AssemblyName>
@@ -52,7 +51,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Packaging\Couchbase.Lite.Support.Android.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0-android' ">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-android'))">
     <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -5,6 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworks>net6.0-android;monoandroid90</TargetFrameworks>
     <SupportedOSPlatformVersion>22.0</SupportedOSPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6'))">31.0</TargetPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.Android</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.Android</AssemblyName>

--- a/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
+++ b/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks>net6.0-ios;net6.0-maccatalyst;Xamarin.iOS10</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">10.15</SupportedOSPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.2</TargetPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.iOS</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.iOS</AssemblyName>

--- a/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
+++ b/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
@@ -3,11 +3,9 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging</Configurations>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworks>net6.0-ios;net6.0-maccatalyst;Xamarin.iOS10</TargetFrameworks>
+    <TargetFrameworks>net6.0-ios14.2;net6.0-maccatalyst14.2;Xamarin.iOS10</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">10.15</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.2</TargetPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.iOS</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.iOS</AssemblyName>
@@ -56,7 +54,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Packaging\Couchbase.Lite.Support.iOS.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0-ios' or '$(TargetFramework)' == 'net6.0-maccatalyst' ">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-ios')) or $(TargetFramework.StartsWith('net6.0-maccatalyst'))">
     <DefineConstants>$(DefineConstants);NET6_0_APPLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging;Debug_Coverage;Release_Coverage</Configurations>
-	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;MonoAndroid90;Xamarin.iOS10</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net6.0-android31;net6.0-ios14.2;net6.0-maccatalyst14.2;MonoAndroid90;Xamarin.iOS10</TargetFrameworks>
 	<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net462;uap10.0.19041;net6.0-windows10.0.19041.0</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</TargetPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">10.15</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.2</TargetPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">22.0</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">31.0</TargetPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
     <AssemblyName>Couchbase.Lite</AssemblyName>

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -6,8 +6,11 @@
     <SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</TargetPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">10.15</SupportedOSPlatformVersion>
+    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.2</TargetPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">22.0</SupportedOSPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">31.0</TargetPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
     <AssemblyName>Couchbase.Lite</AssemblyName>


### PR DESCRIPTION
Revert to include target framework version for .Net 6 iOS/Android in csprojs and nuspec files to fix Nuget error: Some included files are included under TFMs which are missing a platform version: net6.0-android... (Tested with the changes and verified working)
EE branch: https://github.com/couchbaselabs/couchbase-lite-net-ee/tree/PR-1451
