### PR TITLE
Rework the way that platform defines are handled

### DIFF
--- a/src/Couchbase.Lite.Shared/API/DI/Service.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/Service.cs
@@ -57,7 +57,7 @@ namespace Couchbase.Lite.DI
             _Collection.Options.AllowOverridingRegistrations = true;
 
             // Windows 2012 doesn't define NETFRAMEWORK for some reason
-            #if (NET6_0_OR_GREATER || NETFRAMEWORK || NET462) && !CBL_PLATFORM_WINUI && !__MOBILE__
+            #if CBL_PLATFORM_NET_CONSOLE || CBL_PLATFORM_NET_FRAMEWORK
             AutoRegister(typeof(Database).GetTypeInfo().Assembly);
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
@@ -69,7 +69,7 @@ namespace Couchbase.Lite.DI
             }
             #elif CBL_PLATFORM_WINUI
             Service.AutoRegister(typeof(Database).GetTypeInfo().Assembly);
-            #elif __ANDROID__
+            #elif CBL_PLATFORM_ANDROID
             #if !TEST_COVERAGE
             if (Droid.Context == null) {
                 throw new RuntimeException(
@@ -80,7 +80,7 @@ namespace Couchbase.Lite.DI
             Service.Register<IDefaultDirectoryResolver>(() => new DefaultDirectoryResolver(Droid.Context));
             Service.Register<IMainThreadTaskScheduler>(() => new MainThreadTaskScheduler(Droid.Context));
             #endif
-            #elif __IOS__
+            #elif CBL_PLATFORM_IOS
             Service.AutoRegister(typeof(Database).Assembly);
             #elif NETSTANDARD2_0
             throw new RuntimeException(

--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -705,7 +705,7 @@ namespace Couchbase.Lite
 
         #region Private Methods - Observers
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4CollectionObserverCallback))]
         #endif
         private static void DbObserverCallback(C4CollectionObserver* db, void* context)
@@ -717,7 +717,7 @@ namespace Couchbase.Lite
             });
         }
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4DocumentObserverCallback))]
         #endif
         private static void DocObserverCallback(C4DocumentObserver* obs, C4Collection* collection, FLSlice docId, ulong sequence, void* context)

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -496,7 +496,7 @@ namespace Couchbase.Lite.Sync
 
         #region Private Methods - Filters
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4ReplicatorValidationFunction))]
         #endif
         private static bool PullValidateCallback(C4CollectionSpec collectionSpec, FLSlice docID, FLSlice revID, C4RevisionFlags revisionFlags, FLDict* dict, void* context)
@@ -519,7 +519,7 @@ namespace Couchbase.Lite.Sync
             return replicator.PullValidateCallback(collName, scope, docIDStr, revID.CreateString()!, dict, flags);
         }
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4ReplicatorValidationFunction))]
         #endif
         private static bool PushFilterCallback(C4CollectionSpec collectionSpec, FLSlice docID, FLSlice revID, C4RevisionFlags revisionFlags, FLDict* dict, void* context)
@@ -580,7 +580,7 @@ namespace Couchbase.Lite.Sync
 
         #region Private Methods - Doc Ended
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4ReplicatorDocumentEndedCallback))]
         #endif
         private static void OnDocEnded(C4Replicator* repl, bool pushing, IntPtr numDocs, C4DocumentEnded** docs, void* context)
@@ -686,7 +686,7 @@ namespace Couchbase.Lite.Sync
 
         #region Private Methods - Status Change
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4ReplicatorStatusChangedCallback))]
         #endif
         private static void StatusChangedCallback(C4Replicator* repl, C4ReplicatorStatus status, void* context)

--- a/src/Couchbase.Lite.Shared/Log/Log.cs
+++ b/src/Couchbase.Lite.Shared/Log/Log.cs
@@ -107,7 +107,7 @@ namespace Couchbase.Lite.Internal.Logging
             return Native.c4log_getDomain((byte*) bytes, create);
         }
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4LogCallback))]
         #endif
         private static void LiteCoreLog(C4LogDomain* domain, C4LogLevel level, IntPtr message, IntPtr ignored)

--- a/src/Couchbase.Lite.Shared/Query/LiveQuerier.cs
+++ b/src/Couchbase.Lite.Shared/Query/LiveQuerier.cs
@@ -123,7 +123,7 @@ namespace Couchbase.Lite.Internal.Query
 
         #region Private Methods
 
