### PR TITLE
CBL-4983: Map LiteCore log domain 'Changes' to Database instead of Replicator

### DIFF
--- a/src/Couchbase.Lite.Shared/Log/LogTo.cs
+++ b/src/Couchbase.Lite.Shared/Log/LogTo.cs
@@ -216,7 +216,7 @@ namespace Couchbase.Lite.Internal.Logging
             ["Sync"] = LogDomain.Replicator,
             ["SyncBusy"] = LogDomain.Replicator,
             ["Actor"] = LogDomain.Replicator,
-            ["Changes"] = LogDomain.Replicator,
+            ["Changes"] = LogDomain.Database,
             ["Query"] = LogDomain.Query,
             ["Enum"] = LogDomain.Query,
             ["WS"] = LogDomain.Network,


### PR DESCRIPTION
This the same issue, backported to helium