### PR TITLE
CBL-4613: Upgrade .NET non-windows to .NET 7

### DIFF
--- a/packaging/nuget/couchbase-lite-support-android.nuspec
+++ b/packaging/nuget/couchbase-lite-support-android.nuspec
@@ -18,17 +18,17 @@
     <tags>couchbase couchbase-mobile couchbase-lite sync database mobile netcore xamarin ios android windows linux mac osx nosql</tags>
     <language>en-US</language>
     <dependencies>
-      <group targetFramework="net6.0-android31" />
+      <group targetFramework="net7.0-android33" />
       <group targetFramework="monoandroid10.0" />
     </dependencies>
   </metadata>
   <files>
     <file target="" src="packaging\nuget\LICENSE.txt" />
     <file target="logo.png" src="packaging\nuget\logo.png" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.dll" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.pdb" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.xml" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net6.0-android31\Couchbase.Lite.Support.Android.aar" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net7.0-android33\Couchbase.Lite.Support.Android.dll" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net7.0-android33\Couchbase.Lite.Support.Android.pdb" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net7.0-android33\Couchbase.Lite.Support.Android.xml" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\net7.0-android33\Couchbase.Lite.Support.Android.aar" />
     <file target="lib\monoandroid10.0\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\monoandroid10.0\Couchbase.Lite.Support.Android.dll" />
     <file target="lib\monoandroid10.0\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\monoandroid10.0\Couchbase.Lite.Support.Android.pdb" />
     <file target="lib\monoandroid10.0\" src="src\Couchbase.Lite.Support.Android\bin\Packaging\monoandroid10.0\Couchbase.Lite.Support.Android.xml" />

--- a/packaging/nuget/couchbase-lite-support-ios.nuspec
+++ b/packaging/nuget/couchbase-lite-support-ios.nuspec
@@ -18,20 +18,20 @@
     <tags>couchbase couchbase-mobile couchbase-lite sync database mobile netcore xamarin ios android windows linux mac osx nosql</tags>
     <language>en-US</language>
     <dependencies>
-      <group targetFramework="net6.0-maccatalyst14.2" />
-      <group targetFramework="net6.0-ios14.2" />
+      <group targetFramework="net7.0-maccatalyst14.2" />
+      <group targetFramework="net7.0-ios14.2" />
       <group targetFramework="xamarinios" />
     </dependencies>
   </metadata>
   <files>
     <file target="" src="packaging\nuget\LICENSE.txt" />
     <file target="logo.png" src="packaging\nuget\logo.png" />
-    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.dll" />
-    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.pdb" />
-    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.xml" />
-    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.dll" />
-    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.pdb" />
-    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.Support.iOS.xml" />
+    <file target="lib\net7.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net7.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.dll" />
+    <file target="lib\net7.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net7.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.pdb" />
+    <file target="lib\net7.0-maccatalyst14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net7.0-maccatalyst14.2\Couchbase.Lite.Support.iOS.xml" />
+    <file target="lib\net7.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net7.0-ios14.2\Couchbase.Lite.Support.iOS.dll" />
+    <file target="lib\net7.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net7.0-ios14.2\Couchbase.Lite.Support.iOS.pdb" />
+    <file target="lib\net7.0-ios14.2\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\net7.0-ios14.2\Couchbase.Lite.Support.iOS.xml" />
     <file target="runtimes/ios/native/LiteCore.xcframework.zip" src="vendor\prebuilt_core\ios\couchbase-lite-core-ios.zip" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.dll" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite.Support.Apple\iOS\bin\Packaging\xamarin.ios10\Couchbase.Lite.Support.iOS.pdb" />

--- a/packaging/nuget/couchbase-lite.nuspec
+++ b/packaging/nuget/couchbase-lite.nuspec
@@ -40,7 +40,7 @@
         <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
         <dependency id="Couchbase.Lite.Support.UWP" version="[$version$]" />
       </group>
-      <group targetFramework="net6.0-android31">
+      <group targetFramework="net7.0-android33">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
@@ -52,12 +52,12 @@
         <dependency id="Xamarin.Essentials" version="1.7.4" />
         <dependency id="Couchbase.Lite.Support.Android" version="[$version$]" />
       </group>
-      <group targetFramework="net6.0-ios14.2">
+      <group targetFramework="net7.0-ios14.2">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
       </group>
