### PR TITLE
CBL-4289: Don't skip waiting for pending conflict tasks

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/P2PTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/P2PTest.cs
@@ -410,30 +410,12 @@ namespace Test
                 config.AddCollection(colADb);
 
                 RunReplication(config, 0, 0);
-                bool retry = false;
-                int retryCount = 0;
-                do {
-                    // Do a retry loop because there is some sort of race, but it most likely
-                    // lies in the Mock Server implementation.  The funny part is that this never
-                    // seems to actually loop, but rather its mere presence seems to cause the test
-                    // to consistently pass.  Also note, only seems to have this race issue with
-                    // UWP .NET Native.
-                    retry = false;
-                    try {
-                        // Check docs are replicated between collections colADb & colAOtherDb
-                        colAOtherDb.GetDocument("doc").GetString("str").Should().Be("string");
-                        colAOtherDb.GetDocument("doc1").GetString("str1").Should().Be("string1");
-                        colADb.GetDocument("doc2").GetString("str2").Should().Be("string2");
-                        colADb.GetDocument("doc3").GetString("str3").Should().Be("string3");
-                    } catch(Exception) {
-                        if(retryCount ++ == 5) {
-                            throw;
-                        }
 
-                        Thread.Sleep(200);
-                        retry = true;
-                    }
-                } while (retry);
+                // Check docs are replicated between collections colADb & colAOtherDb
+                colAOtherDb.GetDocument("doc").GetString("str").Should().Be("string");
+                colAOtherDb.GetDocument("doc1").GetString("str1").Should().Be("string1");
+                colADb.GetDocument("doc2").GetString("str2").Should().Be("string2");
+                colADb.GetDocument("doc3").GetString("str3").Should().Be("string3");
             }
         }
 


### PR DESCRIPTION
Previous code used to skip the conflict task check if there was no recorded error.  This seems like a meaningless check, so remove it and always check.  Also add the proper task into the conflict tasks list.  Previously the "continue with" tasks was being added, but the actual work task was being removed, which means the list would grow forever (full of completed tasks).