### PR TITLE
CBL-4585: Fix a regression caused by removing Microsoft.Bcl.AsyncInte…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                                 & 'C:\\Program Files\\Git\\bin\\git.exe' submodule update --init
                                 Pop-Location
                                 Push-Location jenkins
-                                & 'C:\\Program Files\\Git\\bin\\git.exe' clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 proj
+                                & 'C:\\Program Files\\Git\\bin\\git.exe' clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 --branch pre-3.2 proj
                                 Pop-Location
                                 '''
                             }
@@ -81,18 +81,9 @@ pipeline {
 	                            popd
 
 	                            pushd jenkins
-	                            git clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 proj
+	                            git clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 --branch pre-3.2 proj
 	                            popd
 	                            '''
-	                        }
-	                    }
-	                    stage(".NET Core Mac") {
-	                        steps {
-	                            catchError {
-	                                sh 'jenkins/run_unix_tests.sh'
-	                            }
-								
-	                            echo currentBuild.result
 	                        }
 	                    }
 	                    stage("Xamarin iOS") {

--- a/packaging/nuget/couchbase-lite.nuspec
+++ b/packaging/nuget/couchbase-lite.nuspec
@@ -20,32 +20,32 @@
     <dependencies>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Newtonsoft.Json" version="13.0.2" />
-        <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
+        <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
 		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.NetDesktop" version="[$version$]" />
       </group>
       <group targetFramework="net461">
         <dependency id="Newtonsoft.Json" version="13.0.2" />
-        <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
+        <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
 		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.NetDesktop" version="[$version$]" />
       </group>
       <group targetFramework="uap10.0.16299">
         <dependency id="Newtonsoft.Json" version="13.0.2" />
-        <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
+        <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
 		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.UWP" version="[$version$]" />
       </group>
       <group targetFramework="monoandroid10.0">
         <dependency id="Newtonsoft.Json" version="13.0.2" />
-        <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
+        <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
 		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Xamarin.Essentials" version="1.7.4" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
       </group>
       <group targetFramework="xamarinios">
         <dependency id="Newtonsoft.Json" version="13.0.2" />
-        <dependency id="SimpleInjector" version="[5.0.0,6.0.0)" />
+        <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
 		    <dependency id="System.Collections.Immutable" version="1.3.0" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>


### PR DESCRIPTION
…rfaces

This was a botched dependency graph in the minimum version of SimpleInjector that we required.  Bump the minimum to 5.2.1 which is the first GA version that doesn't require that dependency at all anymore.