### PR TITLE
CBL-4133: Rewrite Xamarin Android reachability class to use Xamarin Essentials

### DIFF
--- a/packaging/nuget/couchbase-lite.nuspec
+++ b/packaging/nuget/couchbase-lite.nuspec
@@ -21,32 +21,33 @@
       <group targetFramework="netcoreapp3.1">
         <dependency id="Newtonsoft.Json" version="11.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-		<dependency id="System.Collections.Immutable" version="1.3.0" />
-		<dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" />
+		    <dependency id="System.Collections.Immutable" version="1.3.0" />
+		    <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" />
         <dependency id="Couchbase.Lite.Support.NetDesktop" version="[$version$]" />
       </group>
       <group targetFramework="net461">
         <dependency id="Newtonsoft.Json" version="11.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-		<dependency id="System.Collections.Immutable" version="1.3.0" />
+		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.NetDesktop" version="[$version$]" />
       </group>
       <group targetFramework="uap10.0.16299">
         <dependency id="Newtonsoft.Json" version="11.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-		<dependency id="System.Collections.Immutable" version="1.3.0" />
+		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.UWP" version="[$version$]" />
       </group>
       <group targetFramework="monoandroid">
         <dependency id="Newtonsoft.Json" version="11.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-		<dependency id="System.Collections.Immutable" version="1.3.0" />
+		    <dependency id="System.Collections.Immutable" version="1.3.0" />
+        <dependency id="Xamarin.Essentials" version="1.7.4" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
       </group>
       <group targetFramework="xamarinios">
         <dependency id="Newtonsoft.Json" version="11.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-		<dependency id="System.Collections.Immutable" version="1.3.0" />
+		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>
     </dependencies>

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -170,6 +170,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Support\Android\DefaultDirectoryResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support\Android\MainThreadTaskScheduler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support\Android\XamarinAndroidProxy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Support\Android\XEReachability.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support\Freezer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support\iOS\DefaultDirectoryResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support\iOS\iOSConsoleLogger.cs" />

--- a/src/Couchbase.Lite.Shared/Support/Android/XEReachability.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/XEReachability.cs
@@ -1,0 +1,66 @@
+﻿// 
+// XEReachability.cs
+// 
+// Copyright (c) 2023 Couchbase, Inc All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+#if __ANDROID__
+using Couchbase.Lite.DI;
+using Couchbase.Lite.Sync;
+using System;
+using Xamarin.Essentials;
+
+namespace Couchbase.Lite.Support
+{
+    [CouchbaseDependency]
+    internal sealed class XEReachability : IReachability
+    {
+        public Uri Url { get; set; }
+
+        public event EventHandler<NetworkReachabilityChangeEventArgs> StatusChanged;
+
+        #region Private Methods
+
+        private void OnConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
+        {
+            Console.WriteLine($"XEReachability changed: {e.NetworkAccess}");
+            var state = NetworkReachabilityStatus.Unknown;
+            if (e.NetworkAccess == NetworkAccess.None) {
+                state = NetworkReachabilityStatus.Unreachable;
+            } else if(e.NetworkAccess != NetworkAccess.Unknown) {
+                state = NetworkReachabilityStatus.Reachable;
+            }
+
+            var eventArgs = new NetworkReachabilityChangeEventArgs(state);
+            StatusChanged?.Invoke(this, eventArgs);
+        }
+
+        #endregion
+
+        #region IReachability
+
+        public void Start()
+        {
+            Connectivity.ConnectivityChanged += OnConnectivityChanged;
+        }
+
+        public void Stop()
+        {
+            Connectivity.ConnectivityChanged -= OnConnectivityChanged;
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -51,7 +51,8 @@
     <PackageReference Include="SimpleInjector" Version="5.2.0" />
     <PackageReference Condition=" !$(Configuration.StartsWith('Debug')) " Include="SourceLink.Create.GitHub" Version="2.7.5" PrivateAssets="all" />
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
-	<PackageReference Include="System.Collections.Immutable" Version="1.2.5.0" />
+	  <PackageReference Include="System.Collections.Immutable" Version="1.2.5.0" />
+    <PackageReference Condition=" $(TargetFramework.StartsWith('MonoAndroid')) " Include="Xamarin.Essentials" Version="1.7.4" />
     <DotNetCliToolReference Condition=" !$(Configuration.StartsWith('Debug')) " Include="dotnet-sourcelink-git" Version="2.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
To work around a bug with NetworkAddressChanged in which socket fds are not correctly freed by mono

Companion PR: https://github.com/couchbaselabs/couchbase-lite-net-ee/pull/97