### PR TITLE
CBL-5547: Nullability regressions

### DIFF
--- a/src/AssemblyInfo.props
+++ b/src/AssemblyInfo.props
@@ -16,6 +16,7 @@
       <ContinuousIntegrationBuild>True</ContinuousIntegrationBuild>
       <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
       <LangVersion>latest</LangVersion>
+      <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>
     <ItemGroup>
       <None Include="$(MsBuildThisFileDirectory)..\..\packaging\nuget\logo.png" Pack="true" PackagePath=""/>

--- a/src/Couchbase.Lite.Shared/API/Query/Expression.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/Expression.cs
@@ -148,7 +148,7 @@ namespace Couchbase.Lite.Query
         /// </summary>
         /// <param name="value">The value to use</param>
         /// <returns>An expression representing the fixed value</returns>
-        public static IExpression String(string value) => new QueryConstantExpression<string>(value);
+        public static IExpression String(string? value) => new QueryConstantExpression<string?>(value);
 
         /// <summary>
         /// Returns an expression to represent a fixed <see cref="Object"/> value.  It must be one
@@ -156,7 +156,7 @@ namespace Couchbase.Lite.Query
         /// </summary>
         /// <param name="value">The value to use</param>
         /// <returns>An expression representing the fixed value</returns>
-        public static IExpression Value(object value) => new QueryConstantExpression<object>(value);
+        public static IExpression Value(object? value) => new QueryConstantExpression<object?>(value);
 
         #endregion
     }

--- a/src/Couchbase.Lite.Shared/API/Query/IIndex.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/IIndex.cs
@@ -52,6 +52,6 @@ namespace Couchbase.Lite.Query
         /// </summary>
         /// <param name="language">The language code in the form of ISO-639 language code</param>
         /// <returns>The index for further processing</returns>
-        IFullTextIndex SetLanguage(string language);
+        IFullTextIndex SetLanguage(string? language);
     }
 }

--- a/src/Couchbase.Lite.Shared/Util/CBDebug.cs
+++ b/src/Couchbase.Lite.Shared/Util/CBDebug.cs
@@ -59,7 +59,7 @@ namespace Couchbase.Lite.Util
             return argumentValue;
         }
 
-        public static IEnumerable<T> ItemsMustNotBeNull<T>(DomainLogger logger, string tag, string argumentName, IEnumerable<T> argumentValues) where T : class
+        public static IEnumerable<T> ItemsMustNotBeNull<T>(DomainLogger logger, string tag, string argumentName, IEnumerable<T?> argumentValues) where T : class
         {
             Debug.Assert(argumentValues != null);
             if (argumentValues == null) {


### PR DESCRIPTION
See #1607 for the discovery process, but these nullability annotations are incorrect, and there is a new behavior in .NET causing problems with the version string.