-      <group targetFramework="net6.0-maccatalyst14.2">
+      <group targetFramework="net7.0-maccatalyst14.2">
         <dependency id="Newtonsoft.Json" version="13.0.1" />
         <dependency id="SimpleInjector" version="[5.2.1,6.0.0)" />
         <dependency id="Couchbase.Lite.Support.iOS" version="[$version$]" />
@@ -82,9 +82,9 @@
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.dll" />
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.pdb" />
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.xml" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android31\Couchbase.Lite.dll" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android31\Couchbase.Lite.pdb" />
-    <file target="lib\net6.0-android31\" src="src\Couchbase.Lite\bin\Packaging\net6.0-android31\Couchbase.Lite.xml" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite\bin\Packaging\net7.0-android33\Couchbase.Lite.dll" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite\bin\Packaging\net7.0-android33\Couchbase.Lite.pdb" />
+    <file target="lib\net7.0-android33\" src="src\Couchbase.Lite\bin\Packaging\net7.0-android33\Couchbase.Lite.xml" />
     <file target="lib\monoandroid10.0\" src="src\Couchbase.Lite\bin\Packaging\monoandroid10.0\Couchbase.Lite.dll" />
     <file target="lib\monoandroid10.0\" src="src\Couchbase.Lite\bin\Packaging\monoandroid10.0\Couchbase.Lite.pdb" />
     <file target="lib\monoandroid10.0\" src="src\Couchbase.Lite\bin\Packaging\monoandroid10.0\Couchbase.Lite.xml" />
@@ -95,12 +95,12 @@
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite\bin\Packaging\uap10.0.19041\Couchbase.Lite.pdb" />
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite\bin\Packaging\uap10.0.19041\Couchbase.Lite.xml" />
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite\bin\Packaging\uap10.0.19041\Couchbase.Lite.pri" />
-    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.dll" />
-    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.pdb" />
-    <file target="lib\net6.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-maccatalyst14.2\Couchbase.Lite.xml" />
-    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.dll" />
-    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.pdb" />
-    <file target="lib\net6.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net6.0-ios14.2\Couchbase.Lite.xml" />
+    <file target="lib\net7.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net7.0-maccatalyst14.2\Couchbase.Lite.dll" />
+    <file target="lib\net7.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net7.0-maccatalyst14.2\Couchbase.Lite.pdb" />
+    <file target="lib\net7.0-maccatalyst14.2\" src="src\Couchbase.Lite\bin\Packaging\net7.0-maccatalyst14.2\Couchbase.Lite.xml" />
+    <file target="lib\net7.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net7.0-ios14.2\Couchbase.Lite.dll" />
+    <file target="lib\net7.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net7.0-ios14.2\Couchbase.Lite.pdb" />
+    <file target="lib\net7.0-ios14.2\" src="src\Couchbase.Lite\bin\Packaging\net7.0-ios14.2\Couchbase.Lite.xml" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite\bin\Packaging\xamarin.ios10\Couchbase.Lite.dll" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite\bin\Packaging\xamarin.ios10\Couchbase.Lite.pdb" />
     <file target="lib\xamarinios\" src="src\Couchbase.Lite\bin\Packaging\xamarin.ios10\Couchbase.Lite.xml" />

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging</Configurations>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworks>net6.0-android31;monoandroid10.0</TargetFrameworks>
+    <TargetFrameworks>net7.0-android33;monoandroid10.0</TargetFrameworks>
     <SupportedOSPlatformVersion>22.0</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.Android</RootNamespace>
@@ -51,8 +51,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Packaging\Couchbase.Lite.Support.Android.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-android'))">
-    <DefineConstants>$(DefineConstants);NET6_0_ANDROID</DefineConstants>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net7.0-android'))">
+    <DefineConstants>$(DefineConstants);NET_ANDROID</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Couchbase.Lite\Properties\DynamicAssemblyInfo.cs">

--- a/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
+++ b/src/Couchbase.Lite.Support.Apple/iOS/Couchbase.Lite.Support.iOS.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging</Configurations>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworks>net6.0-ios14.2;net6.0-maccatalyst14.2;Xamarin.iOS10</TargetFrameworks>
-    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+    <TargetFrameworks>net7.0-ios14.2;net7.0-maccatalyst14.2;Xamarin.iOS10</TargetFrameworks>
+    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net7')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Couchbase.Lite.Support.iOS</RootNamespace>
@@ -54,8 +54,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Packaging\Couchbase.Lite.Support.iOS.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-ios')) or $(TargetFramework.StartsWith('net6.0-maccatalyst'))">
-    <DefineConstants>$(DefineConstants);NET6_0_APPLE</DefineConstants>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net7.0-ios')) or $(TargetFramework.StartsWith('net7.0-maccatalyst'))">
+    <DefineConstants>$(DefineConstants);NET_APPLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\..\Couchbase.Lite\Properties\DynamicAssemblyInfo.tt">

