### PR TITLE
CBL-4481: Only make snupkg for the main nuget package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                                 & 'C:\\Program Files\\Git\\bin\\git.exe' submodule update --init --recursive
                                 Pop-Location
                                 Push-Location jenkins
-                                & 'C:\\Program Files\\Git\\bin\\git.exe' clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 proj
+                                & 'C:\\Program Files\\Git\\bin\\git.exe' clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth --branch pre-3.2 proj
                                 Pop-Location
                                 '''
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                                 & 'C:\\Program Files\\Git\\bin\\git.exe' submodule update --init --recursive
                                 Pop-Location
                                 Push-Location jenkins
-                                & 'C:\\Program Files\\Git\\bin\\git.exe' clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth --branch pre-3.2 proj
+                                & 'C:\\Program Files\\Git\\bin\\git.exe' clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 --branch pre-3.2 proj
                                 Pop-Location
                                 '''
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                                 popd
 
                                 pushd jenkins
-                                git clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 proj
+                                git clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 --branch pre-3.2 proj
                                 popd
                                 '''
                             }

--- a/packaging/nuget/do_package.ps1
+++ b/packaging/nuget/do_package.ps1
@@ -24,9 +24,13 @@ if($env:WORKSPACE) {
     Copy-Item "$env:WORKSPACE\product-texts\mobile\couchbase-lite\license\LICENSE_community.txt" "$PSScriptRoot\LICENSE.txt"
 }
 
-Get-ChildItem "." -Filter *.nuspec |
+# Only do snupkg for the main package, since the support ones can contain 
+# native pdb which will be rejected by nuget.org
+..\..\nuget.exe pack couchbase-lite.nuspec -Properties version=$env:NUGET_VERSION -BasePath ..\..\ -Symbols -SymbolPackageFormat snupkg
+
+Get-ChildItem "." -Filter *support*.nuspec |
 ForEach-Object {
-    ..\..\nuget.exe pack $_.Name -Properties version=$env:NUGET_VERSION -BasePath ..\..\ -Symbols -SymbolPackageFormat snupkg
+    ..\..\nuget.exe pack $_.Name -Properties version=$env:NUGET_VERSION -BasePath ..\..\
     if($LASTEXITCODE) {
         Pop-Location
         throw "Failed to package $_"

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -22,7 +22,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <DebugType Condition=" !$(TargetFramework.StartsWith('uap')) and !$(TargetFramework.StartsWith('net6.0-windows')) ">portable</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>True</DebugSymbols>
 	<LangVersion Condition=" $(TargetFramework.StartsWith('net6')) ">9.0</LangVersion>
   </PropertyGroup>
@@ -41,7 +41,6 @@
     <DefineConstants>TRACE;RELEASE;LITECORE_PACKAGED</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap')) or $(TargetFramework.StartsWith('net6.0-windows')) ">
-    <DebugType>pdbonly</DebugType>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Coverage|AnyCPU'">


### PR DESCRIPTION
Many others have native pdb which confuse nuget.org and cause the package to be rejected.  In the same spirit, change all Couchbase.Lite pdb to be portable.