### PR TITLE
CBL-5006: Parse any number of version digits

### DIFF
--- a/src/Couchbase.Lite.Shared/Sync/HTTPLogic.cs
+++ b/src/Couchbase.Lite.Shared/Sync/HTTPLogic.cs
@@ -193,7 +193,7 @@ namespace Couchbase.Lite.Sync
 			var versionAtt = (AssemblyInformationalVersionAttribute?)typeof(Database).GetTypeInfo().Assembly
 				.GetCustomAttribute(typeof(AssemblyInformationalVersionAttribute));
 			var version = versionAtt?.InformationalVersion ?? "Unknown";
-            var regex = new Regex("([0-9]+\\.[0-9]+\\.[0-9]+)-b([0-9]+)");
+            var regex = new Regex("((?:[0-9+]\\.)+[0-9]+)-b([0-9]+)");
 			var build = "0";
             var commit = ThisAssembly.Git.Commit;
             #if COUCHBASE_ENTERPRISE


### PR DESCRIPTION
Before it was strictly three, which made 3.1.3.1 appear as 1.3.1 (for example).