### PR TITLE
CBL-4528: Correctly pass parameters for SQL++ query

### DIFF
--- a/src/Couchbase.Lite.Shared/Query/NQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/NQuery.cs
@@ -56,6 +56,7 @@ namespace Couchbase.Lite.Internal.Query
             }
 
             var options = C4QueryOptions.Default;
+            var paramJson = Parameters.FLEncode();
             var e = (C4QueryEnumerator*)ThreadSafety.DoLockedBridge(err =>
             {
                 if (_disposalWatchdog.IsDisposed) {
@@ -63,7 +64,7 @@ namespace Couchbase.Lite.Internal.Query
                 }
 
                 var localOpts = options;
-                return NativeRaw.c4query_run(_c4Query, &localOpts, FLSlice.Null, err);
+                return NativeRaw.c4query_run(_c4Query, &localOpts, (FLSlice)paramJson, err);
             });
 
             if (e == null) {

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -268,7 +268,7 @@ namespace Test
             WriteLog.To.Database.W("TEST", "TEST WARNING");
             WriteLog.To.Database.E("TEST", "TEST ERROR");
             stringWriter.Flush();
-            stringWriter.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Should()
+            stringWriter.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Should()
                 .HaveCount(4, "because all levels should be logged");
 
             var currentCount = 1;
@@ -282,7 +282,7 @@ namespace Test
                 WriteLog.To.Database.W("TEST", "TEST WARNING");
                 WriteLog.To.Database.E("TEST", "TEST ERROR");
                 stringWriter.Flush();
-                stringWriter.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Should()
+                stringWriter.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Should()
                     .HaveCount(currentCount, "because {0} levels should be logged for {1}", currentCount, level);
                 currentCount++;
             }

--- a/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PredictiveQueryTest.cs
@@ -1076,8 +1076,8 @@ namespace Test
             ContentType = blob.ContentType;
 
             var text = Encoding.UTF8.GetString(blob.Content);
-            var wc = text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-            var sc = text.Split('.', StringSplitOptions.RemoveEmptyEntries).Length;
+            var wc = text.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Length;
+            var sc = text.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Length;
 
             var output = new MutableDictionaryObject();
             output.SetInt("wc", wc);


### PR DESCRIPTION
The changes needed are in NQuery.cs and a test was updated to include this in QueryTest.cs.  The other two changes are needed because otherwise .NET 4.6.2 fails to build correctly.