### PR TITLE
Update LiteCore to 3.2.0-103

### DIFF
--- a/core_version.ini
+++ b/core_version.ini
@@ -1,6 +1,6 @@
 [version]
-build = 3.2.0-83
+build = 3.2.0-103
 
 [hashes]
-ce = 36f545885cdb86bda1259d91c5d543680f7a5233
+ce = 650240dc56849c750089022a441f9718c05bcac2
 ee = 6a5fc13a3edc2408d1148ca81698c77cf4af73ca

--- a/src/Couchbase.Lite.Shared/API/Database/Scope.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Scope.cs
@@ -304,10 +304,8 @@ namespace Couchbase.Lite
                         scope = scopeName_.AsFLSlice()
                     };
 
-                    co = (C4Collection*)LiteCoreBridge.Check(err =>
-                    {
-                        return Native.c4db_getCollection(c4Db, collectionSpec, err);
-                    });
+                    co = (C4Collection*) NativeHandler.Create().AllowError(new C4Error(C4ErrorCode.NotFound)).Execute(
+                        err => Native.c4db_getCollection(c4Db, collectionSpec, err));
                 }
             });
 


### PR DESCRIPTION
* Updated LiteCore to 3.2.0-103.
* Allowed NotFound error when getting a collection as LiteCore now returns NotFound error when the collection doesn't exist.