### PR TITLE
Redo Mac Catalyst packaging again

### DIFF
--- a/packaging/nuget/couchbase-lite-support-ios.nuspec
+++ b/packaging/nuget/couchbase-lite-support-ios.nuspec
@@ -29,13 +29,10 @@
     <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.xml" />
-    <file target="build\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\ios.targets" />
-    <file target="build\net6.0-maccatalyst14.2\LiteCore.xcframework\" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\" />
     <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.xml" />
-    <file target="build\net6.0-ios14.2\Couchbase.Lite.Support.iOS.targets" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\ios.targets" />
-    <file target="build\net6.0-ios14.2\LiteCore.xcframework\" src="src\Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\" />
+    <file target="runtimes/ios/native/LiteCore.xcframework.zip" src="vendor\couchbase-lite-core\build_cmake\ios\couchbase-lite-core-ios.zip" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.pdb" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.xml" />

--- a/src/build/do_build.ps1
+++ b/src/build/do_build.ps1
@@ -22,7 +22,8 @@ Push-Location ..
 Write-Host
 Write-Host *** COPYING NATIVE RESOURCES ***
 Write-Host
-Remove-Item -Recurse -Force "Couchbase.Lite.Support.Apple\iOS\Native"
+
+Remove-Item -Recurse -Force "Couchbase.Lite.Support.Apple\iOS\Native\"
 New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native
 New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework
 
@@ -30,16 +31,8 @@ Copy-Item -Force ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframew
 Copy-Item -Recurse -Force ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\ios-arm64\ Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework
 Copy-Item -Recurse -Force ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\ios-arm64_x86_64-simulator\ Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework
 
-# Windows absolutely loses its mind at any notion of symbolic links, so restructure to get rid of them
-$catalystBaseDir = "..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\ios-arm64_x86_64-maccatalyst\LiteCore.framework"
-$catalystDestDir = "Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\ios-arm64_x86_64-maccatalyst\LiteCore.framework"
-New-Item -ItemType Directory Couchbase.Lite.Support.Apple\iOS\Native\LiteCore.xcframework\ios-arm64_x86_64-maccatalyst
-New-Item -ItemType Directory $catalystDestDir
-Copy-Item -Recurse -Force $catalystBaseDir\Versions\A\* $catalystDestDir
-
-if(Test-Path ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\ios-arm64_x86_64-maccatalyst\dSYMs) {
-    Copy-Item -Recurse -Force ..\vendor\couchbase-lite-core\build_cmake\ios\LiteCore.xcframework\ios-arm64_x86_64-maccatalyst\dSYMs $catalystDestDir\..
-}
+# Note that the mac catalyst slice is not copied above, this is on purpose since .NET 6 will directly use a zip file, whereas Xamarin
+# iOS needs an extracted framework to work with (and mac catalyst is not needed)
 
 Write-Host *** BUILDING ***
 Write-Host

--- a/src/build/do_fetch_litecore.ps1
+++ b/src/build/do_fetch_litecore.ps1
@@ -18,21 +18,16 @@ python.exe "..\tools\fetch_litecore.py" -v $Variants $isDebug -s $Sha -o .
 deactivate
 
 # Process MacOS Library
-if(Test-Path "libLiteCore.dylib"){
-	Remove-item "libLiteCore.dylib"
-}
-	
-if(Test-Path "macos/lib/libLiteCore.dylib"){
+if(Test-Path "macos/lib/libLiteCore.dylib") {
+	if(Test-Path "libLiteCore.dylib"){
+		Remove-item "libLiteCore.dylib"
+	}
 	Move-Item "macos/lib/libLiteCore.dylib" .
 	Remove-Item "macos" -Recurse
 }
 
 # Process Linux Libraries
 foreach($arch in @("libLiteCore.so", "libstdc++.so", "libstdc++.so.6", "libicudata.so.71", "libicui18n.so.71", "libicuuc.so.71")) {
-	if(Test-Path $arch){
-		Remove-item $arch
-	}
-	
     if(Test-Path linux\x86_64\lib\$arch){
 	    if($arch -eq 'libicudata.so.71' -Or $arch -eq 'libicui18n.so.71' -Or $arch -eq 'libicuuc.so.71'){
 			$arch1 = $arch.Replace(".71", ".71.1")
@@ -41,20 +36,6 @@ foreach($arch in @("libLiteCore.so", "libstdc++.so", "libstdc++.so.6", "libicuda
 	        Move-Item -Force linux\x86_64\lib\$arch .
 		}
     }
-}
-
-if(Test-Path linux){
-    Remove-Item linux -Recurse
-}
-	
-# Process iOS Library
-if(Test-Path "ios-fat") {
-	Remove-Item "ios-fat" -Recurse
-}
-
-# Process Android Libraries
-if(Test-Path android\lib){
-    Remove-Item android\lib -Recurse
 }
 
 foreach($arch in @("x86", "x86_64", "armeabi-v7a", "arm64-v8a")) {
@@ -68,11 +49,8 @@ foreach($arch in @("x86", "x86_64", "armeabi-v7a", "arm64-v8a")) {
     }
 }
 
-# Process Windows Libraries
-foreach($arch in @("x64", "x64_store", "arm64_store")) {
-	if(Test-Path $arch){
-		Remove-item $arch -Recurse
-	}
+if(Test-Path linux){
+    Remove-Item linux -Recurse
 }
 
 if(Test-Path "windows/arm64-store/bin"){


### PR DESCRIPTION
There is no way to sanely package an xcframework for mac inside of a nuget package EXCEPT to include it directly as a zip (see https://github.com/NuGet/Home/issues/10734 )

So now the process when building the product is to:

1. Download the LiteCore.xcframework zip
2. Extract it, and leave the zip in place
3. Copy ONLY the ios sim and ios devices slice into the package for Xamarin iOS
4. Copy the zip into the runtimes/ios/native portion of the package so that .NET 6 iOS and Mac Catalyst will consume it