### PR TITLE
Fix some packaging typos

### DIFF
--- a/packaging/nuget/couchbase-lite-support-ios.nuspec
+++ b/packaging/nuget/couchbase-lite-support-ios.nuspec
@@ -30,16 +30,16 @@
     <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.xml" />
     <file target="build\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\ios.targets" />
-    <file target="build\net6.0-maccatalyst14.2\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
+    <file target="build\net6.0-maccatalyst14.2\LiteCore.xcframework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\*" />
     <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.xml" />
     <file target="build\net6.0-ios14.2\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\ios.targets" />
-    <file target="build\net6.0-ios14.2\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
+    <file target="build\net6.0-ios14.2\LiteCore.xcframework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\*" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.xml" />
     <file target="build\xamarinios\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\ios.targets" />
-    <file target="build\xamarinios\LiteCore.framework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.framework\*" />
+    <file target="build\xamarinios\LiteCore.xcframework" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\*" />
   </files>
 </package>

--- a/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
+++ b/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
@@ -78,10 +78,10 @@ namespace Couchbase.Lite.Info {
 		public static readonly int DefaultReplicatorMaxAttemptsSingleShot = 10;
 
 		/// <summary>
-		/// Default value for <see cref="ReplicatorConfiguration.MaxAttempts" /> (-1)
+		/// Default value for <see cref="ReplicatorConfiguration.MaxAttempts" /> (Int32.MaxValue)
 		/// When replicator is continuous, never give up unless explicitly stopped
 		/// </summary>
-		public static readonly int DefaultReplicatorMaxAttemptsContinuous = -1;
+		public static readonly int DefaultReplicatorMaxAttemptsContinuous = Int32.MaxValue;
 
 		/// <summary>
 		/// Default value for <see cref="ReplicatorConfiguration.MaxAttemptWaitTime" /> (TimeSpan.FromSeconds(300))

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging</Configurations>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworks>net6.0-android31.0;monoandroid10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0-android31;monoandroid10.0</TargetFrameworks>
     <SupportedOSPlatformVersion>22.0</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.Android</RootNamespace>

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -57,7 +57,7 @@
       <LastGenOutput>DynamicAssemblyInfo.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <ItemGroup Condition=" ($(TargetFramework.StartsWith('net6.0-windows')) and $(Configuration.Contains('Packaging'))) AND '$(JUST_CSHARP)' == '' ">
+  <ItemGroup Condition=" ('$(OS)' == 'Windows_NT' OR $(Configuration.Contains('Packaging'))) AND '$(JUST_CSHARP)' == '' ">
     <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\x64\RelWithDebInfo\LiteCore.dll">
       <Link>x64\LiteCore.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -66,14 +66,14 @@
       <Link>x64\LiteCore.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-	<Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.dll">
-		<Link>arm64\LiteCore.dll</Link>
-		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</Content>
-	<Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.pdb">
-		<Link>arm64\LiteCore.pdb</Link>
-		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.dll">
+      <Link>arm64\LiteCore.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\arm64\RelWithDebInfo\LiteCore.pdb">
+      <Link>arm64\LiteCore.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup Condition=" ($(IsMac) OR $(Configuration.Contains('Packaging'))) AND '$(JUST_CSHARP)' == ''  ">
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\couchbase-lite-core\build_cmake\libLiteCore.dylib">

--- a/src/build/do_build.ps1
+++ b/src/build/do_build.ps1
@@ -2,7 +2,7 @@ Push-Location $PSScriptRoot\..\Couchbase.Lite
 
 $VSInstall = (Get-CimInstance MSFT_VSInstance).InstallLocation
 if(-Not $VSInstall) {
-    throw "Unable to locate VS2019 installation"
+    throw "Unable to locate VS installation"
 }
 
 $MSBuild = "$VSInstall\MSBuild\Current\Bin\MSBuild.exe"


### PR DESCRIPTION
LiteCore.framework -> LiteCore.xcframework
net6.0-android31.0 -> net6.0-android31
Condition for copying LiteCore.dll