### PR TITLE
CBL-5447: Add in required functionality to load and run vector search…

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -37,6 +37,8 @@ using LiteCore.Util;
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Reflection;
+using Couchbase.Lite.Extensions;
 
 namespace Couchbase.Lite
 {
@@ -277,6 +279,27 @@ namespace Couchbase.Lite
         static Database()
         {
             Native.c4log_enableFatalExceptionBacktrace();
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName.Contains("Couchbase"))) {
+                Console.WriteLine($"Searching for extensions in {assembly.FullName}");
+                var extensionType = assembly.GetTypes()
+                    .FirstOrDefault(t => !t.IsInterface && t.GetInterface(typeof(ICouchbaseLiteExtension).FullName) != null);
+                if(extensionType != null) {
+                    try {
+                        var impl = Activator.CreateInstance(extensionType) as ICouchbaseLiteExtension;
+                        if (impl == null) {
+                            Console.WriteLine("Unable to create found extension (Activator.CreateInstance returned null...)");
+                            continue;
+                        }
+
+                        Console.WriteLine($"Extension {impl.Name} in {impl.Path} registered!");
+                        Native.c4_setExtensionPath(impl.Path);
+                        return; // For now, only accept the first one since that's all we can handle
+                    } catch(Exception e) {
+                        WriteLog.To.Database.E(Tag, $"Extension constructor failed", e);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/src/Couchbase.Lite.Shared/API/Info/CouchbaseLiteErrorMessage.cs
+++ b/src/Couchbase.Lite.Shared/API/Info/CouchbaseLiteErrorMessage.cs
@@ -49,7 +49,6 @@ namespace Couchbase.Lite
         internal const string InvalidSchemeURLEndpoint = "Invalid scheme for URLEndpoint url ({0}). It must be either 'ws:' or 'wss:'.";
         internal const string InvalidEmbeddedCredentialsInURL = "Embedded credentials in a URL (username:password@url) are not allowed. Use the BasicAuthenticator class instead.";
         internal const string ReplicatorNotStopped = "Replicator is not stopped. Resetting checkpoint is only allowed when the replicator is in the stopped state.";
-        internal const string QueryParamNotAllowedContainCollections = "Query parameters are not allowed to contain collections.";
         internal const string MissASforJoin = "Missing AS clause for JOIN.";
         internal const string MissONforJoin = "Missing ON statement for JOIN.";
         internal const string ExpressionsMustBeIExpressionOrString = "Expressions must either be {0} or String.";

--- a/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
+++ b/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
@@ -112,11 +112,23 @@ namespace Couchbase.Lite.Info {
 
 #if COUCHBASE_ENTERPRISE
 
-		/// <summary>
-		/// Default value for <see cref="URLEndpointListenerConfiguration.Port" /> (0)
-		/// No port specified, the OS will assign one
-		/// </summary>
-		public static readonly ushort DefaultListenerPort = 0;
+        /// <summary>
+        /// Default value for <see cref="VectorSearchIndexConfiguration.Encoding" /> (ScalarQuantizerType.SQ8)
+        /// Vectors are encoded as 8-bit, by default
+        /// </summary>
+        public static readonly ScalarQuantizerType DefaultVectorSearchIndexEncoding = ScalarQuantizerType.SQ8;
+
+        /// <summary>
+        /// Default value for <see cref="VectorSearchIndexConfiguration.Metric" /> (DistanceMetric.Euclidean)
+        /// By default, vectors are compared using Euclidian metrics
+        /// </summary>
+        public static readonly DistanceMetric DefaultVectorSearchIndexMetric = DistanceMetric.Euclidean;
+
+        /// <summary>
+        /// Default value for <see cref="URLEndpointListenerConfiguration.Port" /> (0)
+        /// No port specified, the OS will assign one
+        /// </summary>
+        public static readonly ushort DefaultListenerPort = 0;
 
 		/// <summary>
 		/// Default value for <see cref="URLEndpointListenerConfiguration.DisableTLS" /> (false)

--- a/src/Couchbase.Lite.Shared/API/Query/Parameters.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/Parameters.cs
@@ -193,6 +193,30 @@ namespace Couchbase.Lite.Query
         }
 
         /// <summary>
+        /// Sets an <see cref="ArrayObject"/> value in the parameters
+        /// </summary>
+        /// <param name="name">The name of the key to set</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>The parameters object for further processing</returns>
+        public Parameters SetArray(string name, ArrayObject? value)
+        {
+            SetValue(name, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an <see cref="DictionaryObject"/> value in the parameters
+        /// </summary>
+        /// <param name="name">The name of the key to set</param>
+        /// <param name="value">The value to set</param>
+        /// <returns>The parameters object for further processing</returns>
+        public Parameters SetDictionary(string name, DictionaryObject? value)
+        {
+            SetValue(name, value);
+            return this;
+        }
+
+        /// <summary>
         /// Sets an untyped value in the parameters
         /// </summary>
         /// <param name="name">The name of the key to set</param>
@@ -201,12 +225,6 @@ namespace Couchbase.Lite.Query
         public Parameters SetValue(string name, object? value)
         {
             CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(name), name);
-
-            // HACK: Use side effect of data validation
-            var cbVal = DataOps.ToCouchbaseObject(value);
-            if (cbVal is MutableDictionaryObject || cbVal is MutableArrayObject) {
-                throw new ArgumentException(CouchbaseLiteErrorMessage.QueryParamNotAllowedContainCollections);
-            }
 
             _freezer.PerformAction(() => _params[name] = value);
             _query?.SetParameters(this.ToString());

--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -15,6 +15,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CblEnterprisePackage Condition="'$(CblEnterprisePackage)' == ''">false</CblEnterprisePackage>
     <PackageId Condition="'$(CblEnterprisePackage)' == 'true'">Couchbase.Lite.Enterprise.Support.Android</PackageId>
+    <PackageId Condition="'$(PackageId)' == ''">Couchbase.Lite.Support.Android</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Couchbase.Lite.Support.WinUI/Couchbase.Lite.Support.WinUI.csproj
+++ b/src/Couchbase.Lite.Support.WinUI/Couchbase.Lite.Support.WinUI.csproj
@@ -15,6 +15,9 @@
     <SingleProject>true</SingleProject>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CblEnterprisePackage Condition="'$(CblEnterprisePackage)' == ''">false</CblEnterprisePackage>
+    <PackageId Condition="'$(CblEnterprisePackage)' == 'true'">Couchbase.Lite.Enterprise.Support.WinUI</PackageId>
+    <PackageId Condition="'$(PackageId)' == ''">Couchbase.Lite.Support.WinUI</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <PlatformTarget>$(Platform)</PlatformTarget>

--- a/src/LiteCore/binding_list/c4.def
+++ b/src/LiteCore/binding_list/c4.def
@@ -53,6 +53,7 @@ c4db_beginTransaction
 c4db_endTransaction
 c4db_getSharedFleeceEncoder
 c4db_getFLSharedKeys
+c4_setExtensionPath
 
 c4doc_release
 c4doc_selectNextLeafRevision

--- a/src/LiteCore/src/LiteCore.Shared/API/CouchbaseLiteException.cs
+++ b/src/LiteCore/src/LiteCore.Shared/API/CouchbaseLiteException.cs
@@ -483,7 +483,6 @@ namespace Couchbase.Lite
         private static readonly IReadOnlyList<int> _BugReportErrors = new List<int>
         {
             (int)C4ErrorCode.AssertionFailed,
-            (int)C4ErrorCode.Unimplemented,
             (int)C4ErrorCode.Unsupported,
             (int)C4ErrorCode.UnsupportedEncryption,
             (int)C4ErrorCode.BadRevisionID,

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Database_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Database_native.cs
@@ -1,7 +1,7 @@
 //
 // C4Database_native.cs
 //
-// Copyright (c) 2023 Couchbase, Inc All rights reserved.
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,13 @@ namespace LiteCore.Interop
 
     internal unsafe static partial class Native
     {
+        public static void c4_setExtensionPath(string? path)
+        {
+            using(var path_ = new C4String(path)) {
+                NativeRaw.c4_setExtensionPath(path_.AsFLSlice());
+            }
+        }
+
         public static C4Database* c4db_openNamed(string? name, C4DatabaseConfig2* config, C4Error* outError)
         {
             using(var name_ = new C4String(name)) {
@@ -90,6 +97,9 @@ namespace LiteCore.Interop
 
     internal unsafe static partial class NativeRaw
     {
+        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void c4_setExtensionPath(FLSlice path);
+
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern C4Database* c4db_openNamed(FLSlice name, C4DatabaseConfig2* config, C4Error* outError);
 

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4DocumentTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4DocumentTypes_defs.cs
@@ -1,7 +1,7 @@
 //
 // C4DocumentTypes_defs.cs
 //
-// Copyright (c) 2023 Couchbase, Inc All rights reserved.
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ namespace LiteCore.Interop
         DocGetMetadata,
         DocGetCurrentRev,
         DocGetAll,
+        DocGetUpgraded,
     }
 
 	internal unsafe struct C4Revision

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4IndexTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4IndexTypes_defs.cs
@@ -1,7 +1,7 @@
 //
 // C4IndexTypes_defs.cs
 //
-// Copyright (c) 2023 Couchbase, Inc All rights reserved.
+// Copyright (c) 2024 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,54 @@ namespace LiteCore.Interop
         FullTextIndex,
         ArrayIndex,
         PredictiveIndex,
+        VectorIndex,
+    }
+
+    internal enum C4VectorMetricType : uint
+    {
+        VectorMetricDefault,
+        VectorMetricEuclidean,
+        VectorMetricCosine,
+    }
+
+    internal enum C4VectorClusteringType : uint
+    {
+        VectorClusteringFlat,
+        VectorClusteringMulti,
+    }
+
+    internal enum C4VectorEncodingType : uint
+    {
+        VectorEncodingDefault,
+        VectorEncodingNone,
+        VectorEncodingPQ,
+        VectorEncodingSQ,
+    }
+
+	internal unsafe struct C4VectorClustering
+    {
+        public C4VectorClusteringType type;
+        public uint flat_centroids;
+        public uint multi_subquantizers;
+        public uint multi_bits;
+    }
+
+	internal unsafe struct C4VectorEncoding
+    {
+        public C4VectorEncodingType type;
+        public uint pq_subquantizers;
+        public uint bits;
+    }
+
+	internal unsafe struct C4VectorIndexOptions
+    {
+        public uint dimensions;
+        public C4VectorMetricType metric;
+        public C4VectorClustering clustering;
+        public C4VectorEncoding encoding;
+        public uint minTrainingSize;
+        public uint maxTrainingSize;
+        public uint numProbes;
     }
 
 	internal unsafe partial struct C4IndexOptions
@@ -45,6 +93,7 @@ namespace LiteCore.Interop
         private byte _ignoreDiacritics;
         private byte _disableStemming;
         private IntPtr _stopWords;
+        public C4VectorIndexOptions vector;
 
         public string? language
         {


### PR DESCRIPTION
… extensions

The API is EE so it it not in this repo.  A few things needed to be done in order to accomplish this:

1. The static database constructor now searches for plugins (though I may change this since a call to activate is currently required anyway, to make things a bit more understandable)
2. Remove defunct error message constant (needed to add the functionality that it claimed was illegal)
3. Add in defaults for some vector search parameters
4. Add the ability to add collections to query parameters
5. Fix up some packaging stuff in Android and WinUI
6. Add the new C4 API to the list of methods that .NET uses, and generate new bindings
7. Remove Unimplemented from the list of bugs that attach a "please file a bug report" message since we now use it to indicate lack of extensions.