### PR TITLE
No need to check Platform when including LiteCore libs in Packaging Config

### DIFF
--- a/src/Couchbase.Lite.Support.WinUI/Couchbase.Lite.Support.WinUI.csproj
+++ b/src/Couchbase.Lite.Support.WinUI/Couchbase.Lite.Support.WinUI.csproj
@@ -72,19 +72,19 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup Condition="$(Configuration.Contains('Packaging'))">
-    <Content Condition="'$(Platform)' == 'x64'" Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\x64\RelWithDebInfo\LiteCore.dll">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\x64\RelWithDebInfo\LiteCore.dll">
       <Link>x64\LiteCore.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Condition="'$(Platform)' == 'x64'" Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\x64\RelWithDebInfo\LiteCore.pdb">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\x64\RelWithDebInfo\LiteCore.pdb">
       <Link>x64\LiteCore.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Condition="'$(Platform)' == 'arm64'" Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.dll">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.dll">
       <Link>arm64\LiteCore.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Condition="'$(Platform)' == 'arm64'" Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.pdb">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.pdb">
       <Link>arm64\LiteCore.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fix CI build in packaging stage (winui)
https://mobile.jenkins.couchbase.com/blue/organizations/jenkins/couchbase-lite-net-edition-build/detail/couchbase-lite-net-edition-build/3292/pipeline