### PR TITLE
CBL-4108 Update MacCatalyst test

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1174,7 +1174,7 @@ namespace Couchbase.Lite
                 } else {
                     var pathStr = String.Concat(uri.Segments.Take(uri.Segments.Length - 1));
                     C4Error err = new C4Error();
-                    cookieSaved = Native.c4db_setCookie(_c4db, cookieStr, uri.Host, pathStr, acceptParentDomain, &err);
+                    cookieSaved = Native.c4db_setCookie(_c4db, cookie, uri.Host, pathStr, acceptParentDomain, &err);
                     if(err.code > 0) {
                         WriteLog.To.Sync.W(Tag, $"{err.domain}/{err.code} Failed saving Cookie {cookie}.");
                     }

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1172,12 +1172,11 @@ namespace Couchbase.Lite
                 if (uri == null) {
                     WriteLog.To.Sync.V(Tag, "The Uri used to set cookie is null.");
                 } else {
-                    var cookieStr = cookie.ToCBLCookieString();
                     var pathStr = String.Concat(uri.Segments.Take(uri.Segments.Length - 1));
                     C4Error err = new C4Error();
                     cookieSaved = Native.c4db_setCookie(_c4db, cookieStr, uri.Host, pathStr, acceptParentDomain, &err);
                     if(err.code > 0) {
-                        WriteLog.To.Sync.W(Tag, $"{err.domain}/{err.code} Failed saving Cookie {cookieStr}.");
+                        WriteLog.To.Sync.W(Tag, $"{err.domain}/{err.code} Failed saving Cookie {cookie}.");
                     }
                 }
             });

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging</Configurations>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworks>net6.0-android31;monoandroid90</TargetFrameworks>
+    <TargetFrameworks>net6.0-android31.0;monoandroid10.0</TargetFrameworks>
     <SupportedOSPlatformVersion>22.0</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.Android</RootNamespace>

--- a/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
+++ b/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworks>net6.0-ios14.2;net6.0-maccatalyst14.2;Xamarin.iOS10</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">10.15</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.iOS</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.iOS</AssemblyName>

--- a/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
+++ b/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworks>net6.0-ios14.2;net6.0-maccatalyst14.2;Xamarin.iOS10</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.5</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.iOS</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.iOS</AssemblyName>

--- a/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
+++ b/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <TargetFrameworks>net6.0-ios14.2;net6.0-maccatalyst14.2;Xamarin.iOS10</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.5</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.iOS</RootNamespace>
     <AssemblyName>Couchbase.Lite.Support.iOS</AssemblyName>

--- a/src/Couchbase.Lite.Support.Apple/iOS/ios.targets
+++ b/src/Couchbase.Lite.Support.Apple/iOS/ios.targets
@@ -1,7 +1,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <NativeReference Include="$(MSBuildThisFileDirectory)LiteCore.framework">
+        <NativeReference Include="$(MSBuildThisFileDirectory)LiteCore.xcframework">
           <Kind>Framework</Kind>
+          <SmartLink>False</SmartLink>
         </NativeReference>
     </ItemGroup>
 </Project>

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging;PackagingDebug</Configurations>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net462;net6.0</TargetFrameworks>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsMac>false</IsMac>
     <IsMac Condition=" '$(OS)' == 'Unix' AND Exists('/Library/Frameworks') ">true</IsMac>
   </PropertyGroup>
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging;PackagingDebug</Configurations>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net462</TargetFrameworks>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -57,7 +57,7 @@
       <LastGenOutput>DynamicAssemblyInfo.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <ItemGroup Condition=" ('$(OS)' == 'Windows_NT' OR $(Configuration.Contains('Packaging'))) AND '$(JUST_CSHARP)' == '' ">
+  <ItemGroup Condition=" ($(TargetFramework.StartsWith('net6.0-windows')) and $(Configuration.Contains('Packaging'))) AND '$(JUST_CSHARP)' == '' ">
     <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\x64\RelWithDebInfo\LiteCore.dll">
       <Link>x64\LiteCore.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.shproj
