### PR TITLE
CBL-5304: Remove version specific Windows RID from nuget package

### DIFF
--- a/src/Couchbase.Lite.Support.NetDesktop/Activate.cs
+++ b/src/Couchbase.Lite.Support.NetDesktop/Activate.cs
@@ -102,7 +102,7 @@ namespace Couchbase.Lite.Support
                 var dllPath = Path.Combine(codeBase ?? "", architecture, "LiteCore.dll");
                 var dllPathAsp = Path.Combine(codeBase ?? "", "bin", architecture, "LiteCore.dll");
                 var dllPathRuntimes =
-                    Path.Combine(codeBase ?? "", "runtimes", $"win10-{architecture}", "native", "LiteCore.dll");
+                    Path.Combine(codeBase ?? "", "runtimes", $"win-{architecture}", "native", "LiteCore.dll");
                 var foundPath = default(string);
                 foreach (var path in new[] { dllPathRuntimes, dllPath, dllPathAsp}) {
                     foundPath = File.Exists(path) ? path : null;

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -48,22 +48,22 @@
     <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\x86_64\bin\LiteCore.dll">
       <Link>x64\LiteCore.dll</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-x64/native/LiteCore.dll</PackagePath>
+      <PackagePath>runtimes/win-x64/native/LiteCore.dll</PackagePath>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\x86_64\bin\LiteCore.pdb">
       <Link>x64\LiteCore.pdb</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-x64/native/LiteCore.pdb</PackagePath>
+      <PackagePath>runtimes/win-x64/native/LiteCore.pdb</PackagePath>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\arm64\bin\LiteCore.dll">
       <Link>arm64\LiteCore.dll</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-arm64/native/LiteCore.dll</PackagePath>
+      <PackagePath>runtimes/win-arm64/native/LiteCore.dll</PackagePath>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\arm64\bin\LiteCore.pdb">
       <Link>arm64\LiteCore.pdb</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-arm64/native/LiteCore.pdb</PackagePath>
+      <PackagePath>runtimes/win-arm64/native/LiteCore.pdb</PackagePath>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" ($(IsMac) OR $(Configuration.Contains('Packaging'))) AND '$(JUST_CSHARP)' == ''  ">

--- a/src/Couchbase.Lite.Support.NetDesktop/desktop.props
+++ b/src/Couchbase.Lite.Support.NetDesktop/desktop.props
@@ -3,11 +3,11 @@
         <_NugetRuntimesPath Condition="'$(_NugetRuntimesPath)' == ''">$(MSBuildThisFileDirectory)..\..\runtimes\</_NugetRuntimesPath>
     </PropertyGroup>
     <ItemGroup>
-        <Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(_NugetRuntimesPath)win10-x64\native\LiteCore.dll">
+        <Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(_NugetRuntimesPath)win-x64\native\LiteCore.dll">
             <Link>x64\LiteCore.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-		<Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(_NugetRuntimesPath)win10-arm64\native\LiteCore.dll">
+		<Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(_NugetRuntimesPath)win-arm64\native\LiteCore.dll">
             <Link>arm64\LiteCore.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>

--- a/src/Couchbase.Lite.Support.UWP/Couchbase.Lite.Support.UWP.csproj
+++ b/src/Couchbase.Lite.Support.UWP/Couchbase.Lite.Support.UWP.csproj
@@ -73,22 +73,22 @@
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\x86_64-store\bin\LiteCore.dll">
       <Link>x64\LiteCore.dll</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-x64/nativeassets/uap10.0/LiteCore.dll</PackagePath>
+      <PackagePath>runtimes/win-x64/nativeassets/uap10.0/LiteCore.dll</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\x86_64-store\bin\LiteCore.pdb">
       <Link>x64\LiteCore.pdb</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-x64/nativeassets/uap10.0/LiteCore.pdb</PackagePath>
+      <PackagePath>runtimes/win-x64/nativeassets/uap10.0/LiteCore.pdb</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\arm64-store\bin\LiteCore.dll">
       <Link>arm64\LiteCore.dll</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-arm64/nativeassets/uap10.0/LiteCore.dll</PackagePath>
+      <PackagePath>runtimes/win-arm64/nativeassets/uap10.0/LiteCore.dll</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\arm64-store\bin\LiteCore.pdb">
       <Link>arm64\LiteCore.pdb</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-arm64/nativeassets/uap10.0/LiteCore.pdb</PackagePath>
+      <PackagePath>runtimes/win-arm64/nativeassets/uap10.0/LiteCore.pdb</PackagePath>
     </None>
   </ItemGroup>
   <ItemGroup Condition="!$(Configuration.Contains('Packaging'))">

--- a/src/Couchbase.Lite.Support.WinUI/Couchbase.Lite.Support.WinUI.csproj
+++ b/src/Couchbase.Lite.Support.WinUI/Couchbase.Lite.Support.WinUI.csproj
@@ -3,7 +3,7 @@
     <Configurations>Debug;Release;Packaging;PackagingDebug</Configurations>
     <Platforms>x64;arm64</Platforms>
     <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-    <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
@@ -65,22 +65,22 @@
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\x86_64\bin\LiteCore.dll">
       <Link>x64\LiteCore.dll</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-x64/native/LiteCore.dll</PackagePath>
+      <PackagePath>runtimes/win-x64/native/LiteCore.dll</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\x86_64\bin\LiteCore.pdb">
       <Link>x64\LiteCore.pdb</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-x64/native/LiteCore.pdb</PackagePath>
+      <PackagePath>runtimes/win-x64/native/LiteCore.pdb</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\arm64\bin\LiteCore.dll">
       <Link>arm64\LiteCore.dll</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-arm64/native/LiteCore.dll</PackagePath>
+      <PackagePath>runtimes/win-arm64/native/LiteCore.dll</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\windows\arm64\bin\LiteCore.pdb">
       <Link>arm64\LiteCore.pdb</Link>
       <Pack>true</Pack>
-      <PackagePath>runtimes/win10-arm64/native/LiteCore.pdb</PackagePath>
+      <PackagePath>runtimes/win-arm64/native/LiteCore.pdb</PackagePath>
     </None>
   </ItemGroup>
   <ItemGroup Condition="!$(Configuration.Contains('Packaging'))">


### PR DESCRIPTION
Basically, when putting LiteCore into nuget put it into a folder named win-<arch> instead of win10-<arch>.  The reason I put it in win10-<arch> in the first place was to sort of have a few more hints that we weren't supporting Windows 7 or 8.  Nobody seems to be under that misconception anyway, now, and the toolchain is actually complaining about this so I will oblige.  It doesn't hurt the code any, as long as everything agrees on the location.

This will be kind of weird to test because PR validation is meaningless.  The post commit tests which run tests on the packaged library will show pretty quickly if anything is wrong.