-        #if __IOS__
+        #if CBL_PLATFORM_IOS
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4QueryObserverCallback))]
         #endif
         private static void QueryObserverCallback(C4QueryObserver* obs, C4Query* query, void* context)

--- a/src/Couchbase.Lite.Shared/Support/Android/AndroidConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/AndroidConsoleLogger.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __ANDROID__
+#if CBL_PLATFORM_ANDROID
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Couchbase.Lite.Shared/Support/Android/AndroidRuntimePlatform.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/AndroidRuntimePlatform.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __ANDROID__
+#if CBL_PLATFORM_ANDROID
 using System;
 using Android.OS;
 using Couchbase.Lite.DI;

--- a/src/Couchbase.Lite.Shared/Support/Android/DefaultDirectoryResolver.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/DefaultDirectoryResolver.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#if __ANDROID__
+#if CBL_PLATFORM_ANDROID
 using Android.Content;
 using Couchbase.Lite.DI;
 using LiteCore.Interop;

--- a/src/Couchbase.Lite.Shared/Support/Android/MainThreadTaskScheduler.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/MainThreadTaskScheduler.cs
@@ -15,7 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // 
-#if __ANDROID__
+#if CBL_PLATFORM_ANDROID
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Couchbase.Lite.Shared/Support/Android/XEReachability.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/XEReachability.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __ANDROID__ && !NET6_0_OR_GREATER
+#if CBL_PLATFORM_XAMARIN_ANDROID
 using Couchbase.Lite.DI;
 using Couchbase.Lite.Sync;
 using System;

--- a/src/Couchbase.Lite.Shared/Support/Android/XamarinAndroidProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/Android/XamarinAndroidProxy.cs
@@ -15,7 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // 
-#if __ANDROID__
+#if CBL_PLATFORM_ANDROID
 using System;
 using System.Linq;
 using System.Net;

--- a/src/Couchbase.Lite.Shared/Support/Status.cs
+++ b/src/Couchbase.Lite.Shared/Support/Status.cs
@@ -136,7 +136,7 @@ namespace Couchbase.Lite
                             c4err.code = (int) C4NetworkErrorCode.TLSHandshakeFailed;
                         }
 
