### PR TITLE
Fix UWP tests crashing when built with .NET Native

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -1420,18 +1420,15 @@ namespace Test
             var config = CreateConfig(false, true, false);
             config.ConflictResolver = new TestConflictResolver((conflict) => {
                 if (resolveCnt == 0) {
-                    Task.Run(() =>
-                    {
-                        using (var d = Db.GetDocument("doc1"))
-                        using (var doc = d.ToMutable()) {
-                            d.GetString("name").Should().Be("Cat");
-                            doc.SetString("name", "Cougar");
-                            Db.Save(doc);
-                            using (var docCheck = Db.GetDocument("doc1")) {
-                                docCheck.GetString("name").Should().Be("Cougar", "Because database save operation was not blocked");
-                            }
+                    using (var d = Db.GetDocument("doc1"))
+                    using (var doc = d.ToMutable()) {
+                        d.GetString("name").Should().Be("Cat");
+                        doc.SetString("name", "Cougar");
+                        Db.Save(doc);
+                        using (var docCheck = Db.GetDocument("doc1")) {
+                            docCheck.GetString("name").Should().Be("Cougar", "Because database save operation was not blocked");
                         }
-                    });
+                    }
                 }
 
                 resolveCnt++;
@@ -1911,29 +1908,6 @@ namespace Test
                 Action badAct = () => replicator.IsDocumentPending("doc1");
                 badAct.Should().Throw<InvalidOperationException>().WithMessage(CouchbaseLiteErrorMessage.DBClosed);
             }
-        }
-
-        [Fact]
-        public void TestForum()
-        {
-            var bucketstring = "anything";
-            var _database = new Database(bucketstring);
-            var targetEndpoint = new URLEndpoint(new Uri("ws://zzz:4984/" + bucketstring));
-            var replConfig = new ReplicatorConfiguration(_database, targetEndpoint);
-            replConfig.ReplicatorType = ReplicatorType.PushAndPull;
-            replConfig.Continuous = true;
-            replConfig.Authenticator = new BasicAuthenticator("user", "password");
-
-            var _replicator = new Replicator(replConfig);
-            _replicator.AddChangeListener((sender, args) =>
-            {
-                if (args.Status.Error != null)
-                {
-                    Console.WriteLine($"Error :: {args.Status.Error}");
-                    _replicator.Stop();
-                }
-            });
-            _replicator.Start();
         }
 
         //end pending doc id tests

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Database.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Database.cs
@@ -65,4 +65,49 @@ namespace LiteCore.Interop
             return true;
         }*/
     }
+
+    internal sealed class CollectionSpec : IDisposable
+    {
+        private C4String _name;
+        private C4String _scope;
+        private bool disposedValue;
+
+        public FLSlice Name => _name.AsFLSlice();
+
+        public FLSlice Scope => _scope.AsFLSlice();
+
+        public CollectionSpec(string scope, string name)
+        {
+            _name = new C4String(name);
+            _scope = new C4String(scope);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue) {
+                _name.Dispose();
+                _scope.Dispose();
+            }
+        }
+
+        public static implicit operator C4CollectionSpec(CollectionSpec c)
+        {
+            return new C4CollectionSpec()
+            {
+                name = c.Name,
+                scope = c.Scope
+            };
+        }
+
+        ~CollectionSpec()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
 }


### PR DESCRIPTION
This is tough to explain, but the lifetime management of the various interop objects was a bit sketchy and somehow, only in .NET Native, this caused push and/or pull filter functions defined by C# to become invalid (GC?  Memory move?) which meant that when LiteCore tried to call them it would get an unrecoverable native exception.  This PR creates a better hierarchy of objects that can have lifetimes tied to their parents.

There was also a few other issues found during this investigation dealing with tests.  The NonBlockingDatabaseOperation test was always throwing an exception and never actually verifying anything (the exception would kill the background thread and go unnoticed) and the "forum" test appears to not actually do anything and so it was removed.