### PR TITLE
Fix a use after dispose issue in query result objects

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
@@ -130,6 +130,7 @@ namespace Couchbase.Lite
 
         private static MValue Get(FleeceMutableArray array, int index, IThreadSafety? threadSafety = null)
         {
+            array.Context.CheckDisposed();
             return (threadSafety ?? NullThreadSafety.Instance).DoLocked(() =>
             {
                 var val = array.Get(index);

--- a/src/Couchbase.Lite.Shared/API/Document/MutableArrayObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/MutableArrayObject.cs
@@ -307,77 +307,77 @@ namespace Couchbase.Lite
         /// <inheritdoc />
         public IMutableArray SetValue(int index, object? value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetString(int index, string? value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetInt(int index, int value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetLong(int index, long value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetFloat(int index, float value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetDouble(int index, double value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetBoolean(int index, bool value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetBlob(int index, Blob? value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetDate(int index, DateTimeOffset value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetArray(int index, ArrayObject? value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 
         /// <inheritdoc />
         public IMutableArray SetDictionary(int index, DictionaryObject? value)
         {
-            _threadSafety.DoLocked(() => SetValueInternal(index, value));
+            SetValueInternal(index, value);
             return this;
         }
 

--- a/src/Couchbase.Lite.Shared/API/Query/IResultSet.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/IResultSet.cs
@@ -16,6 +16,7 @@
 //  limitations under the License.
 // 
 
+using System;
 using System.Collections.Generic;
 
 namespace Couchbase.Lite.Query
@@ -29,7 +30,7 @@ namespace Couchbase.Lite.Query
     /// more than once, then use <see cref="AllResults"/> or another LINQ
     /// method to materialize the results.
     /// </warning>
-    public interface IResultSet : IEnumerable<Result>
+    public interface IResultSet : IEnumerable<Result>, IDisposable
     {
         /// <summary>
         /// Cross platform API entry to get all results in a list.  Same

--- a/src/Couchbase.Lite.Shared/API/Query/Result.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/Result.cs
@@ -34,7 +34,13 @@ namespace Couchbase.Lite.Query
 {
     /// <summary>
     /// A class representing information about a "row" in the result of an
-    /// <see cref="IQuery"/>
+    /// <see cref="IQuery"/><br /><br />
+    /// 
+    /// > [!WARNING]
+    /// > The data inside this class is tied to the lifetime of its parent 
+    /// > <see cref="IResultSet"/> and will become invalid if the parent is 
+    /// > disposed or garbage collected, unless the data is first converted to
+    /// > .NET objects via ToList, ToDictionary, etc.
     /// </summary>
     public sealed unsafe class Result : IArray, IDictionaryObject, IJSON
     {
@@ -67,6 +73,7 @@ namespace Couchbase.Lite.Query
         public IFragment this[int index]
         {
             get {
+                _context.CheckDisposed();
                 if (index >= Count) {
                     return Fragment.Null;
                 }
@@ -76,7 +83,13 @@ namespace Couchbase.Lite.Query
         }
 
         /// <inheritdoc />
-        public IFragment this[string key] => this[IndexForColumnName(key)];
+        public IFragment this[string key]
+        {
+            get {
+                _context.CheckDisposed();
+                return this[IndexForColumnName(key)];
+            }
+        }
 
         /// <inheritdoc />
         public ICollection<string> Keys => _columnNames.Keys;
@@ -144,12 +157,14 @@ namespace Couchbase.Lite.Query
         /// <inheritdoc />
         public ArrayObject? GetArray(int index)
         {
+            _context.CheckDisposed();
             return _deserialized[index] as ArrayObject;
         }
 
         /// <inheritdoc />
         public Blob? GetBlob(int index)
         {
+            _context.CheckDisposed();
             return _deserialized[index] as Blob;  
         }
 
@@ -168,6 +183,7 @@ namespace Couchbase.Lite.Query
         /// <inheritdoc />
         public DictionaryObject? GetDictionary(int index)
         {
+            _context.CheckDisposed();
             return _deserialized[index] as DictionaryObject;
         }
 
@@ -198,6 +214,7 @@ namespace Couchbase.Lite.Query
         /// <inheritdoc />
         public object? GetValue(int index)
         {
+            _context.CheckDisposed();
             return _deserialized[index];
         }
 
@@ -299,6 +316,7 @@ namespace Couchbase.Lite.Query
         /// <inheritdoc />
         public object? GetValue(string key)
         {
+            _context.CheckDisposed();
             CBDebug.MustNotBeNull(WriteLog.To.Query, Tag, nameof(key), key);
             var index = IndexForColumnName(key);
             return index >= 0 ? GetValue(index) : null;

--- a/src/Couchbase.Lite.Shared/Query/NQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/NQuery.cs
@@ -68,9 +68,7 @@ namespace Couchbase.Lite.Internal.Query
                 return new NullResultSet();
             }
 
-            var retVal = new QueryResultSet(this, ThreadSafety, e, ColumnNames);
-            _history.Add(retVal);
-            return retVal;
+            return new QueryResultSet(this, ThreadSafety, e, ColumnNames);
         }
 
         public override unsafe string Explain()

--- a/src/Couchbase.Lite.Shared/Query/QueryBase.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryBase.cs
@@ -42,7 +42,6 @@ namespace Couchbase.Lite.Internal.Query
 
         protected readonly DisposalWatchdog _disposalWatchdog = new DisposalWatchdog(nameof(IQuery));
         protected unsafe C4Query* _c4Query;
-        protected List<QueryResultSet> _history = new List<QueryResultSet>();
         protected Parameters _queryParameters;
         protected Dictionary<ListenerToken, LiveQuerier?> _listenerTokens = new Dictionary<ListenerToken, LiveQuerier?>();
         protected int _observingCount;
@@ -129,11 +128,6 @@ namespace Couchbase.Lite.Internal.Query
                 Stop();
                 ThreadSafety.DoLocked(() =>
                 {
-                    foreach (var e in _history) {
-                        e.Release();
-                    }
-
-                    _history.Clear();
                     Native.c4query_release(_c4Query);
                     _c4Query = null;
                     _disposalWatchdog.Dispose();

--- a/src/Couchbase.Lite.Shared/Query/QueryResultSet.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryResultSet.cs
@@ -113,7 +113,16 @@ namespace Couchbase.Lite.Internal.Query
 
         #region Internal Methods
 
-        internal void Release()
+        internal void CheckDisposed()
+        {
+            if(_disposed) {
+                throw new ObjectDisposedException("QueryResultSet was disposed");
+            }
+        }
+
+        #endregion
+
+        public void Dispose()
         {
             _threadSafety.DoLocked(() =>
             {
@@ -125,8 +134,6 @@ namespace Couchbase.Lite.Internal.Query
                 _context.Dispose();
             });
         }
-
-        #endregion
 
         #region IEnumerable
 
@@ -140,12 +147,9 @@ namespace Couchbase.Lite.Internal.Query
         {
             _threadSafety.DoLocked(() =>
             {
+                CheckDisposed();
                 if (_enumeratorGenerated) {
                     throw new InvalidOperationException(CouchbaseLiteErrorMessage.ResultSetAlreadyEnumerated);
-                }
-
-                if (_disposed) {
-                    throw new ObjectDisposedException(nameof(QueryResultSet));
                 }
 
                 _enumeratorGenerated = true;
@@ -158,7 +162,11 @@ namespace Couchbase.Lite.Internal.Query
 
         #region IResultSet
 
-        public List<Result> AllResults() => this.ToList();
+        public List<Result> AllResults()
+        {
+            CheckDisposed();
+            return this.ToList();
+        }
 
         #endregion
 

--- a/src/Couchbase.Lite.Shared/Query/XQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/XQuery.cs
@@ -132,9 +132,7 @@ namespace Couchbase.Lite.Internal.Query
                 return new NullResultSet();
             }
 
-            var retVal = new QueryResultSet(this, fromImpl.ThreadSafety, e, ColumnNames);
-            _history.Add(retVal);
-            return retVal;
+            return new QueryResultSet(this, fromImpl.ThreadSafety, e, ColumnNames);
         }
 
         public override unsafe string Explain()

--- a/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FleeceMutableArray.cs
@@ -69,6 +69,7 @@ namespace Couchbase.Lite.Fleece
 
         public MValue Get(int index)
         {
+            Context.CheckDisposed();
             if (index < 0 || index >= _vec.Count) {
                 return MValue.Empty;
             }
@@ -89,6 +90,7 @@ namespace Couchbase.Lite.Fleece
 
         public void RemoveRange(int start, int count = 1)
         {
+            Context.CheckDisposed();
             if (!IsMutable) {
                 throw new InvalidOperationException(CouchbaseLiteErrorMessage.CannotRemoveItemsFromNonMutableMArray);
             }
@@ -120,6 +122,7 @@ namespace Couchbase.Lite.Fleece
 
         public void Set(int index, object? val)
         {
+            Context.CheckDisposed();
             if (!IsMutable) {
                 throw new InvalidOperationException(CouchbaseLiteErrorMessage.CannotSetItemsInNonMutableMArray);
             }
@@ -195,6 +198,7 @@ namespace Couchbase.Lite.Fleece
 
         public void Clear()
         {
+            Context.CheckDisposed();
             if (!IsMutable) {
                 throw new InvalidOperationException(CouchbaseLiteErrorMessage.CannotClearNonMutableMArray);
             }
@@ -237,6 +241,7 @@ namespace Couchbase.Lite.Fleece
 
         public IEnumerator<object?> GetEnumerator()
         {
+            Context.CheckDisposed();
             return new Enumerator(this);
         }
 
@@ -246,6 +251,7 @@ namespace Couchbase.Lite.Fleece
 
         public override void FLEncode(FLEncoder* enc)
         {
+            Context.CheckDisposed();
             if (!IsMutated) {
                 if (BaseArray == null) {
                     Native.FLEncoder_BeginArray(enc, 0UL);
@@ -281,6 +287,7 @@ namespace Couchbase.Lite.Fleece
 
         public void Insert(int index, object? val)
         {
+            Context.CheckDisposed();
             if (!IsMutable) {
                 throw new InvalidOperationException("Cannot insert items in a non-mutable FleeceMutableArray");
             }

--- a/src/Couchbase.Lite.Shared/Serialization/MContext.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/MContext.cs
@@ -30,15 +30,19 @@ namespace Couchbase.Lite.Internal.Serialization
 
         #endregion
 
+        private bool _disposed;
+
+        private readonly FLSlice _data;
+
         #region Properties
 
-        public FLSlice Data { get; }
-
-#if DEBUG
-        internal bool Disposed { get; private set; }
-#endif
-
-        public FLSharedKeys* SharedKeys { get; }
+        public FLSlice Data
+        {
+            get {
+                CheckDisposed();
+                return _data;
+            }
+        }
 
         #endregion
 
@@ -50,7 +54,7 @@ namespace Couchbase.Lite.Internal.Serialization
 
         public MContext(FLSlice data)
         {
-            Data = data;
+            _data = data;
         }
 
         ~MContext()
@@ -64,12 +68,17 @@ namespace Couchbase.Lite.Internal.Serialization
 
         protected virtual void Dispose(bool disposing)
         {
-            #if DEBUG
-            Disposed = true;
-            #endif
+            _disposed = true;
         }
 
         #endregion
+
+        internal void CheckDisposed()
+        {
+            if(_disposed) {
+                throw new ObjectDisposedException("MContext was disposed (probably QueryResultSet)");
+            }
+        }
 
         #region IDisposable
 


### PR DESCRIPTION
If the query is disposed, and then any of its results are used (in particular ones that involve collections are especially affected) then garbage native data will be used.  Try to catch this using Dispose and refuse to go further with it.