-#if __IOS__
+#if CBL_PLATFORM_IOS
                         if (ie.Message == "Connection closed.") {
                         //AppleTlsContext.cs
                         //case SslStatus.ClosedAbort:

--- a/src/Couchbase.Lite.Shared/Support/WinUI/WinUIProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/WinUI/WinUIProxy.cs
@@ -36,24 +36,12 @@ namespace Couchbase.Lite.Support
 
         private const string Tag = nameof(WinUIProxy);
 
-        #if WINDOWS_PHONE
-        private static bool _Logged;
-        #endif
-
         #endregion
 
         #region IProxy
 
-        public async Task<WebProxy> CreateProxyAsync(Uri destination)
+        public async Task<WebProxy?> CreateProxyAsync(Uri destination)
         {
-            #if WINDOWS_PHONE 
-            if (!_Logged) {
-                _Logged = true;
-                WriteLog.To.Sync.W(Tag, "Proxy is not supported on Windows phone");
-            }
-
-            return null;
-            #else
             var config = await NetworkInformation.GetProxyConfigurationAsync(destination);
             if (config.CanConnectDirectly) {
                 WriteLog.To.Sync.V(Tag, "Able to connect directly, bypassing proxy");
@@ -68,7 +56,6 @@ namespace Couchbase.Lite.Support
             var uri = config.ProxyUris.FirstOrDefault();
             WriteLog.To.Sync.I(Tag, "Using {0} as proxy server for {1}", uri, destination);
             return new WebProxy(uri);
-            #endif
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Support/iOS/DefaultDirectoryResolver.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/DefaultDirectoryResolver.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#if __IOS__
+#if CBL_PLATFORM_IOS
 using System.IO;
 using Couchbase.Lite.DI;
 using Foundation;

--- a/src/Couchbase.Lite.Shared/Support/iOS/IOSProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/IOSProxy.cs
@@ -15,7 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // 
-#if __IOS__
+#if CBL_PLATFORM_IOS
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/Couchbase.Lite.Shared/Support/iOS/MainThreadTaskScheduler.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/MainThreadTaskScheduler.cs
@@ -15,7 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // 
-#if __IOS__
+#if CBL_PLATFORM_IOS
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Couchbase.Lite.Shared/Support/iOS/iOSConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/iOSConsoleLogger.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __IOS__
+#if CBL_PLATFORM_IOS
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Couchbase.Lite.Shared/Support/iOS/iOSReachability.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/iOSReachability.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __IOS__
+#if CBL_PLATFORM_IOS
 using System;
 using System.Net;
 

--- a/src/Couchbase.Lite.Shared/Support/iOS/iOSRuntimePlatform.cs
+++ b/src/Couchbase.Lite.Shared/Support/iOS/iOSRuntimePlatform.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-#if __IOS__
+#if CBL_PLATFORM_IOS
 using Couchbase.Lite.DI;
 using Foundation;
 using UIKit;
@@ -25,7 +25,7 @@ namespace Couchbase.Lite.Support
     [CouchbaseDependency]
 	internal sealed class iOSRuntimePlatform : IRuntimePlatform
 	{
-#if MACCATALYST
+#if CBL_PLATFORM_NET_MAC_CATALYST
         public string OSDescription => $"macOS (Catalyst) {NSProcessInfo.ProcessInfo.OperatingSystemVersion}";
 
         public string HardwareName => null;

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/DefaultDirectoryResolver.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/DefaultDirectoryResolver.cs
@@ -16,8 +16,7 @@
 //  limitations under the License.
 //
 
-// Windows 2012 doesn't define the more generic variants
-#if (NETFRAMEWORK || NET462 || NET6_0_OR_GREATER) && !__MOBILE__ && !NET6_0_WINDOWS10_0_19041_0
+#if CBL_PLATFORM_NET_CONSOLE || CBL_PLATFORM_NET_FRAMEWORK
 using System;
 using System.IO;
 using Couchbase.Lite.DI;

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/DesktopConsoleLogger.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/DesktopConsoleLogger.cs
@@ -20,9 +20,7 @@
 // as opposed to C / C++ which defines from that point onward) to be able
 // to use Debug.WriteLine even in a release build
 
-// Windows 2012 doesn't define the more generic variants
-
-#if (NETFRAMEWORK || NET462 || NET6_0_OR_GREATER) && !NET6_0_WINDOWS10_0_19041_0 && !__MOBILE__
+#if CBL_PLATFORM_NET_CONSOLE || CBL_PLATFORM_NET_FRAMEWORK
 #define DEBUG
 using System;
 using System.Diagnostics;

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/LinuxProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/LinuxProxy.cs
@@ -16,8 +16,7 @@
 //  limitations under the License.
 // 
 
-// Windows 2012 doesn't define the more generic variants
-#if NETFRAMEWORK || NET462 || NET6_0_OR_GREATER
+#if CBL_PLATFORM_NET_CONSOLE || CBL_PLATFORM_NET_FRAMEWORK
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/MacProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/MacProxy.cs
@@ -16,8 +16,7 @@
 //  limitations under the License.
 // 
 
-// Windows 2012 doesn't define the more generic variants
-#if NETFRAMEWORK || NET462 || NET6_0_OR_GREATER
+#if CBL_PLATFORM_NET_CONSOLE || CBL_PLATFORM_NET_FRAMEWORK
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/WindowsProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/WindowsProxy.cs
@@ -16,8 +16,7 @@
 //  limitations under the License.
 // 
 
-// Windows 2012 doesn't define the more generic variants
-#if (NETFRAMEWORK || NET462 || NET6_0_OR_GREATER) && !NET6_0_WINDOWS10_0_19041_0
+#if CBL_PLATFORM_NET_CONSOLE || CBL_PLATFORM_NET_FRAMEWORK
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -2191,7 +2191,7 @@ namespace Test
         [Fact]
         public void TestQueryExpressions()
         {
-            var doubleValue = Math.PI;
+            var doubleValue = Math.Round(Math.PI, 14);
             var floatValue = 1.5F;
             var longValue = 4294967296L;
             var value = (object)"stringObject";


### PR DESCRIPTION
This makes it easier to switch between .NET versions