+++ b/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.shproj
@@ -4,7 +4,7 @@
     <ProjectGuid>{11F38891-8397-49B4-9146-6DAF0A9D7866}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <Service Include="$(MSBuildThisFileDirectory){82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1529,7 +1529,6 @@ namespace Test
                 "id=a3fWa;path=/;HttpOnly;expires=Mon, 4-Jan-2100 05:54:52 GMT"
             };
 
-            var expected = "id=a3fWa";
             foreach (var cookie in noneExpiredCookies) {
                 Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
                 Db.GetCookies(uri).Should().Be("id=a3fWa");

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1518,18 +1518,18 @@ namespace Test
 
             string[] noneExpiredCookies =
             {
-                "id=a3fWa; Expires=Wed, 06 Jan 2100 05:54:52 GMT; Secure; HttpOnly",
                 // RFC 822, updated by RFC 1123
                 "id=a3fWa;expires=Wed, 06 Jan 2100 05:54:52 GMT;Path=/",
-                "id=a3fWa;expires=Wed, 04 Jan 2100 05:54:52 GMT;Path=/",
+                "id=a3fWa;expires=Mon, 04 Jan 2100 05:54:52 GMT;Path=/",
                 // ANSI C's time format
-                "id=a3fWa;expires=Wed Jan  4 05:54:52 2100       ;Path=/",
-                "id=a3fWa;expires=Wed Jan  4 05:54:52 2100;Path=/",
+                "id=a3fWa;expires=Wed Jan  6 05:54:52 2100       ;Path=/",
+                "id=a3fWa;expires=Mon Jan  4 05:54:52 2100;Path=/",
                 // GCLB cookie format
-                "id=a3fWa; path=/; HttpOnly; expires=Wed, 4-Jan-2100 05:54:52 GMT",
-                "id=a3fWa;path=/;HttpOnly;expires=Wed, 4-Jan-2100 05:54:52 GMT"
+                "id=a3fWa; path=/; HttpOnly; expires=Mon, 4-Jan-2100 05:54:52 GMT",
+                "id=a3fWa;path=/;HttpOnly;expires=Mon, 4-Jan-2100 05:54:52 GMT"
             };
 
+            var expected = "id=a3fWa";
             foreach (var cookie in noneExpiredCookies) {
                 Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
                 Db.GetCookies(uri).Should().Be("id=a3fWa");

--- a/src/LiteCore/test/LiteCore.Tests.Shared/LiteCore.Tests.Shared.shproj
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/LiteCore.Tests.Shared.shproj
@@ -9,7 +9,7 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
   <PropertyGroup />
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <Service Include="$(MSBuildThisFileDirectory){82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="LiteCore.Tests.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />

--- a/src/build/do_fetch_litecore.ps1
+++ b/src/build/do_fetch_litecore.ps1
@@ -52,9 +52,9 @@ if(Test-Path "ios-fat") {
 	Remove-Item "ios-fat" -Recurse
 }
 	
-$framework = "LiteCore.framework"
+$framework = "LiteCore.xcframework"
 if($DebugLib) {
-	$framework = "LiteCore-Debug.framework"
+	$framework = "LiteCore-Debug.xcframework"
 }
 
 if(Test-Path ios/$framework/LiteCore) {

--- a/src/global.json
+++ b/src/global.json
@@ -1,8 +1,4 @@
 {
-    "sdk": {
-        "version": "3.1.100",
-		"rollForward": "latestMajor"
-    },
     "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "3.0.44"
     }


### PR DESCRIPTION
The main components here are to make the necessary changes (which were a lot both in core and .NET) for Mac Catalyst to function (all tests have passed locally).  Since PR validation is so out of control, this PR also removes the dropped platform .NET Core 3.1 from the testing, as well as the technically unsupported .NET Core / .NET 6 mac desktop.  Xamarin is dropping from validation testing in favor of MAUI.  The rest is just packaging and/or testing changes needed to accommodate Mac Catalyst.