### PR TITLE
CBL-4421: Properly freeze collection configuration after used in Replicator

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/CollectionConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/CollectionConfiguration.cs
@@ -120,7 +120,7 @@ namespace Couchbase.Lite.Sync
         internal ReplicatorType ReplicatorType
         {
             get => _replicatorType;
-            set => _freezer.SetValue(ref _replicatorType, value);
+            set => _replicatorType = value;
         }
 
         [NotNull]

--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
@@ -527,8 +527,9 @@ namespace Couchbase.Lite.Sync
         [NotNull]
         internal ReplicatorConfiguration Freeze()
         {
+            var frozenConfigs = new Dictionary<Collection, CollectionConfiguration>();
             foreach (var cc in CollectionConfigs) {
-                cc.Value.Freeze();
+                frozenConfigs[cc.Key] = cc.Value.Freeze();
             }
 
             var retVal = new ReplicatorConfiguration(Target)
@@ -540,7 +541,7 @@ namespace Couchbase.Lite.Sync
                 Continuous = Continuous,
                 ReplicatorType = ReplicatorType,
                 Options = Options,
-                CollectionConfigs = CollectionConfigs
+                CollectionConfigs = frozenConfigs
             };
 
             retVal._freezer.Freeze("Cannot modify a ReplicatorConfiguration that is in use");


### PR DESCRIPTION
The old implementation mistakenly believed that calling `Freeze()` was enough, but that method returns a frozen copy, and doesn't modify in place.