### PR TITLE
While .NET 6 and above automatically uses native libs, Xamarin does not

### DIFF
--- a/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
+++ b/src/Couchbase.Lite.Support.Android/Couchbase.Lite.Support.Android.csproj
@@ -72,6 +72,8 @@
       <PackagePath>runtimes\android-x64\native</PackagePath>
       <Link>x86_64\libLiteCore.so</Link>
     </None>
+    <None Include="android.props" Pack="true" PackagePath="build\monoandroid\$(PackageId).props" />
+    <None Include="android.props" Pack="true" PackagePath="buildTransitive\monoandroid\$(PackageId).props" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">

--- a/src/Couchbase.Lite.Support.Android/android.props
+++ b/src/Couchbase.Lite.Support.Android/android.props
@@ -1,0 +1,19 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+      <_CblNugetRuntimePath Condition="'$(_CblNugetRuntimePath)' == ''">$(MSBuildThisFileDirectory)..\..\runtimes\</_CblNugetRuntimePath>
+    </PropertyGroup>
+    <ItemGroup>
+      <AndroidNativeLibrary Include="$(_CblNugetRuntimePath)android-arm\native\libLiteCore.so">
+        <Abi>armeabi-v7a</Abi>
+      </AndroidNativeLibrary>
+      <AndroidNativeLibrary Include="$(_CblNugetRuntimePath)android-x86\native\libLiteCore.so">
+        <Abi>x86</Abi>
+      </AndroidNativeLibrary>
+      <AndroidNativeLibrary Include="$(_CblNugetRuntimePath)android-arm64\native\libLiteCore.so">
+        <Abi>arm64-v8a</Abi>
+      </AndroidNativeLibrary>
+      <AndroidNativeLibrary Include="$(_CblNugetRuntimePath)android-x64\native\libLiteCore.so">
+        <Abi>x86_64</Abi>
+      </AndroidNativeLibrary>
+    </ItemGroup>
+  </Project>


### PR DESCRIPTION
It needs a special file to tell it to deploy LiteCore along with the application being built.