### PR TITLE
CBL-4419: Live queries built using DataSource.Collection don't get added to Database Stoppable list

### DIFF
--- a/src/Couchbase.Lite.Shared/Query/DatabaseSource.cs
+++ b/src/Couchbase.Lite.Shared/Query/DatabaseSource.cs
@@ -41,6 +41,7 @@ namespace Couchbase.Lite.Internal.Query
         private string _as;
         private string _collection;
         private string _scope;
+        private bool _legacyColumn;
 
         #endregion
 
@@ -53,11 +54,9 @@ namespace Couchbase.Lite.Internal.Query
                     return _as;
                 }
 
-                return Database?.Name;
+                return _legacyColumn ? Collection?.Database?.Name : null;
             }
         }
-
-        internal Database Database => Source as Database;
 
         internal Collection Collection => Source as Collection;
 
@@ -72,9 +71,10 @@ namespace Couchbase.Lite.Internal.Query
             _scope = collection.Scope.Name;
         }
 
-        internal DatabaseSource([NotNull]Database database, [NotNull]ThreadSafety threadSafety) : base(database, threadSafety)
+        internal DatabaseSource([NotNull]Database database, [NotNull]ThreadSafety threadSafety)
+            : this(database?.GetDefaultCollection(), threadSafety)
         {
-            Debug.Assert(database != null);
+            _legacyColumn = true;
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Query/From.cs
+++ b/src/Couchbase.Lite.Shared/Query/From.cs
@@ -44,7 +44,6 @@ namespace Couchbase.Lite.Internal.Query
             Copy(query);
 
             FromImpl = impl as QueryDataSource;
-            Database = (impl as DatabaseSource)?.Database;
             Collection = (impl as DatabaseSource)?.Collection;
         }
 

--- a/src/Couchbase.Lite.Shared/Query/QueryBase.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryBase.cs
@@ -93,7 +93,7 @@ namespace Couchbase.Lite.Internal.Query
 
         public void Stop()
         {
-            Database?.RemoveActiveStoppable(this);
+            Collection?.Database?.RemoveActiveStoppable(this);
             foreach (var t in _listenerTokens) {
                 var token = t.Key;
                 var querier = t.Value;
@@ -164,7 +164,7 @@ namespace Couchbase.Lite.Internal.Query
             _disposalWatchdog.CheckDisposed();
 
             if (Interlocked.Increment(ref _observingCount) == 1) {
-                Database?.AddActiveStoppable(this);
+                Collection?.Database?.AddActiveStoppable(this);
             }
 
             var cbHandler = new CouchbaseEventHandler<QueryChangedEventArgs>(handler, scheduler);

--- a/src/Couchbase.Lite.Shared/Query/QueryResultSet.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryResultSet.cs
@@ -54,8 +54,6 @@ namespace Couchbase.Lite.Internal.Query
 
         internal IDictionary<string, int> ColumnNames { get; }
 
-        internal Database Database => _query?.Database;
-
         internal Collection Collection => _query?.Collection;
 
         internal Result this[int index]

--- a/src/Couchbase.Lite.Shared/Query/XQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/XQuery.cs
@@ -96,12 +96,11 @@ namespace Couchbase.Lite.Internal.Query
 
         public override unsafe IResultSet Execute()
         {
-            if (Database == null && Collection == null) {
+            if (Collection == null) {
                 throw new InvalidOperationException(CouchbaseLiteErrorMessage.InvalidQueryDBNull);
             }
 
-            if (Database == null)
-                Database = Collection.Database;
+            Database = Collection.Database;
 
             var fromImpl = FromImpl;
             if (SelectImpl == null || fromImpl == null) {

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -2330,7 +2330,7 @@ namespace Test
                     Expression.Property("timestamp").EqualTo(Expression.Date(dto1))
                 )) {
                 resultset = (QueryResultSet)query.Execute();
-                resultset.Database.Should().Be(Db);
+                resultset.Collection.Should().Be(DefaultCollection); 
                 List<Result> allRes = resultset.AllResults();
                 allRes.Count.Should().Be(1);
                 var columnName = resultset.ColumnNames;


### PR DESCRIPTION
The heart of the problem was the methods to add and remove active stoppables in QueryBase.  In the case of DataSource.Collection, the Database property will be null and so this logic was silently skipped.