### PR TITLE
Add doc subscript in Collection and Deprecate the Database's one

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -134,6 +134,14 @@ namespace Couchbase.Lite
         /// </summary>
         public ulong Count => ThreadSafety.DoLocked(() => Native.c4coll_getDocumentCount(c4coll));
 
+        /// <summary>
+        /// Gets a <see cref="DocumentFragment"/> with the given document ID
+        /// </summary>
+        /// <param name="id">The ID of the <see cref="DocumentFragment"/> to retrieve</param>
+        /// <returns>The <see cref="DocumentFragment"/> object</returns>
+        [NotNull]
+        public DocumentFragment this[string id] => new DocumentFragment(GetDocument(id));
+
         #endregion
 
         #region Constructors

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -167,10 +167,11 @@ namespace Couchbase.Lite
         public ulong Count => DefaultCollection == null ? 0 : DefaultCollection.Count;
 
         /// <summary>
-        /// Gets a <see cref="DocumentFragment"/> with the given document ID
+        /// [DEPRECATED] Gets a <see cref="DocumentFragment"/> with the given document ID
         /// </summary>
         /// <param name="id">The ID of the <see cref="DocumentFragment"/> to retrieve</param>
         /// <returns>The <see cref="DocumentFragment"/> object</returns>
+        [Obsolete("Document subscript in the Database class is deprecated, please use Document Script of the default collection.")]
         [@NotNull]
         public DocumentFragment this[string id] => new DocumentFragment(GetDocument(id));
 

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -962,6 +962,28 @@ namespace Test
             defaultCollection.Count.Should().Be(0);
         }
 
+        #region Document Subscript
+
+        [Fact]
+        public void TestDocumentSubscript()
+        {
+            var defaultCollection = Db.GetDefaultCollection();
+            var doc1 = defaultCollection["doc1"];
+            doc1.Exists.Should().BeFalse("because the document id'doc1' doesn't exist in the collection");
+
+            using (var doc = new MutableDocument("doc1")) {
+                doc.SetString("str", "string");
+                defaultCollection.Save(doc);    
+            }
+            doc1 = defaultCollection["doc1"];
+            doc1.Exists.Should().BeTrue("because the document id 'doc1' exists in the collection");
+            doc1["foo"].Exists.Should().BeFalse("because this portion of the data doesn't exist");
+            doc1["str"].Exists.Should().BeTrue("because this portion of the data exists");
+            doc1["str"].String.Should().Be("string", "because that is the stored value");
+        }
+        
+        #endregion
+
         #region Private Methods
 
         private void TestGetScopesOrCollections(Action dbDispose)


### PR DESCRIPTION
* CBL-4980 : Added the missing document subscript in Collection class
* CBL-4953 : Deprecated document subscript in Database class
* Document Subscript Operator is .NET and iOS specific operator for getting a document frament object by id from a collection such as 

 ```
 var doc = collection["doc1"];
 var name = doc["name"].String;
 ```