### PR TITLE
CBL-4433: Defer replicator cleanup until stop

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -2041,6 +2041,25 @@ namespace Test
             }
         }
 
+        [Fact]
+        public void TestDisposeRunningReplicator()
+        {
+            var config = CreateConfig(true, false, true);
+            var replicator = new Replicator(config);
+            var stoppedWait = new ManualResetEventSlim();
+            replicator.AddChangeListener((sender, args) =>
+            {
+                if(args.Status.Activity == ReplicatorActivityLevel.Stopped) {
+                    stoppedWait.Set();
+                }
+            });
+            replicator.Start();
+
+            Thread.Sleep(500);
+            replicator.Dispose();
+            stoppedWait.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("because otherwise the replicator didn't stop");
+        }
+
         //end pending doc id tests
 
         /*


### PR DESCRIPTION
This basically makes disposal a tri-state process:

1. If dispose is called, then set the state to disposing 2a. If the replicator is stopped, set the state to disposed and perform cleanup 2b. If the replicator is not stopped, call stop and wait for the stopped callback
3. If stopped is called and the state is disposing, perform the cleanup and set the state to disposed