### PR TITLE
Fix up some build related stuff

### DIFF
--- a/src/build/do_build.ps1
+++ b/src/build/do_build.ps1
@@ -22,11 +22,9 @@ Push-Location ..
 Write-Host
 Write-Host *** COPYING NATIVE RESOURCES ***
 Write-Host
-if(-Not (Test-Path "Couchbase.Lite.Support.Apple\iOS\Native")) {
-    New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native
-    New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework
-} 
-
+Remove-Item -Recurse -Force "Couchbase.Lite.Support.Apple\iOS\Native"
+New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native
+New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework
 
 Copy-Item -Force ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\Info.plist Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework
 Copy-Item -Recurse -Force ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\ios-arm64\ Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework

--- a/src/build/do_fetch_litecore.ps1
+++ b/src/build/do_fetch_litecore.ps1
@@ -11,11 +11,11 @@ if($DebugLib) {
     $isDebug = "-d"
 }
 
-c:\python37\python.exe -m venv venv
+python.exe -m venv venv
 venv\Scripts\activate 
 pip3 install GitPython
-c:\python37\python.exe "..\tools\fetch_litecore.py" -v $Variants $isDebug -s $Sha -o .
-venv\Scripts\deactivate
+python.exe "..\tools\fetch_litecore.py" -v $Variants $isDebug -s $Sha -o .
+deactivate
 
 # Process MacOS Library
 if(Test-Path "libLiteCore.dylib"){


### PR DESCRIPTION
Remove hard coded paths to python / deactivate
Remove the LiteCore.xcframework path each time since Windows has such a hard time dealing with overwrites, especially when symbolic links are involved