### PR TITLE
CBL-4652: Don't allow calls to API after object disposed

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
@@ -659,7 +659,7 @@ namespace Test
             {
                 r.AddDocumentReplicationListener((sender, args) =>
                 {
-                    WriteLine($"{args.IsPush} {JsonConvert.SerializeObject(args.Documents.Select(x => $"{x.Flags} {x.CollectionName} {x.Id}"))}");
+                    Console.WriteLine($"{args.IsPush} {JsonConvert.SerializeObject(args.Documents.Select(x => $"{x.Flags} {x.CollectionName} {x.Id}"))}");
                     pushWait.RunConditionalAssert(() =>
                         args.IsPush 
                         && args.Documents.Any(x => x.Flags.HasFlag(DocumentFlags.Deleted) && x.CollectionName == "colA" && x.Id == "doc")

--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
@@ -659,6 +659,7 @@ namespace Test
             {
                 r.AddDocumentReplicationListener((sender, args) =>
                 {
+                    WriteLine($"{args.IsPush} {JsonConvert.SerializeObject(args.Documents.Select(x => $"{x.Flags} {x.CollectionName} {x.Id}"))}");
                     pushWait.RunConditionalAssert(() =>
                         args.IsPush 
                         && args.Documents.Any(x => x.Flags.HasFlag(DocumentFlags.Deleted) && x.CollectionName == "colA" && x.Id == "doc")


### PR DESCRIPTION
This will prevent situations in which the native object is recreated, and then never disposed because dispose was already called