### PR TITLE
Fix a few tests that are no longer valid

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Document/Document.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/Document.cs
@@ -325,16 +325,28 @@ namespace Couchbase.Lite
             if (!(obj is Document d)) {
                 return false;
             }
+
+            // First check the collection and database match
+            // This needs to be done in a less strict way than
+            // normal comparison because we don't care as much that
+            // the exact instances are the same, just that they refer
+            // to the same on-disk entities
+            if(Database?.Path != d.Database?.Path || Collection?.FullName != d.Collection?.FullName) {
+                return false;
+            }
             
-            if (Id != d.Id || !Equals(Collection, d.Collection)) {
+            // Next check the ID
+            if (Id != d.Id) {
                 return false;
             }
 
+            // Do a quick check that the actual keys are the same
             var commonCount = Keys.Intersect(d.Keys).Count();
             if (commonCount != Keys.Count || commonCount != d.Keys.Count) {
                 return false; // The set of keys is different
             }
 
+            // Final fallback, examine every key and value
             return !(from key in Keys 
                 let left = GetValue(key) 
                 let right = d.GetValue(key) 

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -470,7 +470,7 @@ namespace Test
             using (var colA = Db.CreateCollection("colA", "scopeA"))
             using (var otherDB = OpenDB(Db.Name)) {
                 var cols = otherDB.GetCollections(scope: "scopeA");
-                cols.Contains(colA).Should().BeTrue();
+                cols.FirstOrDefault(x => x.Name == colA.Name).Should().NotBeNull();
                 using (var col = otherDB.GetCollection("colA", "scopeA"))
                     col.Should().NotBeNull();
             }
@@ -533,7 +533,7 @@ namespace Test
                     colATheSecondinOtherDb.Should().NotBeNull();
                     colATheSecondinOtherDb.Equals(colAinOtherDb).Should().BeFalse();
                     //Ensure that the collection is included when getting all collections from the database instance B by using database.getCollections(scope: "scopeA").
-                    otherDB.GetCollections("scopeA").Contains(colATheSecond).Should().BeTrue();
+                    otherDB.GetCollections("scopeA").FirstOrDefault(x => x.Name == colATheSecond.Name).Should().NotBeNull();
                 }  
             }
         }

--- a/src/Couchbase.Lite.Tests.Shared/TLSIdentityTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TLSIdentityTest.cs
@@ -154,15 +154,6 @@ namespace Test
                 ServerCertLabel,
                 null));
             badAction.Should().Throw<CouchbaseLiteException>(CouchbaseLiteErrorMessage.CreateCertAttributeEmpty);
-
-            // Create id with null Attributes
-            badAction = (() => TLSIdentity.CreateIdentity(true,
-                null,
-                null,
-                _store,
-                ServerCertLabel,
-                null));
-            badAction.Should().Throw<CouchbaseLiteException>(CouchbaseLiteErrorMessage.CreateCertAttributeEmpty);
         }
 
         [Fact]


### PR DESCRIPTION
Collection equality is more strict now so a few places that rely on equals need a different mechanism for comparison TLSIdentity.CreateIdentity does not allow null anymore via nullability instead of just checking at runtime so the exception changed away from empty cert attribute for null to just argument null exception (via compiler) Document equality needs to be relaxed back to the way it was whereby documents are equal if their contents are equal and they come from the same underlying database