### PR TITLE
Don't use newer C# features on this branch

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -1041,8 +1041,9 @@ namespace Test
                 validation(q);
             }
 
-            using var q2 = Db.CreateQuery("SELECT number1 FROM _ WHERE number1 BETWEEN $num1 and $num2 ORDER BY number1");
-            validation(q2);
+            using (var q2 = Db.CreateQuery("SELECT number1 FROM _ WHERE number1 BETWEEN $num1 and $num2 ORDER BY number1")) {
+                validation(q2);
+            }
         }
 
         // Verify fix of CBL-1107 Fix bad interpretation of '$' properties


### PR DESCRIPTION
The post build jobs are still set to use C# 7.3.  Eventually update them but not now.