### PR TITLE
CBL-4505: Add attributes to iOS proxy unmanaged delegates

### DIFF
--- a/src/Couchbase.Lite.Shared/Support/iOS/IOSProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/IOSProxy.cs
@@ -160,8 +160,10 @@ namespace Couchbase.Lite.Support
             return GetDelegate<CFNetworkCopyProxiesForURL>(cFNetworkHandle)(url, proxySettings);
         }
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate /* CFDictionaryRef __nullable */ IntPtr CFNetworkCopySystemProxySettings();
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate /* CFArrayRef __nonnull */ IntPtr CFNetworkCopyProxiesForURL(/* CFURLRef __nonnull */ IntPtr url, /* CFDictionaryRef __nonnull */ IntPtr proxySettings);
 
         [DllImport(CoreFoundationLibrary)]


### PR DESCRIPTION
Without this, the AOT compiler will not realize them and they will fail at runtime