### PR TITLE
CBL-4427: Correct an error with disposing the default collection

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -315,7 +315,7 @@ namespace Couchbase.Lite.Sync
         [NotNull]
         public IImmutableSet<string> GetPendingDocumentIDs()
         {
-            return GetPendingDocumentIDs(Config.Database.DefaultCollection);
+            return GetPendingDocumentIDs(Config.Database.GetDefaultCollection());
         }
 
         /// <summary>
@@ -330,7 +330,7 @@ namespace Couchbase.Lite.Sync
         [Obsolete("IsDocumentPending(string documentID) is deprecated, please use IsDocumentPending(string documentID, Collection collection)")]
         public bool IsDocumentPending([NotNull]string documentID)
         {
-            return IsDocumentPending(documentID, Config.Database.DefaultCollection);
+            return IsDocumentPending(documentID, Config.Database.GetDefaultCollection());
         }
 
         /// <summary>

--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
@@ -370,7 +370,7 @@ namespace Couchbase.Lite.Sync
         public IReadOnlyList<Collection> Collections => CollectionConfigs.Keys.ToList();
 
         //Pre 3.1 Default Collection Config
-        internal CollectionConfiguration DefaultCollectionConfig => CollectionConfigs.ContainsKey(Database?.DefaultCollection) ? CollectionConfigs[Database.DefaultCollection] 
+        internal CollectionConfiguration DefaultCollectionConfig => CollectionConfigs.ContainsKey(Database?.GetDefaultCollection()) ? CollectionConfigs[Database.GetDefaultCollection()] 
             : throw new InvalidOperationException("Cannot operate on a missing Default Collection Configuration. Please AddCollection(Database.DefaultCollection, CollectionConfiguration).");
 
         internal IDictionary<Collection, CollectionConfiguration> CollectionConfigs { get; set; } = new Dictionary<Collection, CollectionConfiguration>();
@@ -441,7 +441,7 @@ namespace Couchbase.Lite.Sync
             :this(target)
         {
             CBDebug.MustNotBeNull(WriteLog.To.Sync, Tag, nameof(database), database);
-            AddCollection(database.DefaultCollection);
+            AddCollection(database.GetDefaultCollection());
         }
 
         #endregion

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -848,6 +848,29 @@ namespace Test
 
         #endregion
 
+        [Fact]
+        public void TestDisposingDefaultScopeCollection()
+        {
+            // This is advised against, but need to make sure nothing too bad happens.
+            // Previously, if the caller disposed the result of GetDefaultCollection, 
+            // further calls returned null with no recourse other than re-opening the db
+            var scope = Db.GetDefaultScope();
+            var collection = scope.CreateCollection("foo");
+            var defaultCollection = Db.GetDefaultCollection();
+
+            scope.Dispose();
+            collection.Dispose();
+            defaultCollection.Dispose();
+
+            scope = Db.GetDefaultScope();
+            collection = scope.GetCollection("foo");
+            collection.IsValid.Should().BeTrue("because it still exists in LiteCore");
+            defaultCollection = Db.GetDefaultCollection();
+            defaultCollection.Should().NotBeNull("because a new object should be created");
+            defaultCollection.IsValid.Should().BeTrue("because the new created object should be valid");
+            defaultCollection.Count.Should().Be(0);
+        }
+
         #region Private Methods
 
         private void TestGetScopesOrCollections(Action dbDispose)

--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
@@ -79,8 +79,8 @@ namespace Test
         public void TestCreateConfigWithDatabase()
         {
             var config = new ReplicatorConfiguration(Db, new DatabaseEndpoint(OtherDb));
-            config.Collections.Should().Contain(Db.DefaultCollection, "Because Default collection configuration with default collection is created with ReplicatorConfiguration init.");
-            var collConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            config.Collections.Should().Contain(Db.GetDefaultCollection(), "Because Default collection configuration with default collection is created with ReplicatorConfiguration init.");
+            var collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             collConfig.GetType().Should().Be(typeof(CollectionConfiguration));
             collConfig.Equals(config.DefaultCollectionConfig).Should().BeTrue();
             collConfig.ConflictResolver.Should().Be(ConflictResolver.Default);
@@ -101,7 +101,7 @@ namespace Test
                 ConflictResolver = new FakeConflictResolver()
             });
 
