### PR TITLE
Add in custom xunit test framework and config

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
+++ b/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ArrayTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BlobTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConcurrencyTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CouchbaseTestFramework.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CSharpTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DatabaseEncryptionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DatabaseTest.cs" />
@@ -44,6 +45,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Util\WaitAssert.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\XunitLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WebSocketTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)C\tests\data\*.*">

--- a/src/Couchbase.Lite.Tests.Shared/CouchbaseTestFramework.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CouchbaseTestFramework.cs
@@ -1,0 +1,148 @@
+﻿#if !WINDOWS_UWP
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Test
+{
+    // The final level after all the factories (to read this file, start at the bottom)
+    // in which a single test is ready for execution, and any final processing is done.
+    // We use this opportunity to log some messages (notably that the test started) for 
+    // diagnostic purposes.
+    internal sealed class CouchbaseTestMethodRunner : XunitTestMethodRunner
+    {
+        private readonly IMessageSink _diagnosticSink;
+
+        public CouchbaseTestMethodRunner(ITestMethod method, IReflectionTypeInfo classInfo, IReflectionMethodInfo methodInfo,
+            IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticSink, IMessageBus messageBus, ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource, object[] constructorArgs)
+            : base(method, classInfo, methodInfo, testCases, diagnosticSink, messageBus, aggregator, cancellationTokenSource, constructorArgs)
+        {
+            _diagnosticSink = diagnosticSink;
+        }
+
+        protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+        {
+            _diagnosticSink.OnMessage(new DiagnosticMessage($"Starting {testCase.TestMethod.Method.Name}..."));
+
+            try {
+                var result = await base.RunTestCaseAsync(testCase);
+                var status = result.Failed > 0 ? "FAIL" : "PASS";
+                _diagnosticSink.OnMessage(new DiagnosticMessage($"[{status}] {testCase.TestMethod.Method.Name}"));
+                return result;
+            } catch (Exception e) {
+                _diagnosticSink.OnMessage(new DiagnosticMessage($"[ERROR] {testCase.TestMethod.Method.Name}"));
+                _diagnosticSink.OnMessage(new DiagnosticMessage(e.ToString()));
+                throw;
+            }
+        }
+    }
+
+    // Factory level 5, in which the discovered tests in a given class are grouped by test method name
+    // and processed before being sent to the final level.  Unless there are variations in the passed
+    // arguments for a test (aka Theory) this probably will only result in one test being sent on.  We 
+    // do no processing at the moment.
+    internal sealed class CouchbaseTestClassRunner : XunitTestClassRunner
+    {
+        public CouchbaseTestClassRunner(ITestClass testClass, IReflectionTypeInfo classInfo, IEnumerable<IXunitTestCase> testCases, 
+            IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, 
+            CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings)
+            : base(testClass, classInfo, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+        {
+
+        }
+
+        protected override Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, 
+            object[] constructorArguments)
+        {
+            var methodRunner = new CouchbaseTestMethodRunner(testMethod, Class, method, testCases, DiagnosticMessageSink, MessageBus, Aggregator,
+                CancellationTokenSource, constructorArguments);
+            return methodRunner.RunAsync();
+        }
+    }
+
+    // Factory level 4, in which the discovered tests in a given collection are grouped by test class name
+    // and processed before being sent onto level 5 (we do no processing at the moment)
+    internal sealed class CouchbaseTestCollectionRunner : XunitTestCollectionRunner
+    {
+        public CouchbaseTestCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, 
+            IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+        {
+
+        }
+
+        protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+        {
+            DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Starting class {testClass.Class.Name}..."));
+            var classRunner = new CouchbaseTestClassRunner(testClass, @class, testCases, DiagnosticMessageSink, MessageBus, TestCaseOrderer,
+                Aggregator, CancellationTokenSource, CollectionFixtureMappings);
+            return classRunner.RunAsync().ContinueWith(t =>
+            {
+                DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Finished class {testClass.Class.Name}..."));
+                return t.Result;
+            });
+        }
+    }
+
+    // Factory level 3, in which the discovered tests are grouped by collection and each collection processed
+    // before being sent onto level 4 (we do no processing at the moment)
+    internal sealed class CouchbaseAssemblyRunner : XunitTestAssemblyRunner
+    {
+        public CouchbaseAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, 
+            IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+            : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+        {
+        }
+
+        protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, 
+            IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
+        {
+            var collectionRunner = new CouchbaseTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer,
+                Aggregator, cancellationTokenSource);
+            return collectionRunner.RunAsync();
+        }
+    }
+
+    // Factory level 2, in which all the discovered test cases in a given assembly are processed
+    // before being sent onto level 3 (we do no processing at the moment, just sent them on as-is)
+    internal sealed class CouchbaseExecutor : XunitTestFrameworkExecutor
+    {
+        public CouchbaseExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink messageSink)
+            : base(assemblyName, sourceInformationProvider, messageSink)
+        {
+            
+        }
+
+        protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+        {
+            using var assemblyRunner = new CouchbaseAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions);
+            await assemblyRunner.RunAsync();
+        }
+    }
+
+    // This is where we start injecting custom behavior into Xunit.  It is the factory
+    // that starts the chain of factories all the way down to the exact method invocation
+    // to use for each test.  Each assembly to be processed by Xunit will be sent to level 2.
+    public sealed class CouchbaseTestFramework : XunitTestFramework
+    {
+        public CouchbaseTestFramework(IMessageSink messageSink)
+           : base(messageSink)
+        {
+            messageSink.OnMessage(new DiagnosticMessage("Using CouchbaseTestFramework..."));
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            return new CouchbaseExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+        }
+    }
+}
+
+#endif

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -688,7 +688,7 @@ namespace Test
             var repl1 = new Replicator(config1);
 
             Database.Delete("urlepTestDb", Directory);
-            var urlepTestDb = OpenDB("urlepTestDb");
+            using var urlepTestDb = OpenDB("urlepTestDb");
             using (var doc2 = new MutableDocument()) {
                 urlepTestDb.GetDefaultCollection().Save(doc2);
             }
@@ -1067,7 +1067,7 @@ namespace Test
             var repl1 = new Replicator(config1);
 
             Database.Delete("urlepTestDb", Directory);
-            var urlepTestDb = OpenDB("urlepTestDb");
+            using var urlepTestDb = OpenDB("urlepTestDb");
             using (var doc2 = new MutableDocument()) {
                 urlepTestDb.GetDefaultCollection().Save(doc2);
             }
@@ -1149,7 +1149,7 @@ namespace Test
             var repl1 = new Replicator(config1);
 
             Database.Delete("urlepTestDb", Directory);
-            var urlepTestDb = OpenDB("urlepTestDb");
+            using var urlepTestDb = OpenDB("urlepTestDb");
             using (var doc2 = new MutableDocument()) {
                 urlepTestDb.GetDefaultCollection().Save(doc2);
             }

--- a/src/Couchbase.Lite.Tests.Shared/xunit.runner.json
+++ b/src/Couchbase.Lite.Tests.Shared/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "diagnosticMessages": true,
+    "longRunningTestSeconds": 10
+}


### PR DESCRIPTION
To try to get more information during test runs about tests that are long running, etc.  Prepare for more functionality at a later date.