### PR TITLE
CBL-4142: Add option to allow save of parent domain cookies

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1121,7 +1121,7 @@ namespace Couchbase.Lite
             return cookies;
         }
 
-        internal bool SaveCookie(string cookie, [@NotNull] Uri uri)
+        internal bool SaveCookie(string cookie, [@NotNull] Uri uri, bool acceptParentDomain)
         {
             bool cookieSaved = false;
             ThreadSafety.DoLocked(() =>
@@ -1132,7 +1132,7 @@ namespace Couchbase.Lite
                     var cookieStr = cookie.ToCBLCookieString();
                     var pathStr = String.Concat(uri.Segments.Take(uri.Segments.Length - 1));
                     C4Error err = new C4Error();
-                    cookieSaved = Native.c4db_setCookie(_c4db, cookieStr, uri.Host, pathStr, &err);
+                    cookieSaved = Native.c4db_setCookie(_c4db, cookieStr, uri.Host, pathStr, acceptParentDomain, &err);
                     if(err.code > 0) {
                         WriteLog.To.Sync.W(Tag, $"{err.domain}/{err.code} Failed saving Cookie {cookieStr}.");
                     }

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -459,7 +459,7 @@ namespace Couchbase.Lite.Sync
                 return;
             }
 
-            Config.Database.SaveCookie(e, remoteUrl);
+            Config.Database.SaveCookie(e, remoteUrl, Config.AcceptParentDomainCookies);
         }
 
         #if __IOS__

--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
@@ -102,6 +102,18 @@ namespace Couchbase.Lite.Sync
         #region Properties
 
         /// <summary>
+        /// Gets or sets whether or not a cookie can be set on a parent domain
+        /// of the host that issued it (i.e. foo.bar.com can set a cookie for all
+        /// of bar.com).  This is only recommended if the host issuing the cookie
+        /// is well trusted.
+        /// </summary>
+        public bool AcceptParentDomainCookies
+        {
+            get => Options.AcceptParentDomainCookies;
+            set => _freezer.PerformAction(() => Options.AcceptParentDomainCookies = value);
+        }
+
+        /// <summary>
         /// Gets or sets the class which will authenticate the replication
         /// </summary>
         [CanBeNull]

--- a/src/Couchbase.Lite.Shared/Sync/ReplicatorOptionsDictionary.cs
+++ b/src/Couchbase.Lite.Shared/Sync/ReplicatorOptionsDictionary.cs
@@ -53,6 +53,7 @@ namespace Couchbase.Lite.Sync
         private const string MaxRetriesKey = "maxRetries";
         private const string MaxRetryIntervalKey = "maxRetryInterval";
         private const string EnableAutoPurgeKey = "autoPurge";
+        private const string AcceptParentDomainCookiesKey = "acceptParentDomainCookies";
 
         // HTTP options:
         private const string HeadersKey = "headers";
@@ -82,6 +83,17 @@ namespace Couchbase.Lite.Sync
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Gets or sets whether or not a cookie can be set on a parent domain
+        /// of the host that issued it (i.e. foo.bar.com can set a cookie for all
+        /// of bar.com)
+        /// </summary>
+        public bool AcceptParentDomainCookies
+        {
+            get => this.GetCast<bool>(AcceptParentDomainCookiesKey);
+            set => this[AcceptParentDomainCookiesKey] = value;
+        }
 
         /// <summary>
         /// Gets or sets the authentication parameters

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1499,26 +1499,27 @@ namespace Test
         {
             var uri = new Uri("http://example.com/");
             var cookieStr = "id=a3fWa; Domain=.example.com; Secure; HttpOnly";
-            Db.SaveCookie(cookieStr, uri);
+            Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
             Db.GetCookies(uri).Should().Be("id=a3fWa");
             cookieStr = "id=a3fWa; Domain=www.example.com; Secure; HttpOnly";
-            Db.SaveCookie(cookieStr, uri);
+            Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
             Db.GetCookies(uri).Should().Be("id=a3fWa");
             uri = new Uri("http://www.example.com/");
-            cookieStr = "id=a3fWa; Domain=.example.com; Secure; HttpOnly";
-            //No longer throw exception. Will log warning messages.
-            //Action badAction = (() => Db.SaveCookie(cookieStr, uri));
-            //badAction.Should().Throw<CouchbaseLiteException>(); //CouchbaseLiteException (LiteCoreDomain / 9): Invalid cookie.
             cookieStr = "id=a3fWa; Domain=www.example.com; Secure; HttpOnly";
-            Db.SaveCookie(cookieStr, uri);
+            Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
             Db.GetCookies(uri).Should().Be("id=a3fWa; id=a3fWa");
             uri = new Uri("http://exampletest.com/");
             cookieStr = "id=a3fWa; Expires=Wed, 20 Oct 2100 05:54:52 GMT; Secure; HttpOnly";
-            Db.SaveCookie(cookieStr, uri);
+            Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
             Db.GetCookies(uri).Should().Be("id=a3fWa");
             cookieStr = "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly";
-            Db.SaveCookie(cookieStr, uri);
+            Db.SaveCookie(cookieStr, uri, false).Should().BeTrue("because otherwise the cookie did not save");
             Db.GetCookies(uri).Should().BeNull("cookie is expired");
+
+            uri = new Uri("http://foo.example.com");
+            cookieStr = "id=a3fWa; Domain=.example.com; Secure; HttpOnly";
+            Db.SaveCookie(cookieStr, uri, true).Should().BeTrue("because otherwise the cookie did not save");
+            Db.SaveCookie(cookieStr, uri, false).Should().BeFalse("because otherwise the cookie saved improperly");
         }
 
         private void WithActiveLiveQueries(bool isCloseNotDelete)

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native.cs
@@ -31,7 +31,7 @@ namespace LiteCore.Interop
         public static extern C4Replicator* c4repl_new(C4Database* db, C4Address remoteAddress, FLSlice remoteDatabaseName, C4ReplicatorParameters @params, C4Error* outError);
         public static bool c4address_fromURL(string url, C4Address* address, FLSlice* dbName)
         {
-            using(var url_ = new C4String(url)) {
+            using (var url_ = new C4String(url)) {
                 return NativeRaw.c4address_fromURL(url_.AsFLSlice(), address, dbName);
             }
         }
@@ -43,7 +43,7 @@ namespace LiteCore.Interop
         public static extern C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSocket, C4ReplicatorParameters @params, C4Error* outError);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void c4repl_start(C4Replicator* repl, [MarshalAs(UnmanagedType.U1)]bool reset);
