### PR TITLE
Fix an incorrect ifdef that was breaking the CE build

### DIFF
--- a/src/Couchbase.Lite.Shared/Support/WinUI/WinUIProxy.cs
+++ b/src/Couchbase.Lite.Shared/Support/WinUI/WinUIProxy.cs
@@ -44,7 +44,7 @@ namespace Couchbase.Lite.Support
 
         #region IProxy
 
-        public async Task<WebProxy> CreateProxyAsync(Uri destination)
+        public async Task<WebProxy?> CreateProxyAsync(Uri destination)
         {
             #if WINDOWS_PHONE 
             if (!_Logged) {

--- a/src/Couchbase.Lite.Shared/Support/netdesktop/DefaultDirectoryResolver.cs
+++ b/src/Couchbase.Lite.Shared/Support/netdesktop/DefaultDirectoryResolver.cs
@@ -17,7 +17,7 @@
 //
 
 // Windows 2012 doesn't define the more generic variants
-#if (NETFRAMEWORK || NET462 || NET6_0_OR_GREATER) && !__MOBILE__ && !NET6_0_WINDOWS10_0_19041_0
+#if (NETFRAMEWORK || NET462 || NET6_0_OR_GREATER) && !__MOBILE__ && !CBL_PLATFORM_WINUI
 using System;
 using System.IO;
 using Couchbase.Lite.DI;

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -52,6 +52,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SimpleInjector" Version="[5.2.1,6.0.0)" />
     <PackageReference Include="SerialQueue" Version="2.1.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" Include="Nullable" Version="1.3.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
     <PackageReference Condition=" $(TargetFramework.StartsWith('Xamarin')) or $(TargetFramework.StartsWith('MonoAndroid')) or '$(TargetFramework)' == 'net462' or $(TargetFramework.StartsWith('netstandard')) " Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Also add in a dev package that is now required for .NET 4.6.2 and .NET Standard to build correctly (nullable reference support via nuget package) and fix a mistaken mismatched nullability signature.