### PR TITLE
maccatalyst: fix dotnet build with a valid SupportedOSPlatformVersion

### DIFF
--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -6,7 +6,7 @@
     <SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">10.15</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">22.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>


### PR DESCRIPTION
Use the same version as the one in the target framework

```
/usr/local/share/dotnet/packs/Microsoft.MacCatalyst.Sdk/16.2.3/tools/msbuild/iOS/Xamarin.Shared.targets(532,3): error : Could not map the Mac Catalyst version 10.15 to a corresponding macOS version. Valid Mac Catalyst versions are: 15.0, 13.3.1, 16.2, 14.3, 15.5, 13.1, 16.0, 14.1, 15.3, 14.6, 13.4, 15.6, 13.2, 14.4, 16.1, 14.2, 15.4, 13.5, 14.7, 15.2, 14.0, 13.3, 14.5 [/Users/andoni/git/couchbase-lite-net/src/Couchbase.Lite/Couchbase.Lite.csproj::TargetFramework=net6.0-maccatalyst14.2]
```