-            var collConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            var collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             collConfig.ConflictResolver.Should().Be(config.ConflictResolver);
         }
 
@@ -110,14 +110,14 @@ namespace Test
         public void TestUpdateConflictResolverForDefaultCollection()
         {
             var config = new ReplicatorConfiguration(Db, new DatabaseEndpoint(OtherDb)) { ConflictResolver = new FakeConflictResolver() };
-            var collConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            var collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             collConfig.ConflictResolver.Should().Be(config.ConflictResolver);
             config.ConflictResolver = new TestConflictResolver((conflict) => { return conflict.LocalDocument; });
-            collConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             collConfig.ConflictResolver.Should().Be(config.ConflictResolver);
             collConfig.ConflictResolver = new FakeConflictResolver();
-            config.AddCollection(Db.DefaultCollection, collConfig);
-            collConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            config.AddCollection(Db.GetDefaultCollection(), collConfig);
+            collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             collConfig.ConflictResolver.Should().Be(config.ConflictResolver);
         }
 
@@ -134,7 +134,7 @@ namespace Test
                 PushFilter = _replicator__filterCallbackTrue
             };
 
-            var defaultCollConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            var defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             defaultCollConfig.Channels.Should().BeSameAs(config.Channels);
             defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
             defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
@@ -155,7 +155,7 @@ namespace Test
                 PushFilter = _replicator__filterCallbackTrue
             };
 
-            var defaultCollConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            var defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             defaultCollConfig.Channels.Should().BeSameAs(config.Channels);
             defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
             defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
@@ -168,7 +168,7 @@ namespace Test
             config.PullFilter = _replicator__filterCallbackFalse;
             config.PushFilter = _replicator__filterCallbackFalse;
 
-            defaultCollConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             defaultCollConfig.Channels.Should().BeSameAs(config.Channels);
             defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
             defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
@@ -181,9 +181,9 @@ namespace Test
             defaultCollConfig.PullFilter = _replicator__filterCallbackTrue;
             defaultCollConfig.PushFilter = _replicator__filterCallbackTrue;
 
-            config.AddCollection(Db.DefaultCollection, defaultCollConfig);
+            config.AddCollection(Db.GetDefaultCollection(), defaultCollConfig);
 
-            defaultCollConfig = config.GetCollectionConfig(Db.DefaultCollection);
+            defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
             defaultCollConfig.Channels.Should().BeSameAs(config.Channels);
             defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
             defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
@@ -948,7 +948,7 @@ namespace Test
 
             config.AddCollections(new List<Collection>() { colA, colB });
 
-            var defaultCollection = Db.DefaultCollection;
+            var defaultCollection = Db.GetDefaultCollection();
 
             // set the outer filters after adding default collection
             config.AddCollection(defaultCollection);
@@ -972,7 +972,7 @@ namespace Test
         public void TestUpdateCollectionConfigWithDefault()
         {
             var colA = Db.CreateCollection("colA", "scopeA");
-            var defaultCollection = Db.DefaultCollection;
+            var defaultCollection = Db.GetDefaultCollection();
 
             var targetEndpoint = new URLEndpoint(new Uri("wss://foo:4984/"));
             var replConfig = new ReplicatorConfiguration(targetEndpoint);


### PR DESCRIPTION
GetDefaultCollection will now return a new object if it detects that the previously stored one has been invalidated by a dispose

This is ported from 0b179984e03cb43be5af6efa50af8ca7745443e7 via cherry pick plus extra changes (removing a redundant variable and its usage.  The change was too large for the release branch)