--- a/src/Couchbase.Lite.Tests.Shared/BlobTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/BlobTest.cs
@@ -137,7 +137,7 @@ namespace Test
         {
             byte[] bytes = GetFileByteArray("iTunesMusicLibrary.json", typeof(BlobTest));
             C4BlobKey key;
-            #if NET6_0_WINDOWS10 || NET6_0_ANDROID || NET6_0_APPLE
+            #if NET6_0_WINDOWS10 || NET_ANDROID || NET_APPLE
             using (var stream = FileSystem.OpenAppPackageFileAsync("iTunesMusicLibrary.json").Result) {
             #else
             using (var stream = typeof(BlobTest).GetTypeInfo().Assembly

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -61,7 +61,7 @@ namespace Test
 
         public Database Db { get; private set; }
 
-        #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !NET6_0_ANDROID && !__IOS__ && !WINUI
+        #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !NET_ANDROID && !__IOS__ && !WINUI
         static PerfTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -76,7 +76,7 @@ namespace Test
         public X509Certificate2 DefaultServerCert
         {
             get {
-                #if NET6_0_WINDOWS10 || NET6_0_ANDROID || NET6_0_APPLE
+                #if NET6_0_WINDOWS10 || NET_ANDROID || NET_APPLE
                 using (var cert =  FileSystem.OpenAppPackageFileAsync("SelfSigned.cer").Result)
                 #else
                 using (var cert = typeof(ReplicatorTestBase).GetTypeInfo().Assembly.GetManifestResourceStream("SelfSigned.cer"))

--- a/src/Couchbase.Lite.Tests.Shared/TLSIdentityTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TLSIdentityTest.cs
@@ -79,7 +79,7 @@ namespace Test
         }
 
         #region TLSIdentity tests
-        #if !NET6_0_APPLE && !NET6_0_ANDROID
+        #if !NET_APPLE && !NET_ANDROID
         [Fact]
         public void TestCreateGetDeleteServerIdentity() => CreateGetDeleteServerIdentity(true);
 
@@ -117,7 +117,7 @@ namespace Test
         public void TestImportIdentity()
         {
             TLSIdentity id;
-            #if NET6_0_ANDROID
+            #if NET_ANDROID
             //Note: Maui Android cert requirement: https://stackoverflow.com/questions/70100597/read-x509-certificate-in-android-net-6-0-application
             //When export the cert, encryption has to be TripleDES-SHA1, AES256-SHA256 will not work...
             byte[] data = GetFileByteArray("certs.pfx", typeof(TLSIdentityTest));

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -506,7 +506,7 @@ namespace Test
         internal static byte[] GetFileByteArray(string filename, Type type = null)
         {
             byte[] bytes = null;
-            #if NET6_0_WINDOWS10 || NET6_0_ANDROID || NET6_0_APPLE
+            #if NET6_0_WINDOWS10 || NET_ANDROID || NET_APPLE
             using (var stream = FileSystem.Current.OpenAppPackageFileAsync(filename).Result)
             using (var memoryStream = new MemoryStream()) {
                 stream.CopyTo(memoryStream);
@@ -677,12 +677,12 @@ namespace Test
 
                 var lines = Windows.Storage.FileIO.ReadLinesAsync(file).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
                 foreach(var line in lines) {
-            #elif NET6_0_WINDOWS10 || NET6_0_ANDROID || NET6_0_APPLE
+            #elif NET6_0_WINDOWS10 || NET_ANDROID || NET_APPLE
             using(var stream = FileSystem.Current.OpenAppPackageFileAsync(path.Replace("C/tests/data/", "")).Result)
             using (var tr = new StreamReader(stream)) { 
                 string line;
 				while ((line = tr.ReadLine()) != null) {
-            #elif __ANDROID__ && !NET6_0_ANDROID
+            #elif __ANDROID__ && !NET_ANDROID
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
             using (var tr = new StreamReader(ctx.Assets.Open(path))) {
                 string line;
@@ -719,12 +719,12 @@ namespace Test
                     .GetResult();
 
                 return file.OpenStreamForReadAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            #elif NET6_0_WINDOWS10 || NET6_0_APPLE || NET6_0_ANDROID
+            #elif NET6_0_WINDOWS10 || NET_APPLE || NET_ANDROID
             return FileSystem.Current.OpenAppPackageFileAsync(path).Result;
-            #elif __ANDROID__ && !NET6_0_ANDROID
+            #elif __ANDROID__ && !NET_ANDROID
             var ctx = global::Couchbase.Lite.Tests.Android.MainActivity.ActivityContext;
             return ctx.Assets.Open(path);
-            #elif __IOS__ && !NET6_0_APPLE
+            #elif __IOS__ && !NET_APPLE
             var bundlePath = Foundation.NSBundle.MainBundle.PathForResource(Path.GetFileNameWithoutExtension(path), Path.GetExtension(path));
 			return File.Open(bundlePath, FileMode.Open, FileAccess.Read);
             #elif WINUI

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -108,7 +108,7 @@ namespace Test
 
 
         #endregion
-        #if !NET6_0_APPLE && !NET6_0_ANDROID
+        #if !NET_APPLE && !NET_ANDROID
         #region Public Methods
         
 
@@ -302,7 +302,7 @@ namespace Test
             wrongPwSecureString.Dispose();
         }
 
-        #if !NET6_0_ANDROID
+        #if !NET_ANDROID
         [Fact]
         public void TestClientCertAuthWithCallback()
         {
@@ -405,13 +405,13 @@ namespace Test
             _listener.Stop();
         }
 
-        #if !NET6_0_ANDROID
+        #if !NET_ANDROID
         [Fact]
         public void TestClientCertAuthenticatorRootCerts()
         {
             byte[] caData = GetFileByteArray("client-ca.der", typeof(URLEndpointListenerTest));
 
-            #if NET6_0_ANDROID
+            #if NET_ANDROID
             byte[] clientData = GetFileByteArray("client.pfx", typeof(URLEndpointListenerTest));
             #else
             byte[] clientData = GetFileByteArray("client.p12", typeof(URLEndpointListenerTest)); 
@@ -446,7 +446,7 @@ namespace Test
         [Fact]
         public void TestListenerWithImportIdentity()
         {
-			#if NET6_0_ANDROID
+			#if NET_ANDROID
             byte[] serverData = GetFileByteArray("client.pfx", typeof(URLEndpointListenerTest));
 			#else 
             byte[] serverData = GetFileByteArray("client.p12", typeof(URLEndpointListenerTest)); 
@@ -639,7 +639,7 @@ namespace Test
         }
 #endif
 
-#if !NET6_0_ANDROID
+#if !NET_ANDROID
         [Fact]
         public void TestMultipleListenersOnSameDatabase()
         {
@@ -775,7 +775,7 @@ namespace Test
         [Fact]
         public void TestReplicatorServerCertNoTLS() => CheckReplicatorServerCert(false, false);
 
-#if !NET6_0_ANDROID
+#if !NET_ANDROID
         [Fact]
         public void TestReplicatorServerCertWithTLS() => CheckReplicatorServerCert(true, true);
 

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging;Debug_Coverage;Release_Coverage</Configurations>
-	<TargetFrameworks>netstandard2.0;net6.0;net6.0-android31;net6.0-ios14.2;net6.0-maccatalyst14.2;MonoAndroid10.0;Xamarin.iOS10</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net6.0;net7.0-android31;net7.0-ios14.2;net7.0-maccatalyst14.2;MonoAndroid10.0;Xamarin.iOS10</TargetFrameworks>
 	<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net462;uap10.0.19041;net6.0-windows10.0.19041.0</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net6')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">22.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">22.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
     <AssemblyName>Couchbase.Lite</AssemblyName>
@@ -64,7 +64,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net6.0' ">
     <ProjectReference Include="..\..\src\Couchbase.Lite.Support.NetDesktop\Couchbase.Lite.Support.NetDesktop.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" ($(TargetFramework.StartsWith('MonoAndroid')) or $(TargetFramework.StartsWith('net6.0-android'))) and !$(DefineConstants.Contains('TEST_COVERAGE')) ">
+  <ItemGroup Condition=" ($(TargetFramework.StartsWith('MonoAndroid')) or $(TargetFramework.StartsWith('net7.0-android'))) and !$(DefineConstants.Contains('TEST_COVERAGE')) ">
     <ProjectReference Include="..\..\src\Couchbase.Lite.Support.Android\Couchbase.Lite.Support.Android.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid'))" >


### PR DESCRIPTION
Since .NET has a different Microsoft support lifecycle for these targets (.NET 6 already out of support)