### PR TITLE
Fix too high precision in TestQueryExpressions

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -2189,7 +2189,7 @@ namespace Test
         [Fact]
         public void TestQueryExpressions()
         {
-            var doubleValue = Math.PI;
+            var doubleValue = Math.Round(Math.PI, 14);
             var floatValue = 1.5F;
             var longValue = 4294967296L;
             var value = (object)"stringObject";


### PR DESCRIPTION
Math.PI has 17 total digits but double can only guarantee 15, so round to 14 fractional for 15 total.  This test was failing because equality comparison was failing due to the high precision on iOS and Android