### PR TITLE
CBL-4578: Make IReachability public

### DIFF
--- a/src/Couchbase.Lite.Shared/API/DI/IReachability.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/IReachability.cs
@@ -20,7 +20,7 @@ using Couchbase.Lite.Sync;
 
 namespace Couchbase.Lite.DI
 {
-    internal interface IReachability
+    public interface IReachability
     {
         #region Variables
 

--- a/src/Couchbase.Lite.Shared/API/DI/Service.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/Service.cs
@@ -53,6 +53,8 @@ namespace Couchbase.Lite.DI
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         static Service()
         {
+            _Collection.Options.AllowOverridingRegistrations = true;
+
             // Windows 2012 doesn't define NETFRAMEWORK for some reason
             #if (NET6_0_OR_GREATER || NETFRAMEWORK || NET462) && !NET6_0_WINDOWS10_0_19041_0 && !__MOBILE__
             AutoRegister(typeof(Database).GetTypeInfo().Assembly);

--- a/src/Couchbase.Lite.Shared/Sync/Reachability.cs
+++ b/src/Couchbase.Lite.Shared/Sync/Reachability.cs
@@ -26,14 +26,14 @@ using Couchbase.Lite.Logging;
 
 namespace Couchbase.Lite.Sync
 {
-    internal enum NetworkReachabilityStatus
+    public enum NetworkReachabilityStatus
     {
         Unknown,
         Reachable,
         Unreachable
     }
 
-    internal sealed class NetworkReachabilityChangeEventArgs : EventArgs
+    public sealed class NetworkReachabilityChangeEventArgs : EventArgs
     {
         #region Properties
 


### PR DESCRIPTION
This won't have any bearing on most users, but in rare cases they may want to provide their own reachability logic in guided support cases