+        public static extern void c4repl_start(C4Replicator* repl, [MarshalAs(UnmanagedType.U1)] bool reset);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void c4repl_stop(C4Replicator* repl);
@@ -53,11 +53,11 @@ namespace LiteCore.Interop
         public static extern bool c4repl_retry(C4Replicator* repl, C4Error* outError);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void c4repl_setHostReachable(C4Replicator* repl, [MarshalAs(UnmanagedType.U1)]bool reachable);
+        public static extern void c4repl_setHostReachable(C4Replicator* repl, [MarshalAs(UnmanagedType.U1)] bool reachable);
 
         public static void c4repl_setOptions(C4Replicator* repl, byte[] optionsDictFleece)
         {
-            fixed(byte *optionsDictFleece_ = optionsDictFleece) {
+            fixed (byte* optionsDictFleece_ = optionsDictFleece) {
                 NativeRaw.c4repl_setOptions(repl, new FLSlice(optionsDictFleece_, optionsDictFleece == null ? 0 : (ulong)optionsDictFleece.Length));
             }
         }
@@ -67,14 +67,14 @@ namespace LiteCore.Interop
 
         public static byte[] c4repl_getPendingDocIDs(C4Replicator* repl, C4Error* outErr)
         {
-            using(var retVal = NativeRaw.c4repl_getPendingDocIDs(repl, outErr)) {
+            using (var retVal = NativeRaw.c4repl_getPendingDocIDs(repl, outErr)) {
                 return ((FLSlice)retVal).ToArrayFast();
             }
         }
 
         public static bool c4repl_isDocumentPending(C4Replicator* repl, string docID, C4Error* outErr)
         {
-            using(var docID_ = new C4String(docID)) {
+            using (var docID_ = new C4String(docID)) {
                 return NativeRaw.c4repl_isDocumentPending(repl, docID_.AsFLSlice(), outErr);
             }
         }
@@ -83,12 +83,12 @@ namespace LiteCore.Interop
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool c4repl_setProgressLevel(C4Replicator* repl, C4ReplicatorProgressLevel level, C4Error* outErr);
 
-        public static bool c4db_setCookie(C4Database* db, string setCookieHeader, string fromHost, string fromPath, C4Error* outError)
+        public static bool c4db_setCookie(C4Database* db, string setCookieHeader, string fromHost, string fromPath, bool acceptParentDomainCookie, C4Error* outError)
         {
             using(var setCookieHeader_ = new C4String(setCookieHeader))
             using(var fromHost_ = new C4String(fromHost))
             using(var fromPath_ = new C4String(fromPath)) {
-                return NativeRaw.c4db_setCookie(db, setCookieHeader_.AsFLSlice(), fromHost_.AsFLSlice(), fromPath_.AsFLSlice(), outError);
+                return NativeRaw.c4db_setCookie(db, setCookieHeader_.AsFLSlice(), fromHost_.AsFLSlice(), fromPath_.AsFLSlice(), acceptParentDomainCookie, outError);
             }
         }
 
@@ -120,7 +120,7 @@ namespace LiteCore.Interop
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool c4db_setCookie(C4Database* db, FLSlice setCookieHeader, FLSlice fromHost, FLSlice fromPath, C4Error* outError);
+        public static extern bool c4db_setCookie(C4Database* db, FLSlice setCookieHeader, FLSlice fromHost, FLSlice fromPath, [MarshalAs(UnmanagedType.U1)]bool acceptParentCookieDomain, C4Error* outError);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern FLSliceResult c4db_getCookies(C4Database* db, C4Address request, C4Error* error);


### PR DESCRIPTION
For example, foo.bar.com could set a cookie for all of bar.com, which is normally disallowed for security reasons.