### PR TITLE
CBL-4891: Backport a hanging test fix and log test starts

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -105,10 +105,14 @@ namespace Test
         {
             Database.Log.Custom = new XunitLogger(output) { Level = LogLevel.Info };
             _output = output;
-        #else
+            var type = output.GetType();
+            var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            var test = (ITest)testMember.GetValue(output);
+            _output.WriteLine($"== TEST STARTING {test.DisplayName} ==");
+#else
         public TestCase()
         { 
-        #endif
+#endif
             var nextCounter = Interlocked.Increment(ref _counter);
             Database.Delete($"{DatabaseName}{nextCounter}", Directory);
             OpenDB(nextCounter);

--- a/src/LiteCore/test/LiteCore.Tests.Shared/TestBase.cs
+++ b/src/LiteCore/test/LiteCore.Tests.Shared/TestBase.cs
@@ -101,7 +101,7 @@ namespace LiteCore.Tests
         protected void RunTestVariants(Action a, [CallerMemberName]string caller = null)
         {
             var exceptions = new ConcurrentDictionary<int, List<Exception>>();
-            WriteLine($"Begin {caller}");
+            WriteLine($"== TEST STARTING {caller} ==");
             for(int i = 0; i < NumberOfOptions; i++) {
                 CurrentException = null;
                 SetupVariant(i);


### PR DESCRIPTION
The multiple replicators test had some flaky logic in it that sometimes caused that particular test to hang and endless print PING PONG every 5 minutes.  Backported https://github.com/couchbase/couchbase-lite-net/commit/8efacff992e134d4039c4082259e33c10bd4148d to thie branch.  The tests still hung after that, however, so I added in some logging for when a test begins.  This alone caused the hang to stop (or maybe it just didn't feel like hanging today) but it's a good change to keep just in case the hangs come back.