### PR TITLE
CBL-4516 CBL-4527: Remove unneeded deps from project and nuspec

### DIFF
--- a/packaging/nuget/couchbase-lite.nuspec
+++ b/packaging/nuget/couchbase-lite.nuspec
@@ -22,42 +22,32 @@
       <group targetFramework="net6.0">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="System.Collections.Immutable" version="6.0.0" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.NetDesktop" version="[$version$]" />
       </group>
       <group targetFramework="net6.0-windows10.0.19041.0">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="System.Collections.Immutable" version="6.0.0" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.WinUI" version="[$version$]" />
       </group>
       <group targetFramework="net462">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
         <dependency id="System.Collections.Immutable" version="6.0.0" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.NetDesktop" version="[$version$]" />
       </group>
       <group targetFramework="uap10.0.19041">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="System.Collections.Immutable" version="6.0.0" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.UWP" version="[$version$]" />
       </group>
       <group targetFramework="net6.0-android31">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="System.Collections.Immutable" version="6.0.0" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
       </group>
       <group targetFramework="monoandroid10.0">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="System.Collections.Immutable" version="6.0.0" />
         <dependency id="Xamarin.Essentials" version="1.7.4" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
@@ -65,21 +55,16 @@
       <group targetFramework="net6.0-ios14.2">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="System.Collections.Immutable" version="6.0.0" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>
       <group targetFramework="net6.0-maccatalyst14.2">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
-        <dependency id="System.Collections.Immutable" version="6.0.0" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>
       <group targetFramework="xamarinios">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="[5.0.0,6.0.0]" />
         <dependency id="System.Collections.Immutable" version="6.0.0" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -59,10 +59,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SimpleInjector" Version="5.4.0" />
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Condition=" $(TargetFramework.StartsWith('Xamarin')) or $(TargetFramework.StartsWith('MonoAndroid')) or '$(TargetFramework)' == 'net462' or $(TargetFramework.StartsWith('netstandard')) " Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net6.0' ">
     <ProjectReference Include="..\..\src\Couchbase.Lite.Support.NetDesktop\Couchbase.Lite.Support.NetDesktop.csproj" />


### PR DESCRIPTION
System.Collections.Immutable is available without a package on many platforms Microsoft.Bcl.AsyncInterfaces is completely unused Microsoft.Win32.Registry is available everywhere that it is needed, without a package