### PR TITLE
Fix a test error, UWP csproj missing attribute, and bump LiteCore

### DIFF
--- a/src/Couchbase.Lite.Tests.Android/Properties/AndroidManifest.xml
+++ b/src/Couchbase.Lite.Tests.Android/Properties/AndroidManifest.xml
@@ -2,5 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Couchbase.Lite.Tests.Android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="22" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<application android:label="CBLUnit" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -968,7 +968,7 @@ namespace Test
 
         private int GetEADDRINUSECode()
         {
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || __MOBILE__
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return 100;

--- a/src/Couchbase.Lite.Tests.UWP/Couchbase.Lite.Tests.UWP.csproj
+++ b/src/Couchbase.Lite.Tests.UWP/Couchbase.Lite.Tests.UWP.csproj
@@ -18,6 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
     <PackageCertificateThumbprint>7F4D4ACD5A47468C940B6D069ABAF1628459B4B2</PackageCertificateThumbprint>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
LiteCore 3.1.0-341
Need to use the non hardcoded version of EADDRINUSE for Xamarin (both iOS and Android define \_\_MOBILE\_\_) UWP somehow is missing the C# latest version attribute (the default is 7.3, which doesn't support some of the testing code)