### PR TITLE
CBL-3505: Remove version specific RID from packaging

### DIFF
--- a/packaging/nuget/couchbase-lite-support-netdesktop.nuspec
+++ b/packaging/nuget/couchbase-lite-support-netdesktop.nuspec
@@ -36,8 +36,8 @@
     <file target="lib\net6.0\" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net6.0\Couchbase.Lite.Support.NetDesktop.dll" />
     <file target="lib\net6.0\" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net6.0\Couchbase.Lite.Support.NetDesktop.pdb" />
     <file target="lib\net6.0\" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net6.0\Couchbase.Lite.Support.NetDesktop.xml" />
-    <file target="runtimes\win10-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\x64\LiteCore.dll" />
-    <file target="runtimes\win10-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\x64\LiteCore.pdb" />
+    <file target="runtimes\win-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\x64\LiteCore.dll" />
+    <file target="runtimes\win-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\x64\LiteCore.pdb" />
     <file target="runtimes\osx\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\libLiteCore.dylib" />
     <file target="runtimes\linux-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\libLiteCore.so" />
     <file target="runtimes\linux-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\libstdc++.so" />
@@ -45,7 +45,7 @@
     <file target="runtimes\linux-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\libicudata.so.71" />
     <file target="runtimes\linux-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\libicui18n.so.71" />
     <file target="runtimes\linux-x64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\libicuuc.so.71" />
-    <file target="runtimes\win10-arm64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\arm64\LiteCore.dll" />
-    <file target="runtimes\win10-arm64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\arm64\LiteCore.pdb" />
+    <file target="runtimes\win-arm64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\arm64\LiteCore.dll" />
+    <file target="runtimes\win-arm64\native" src="src\Couchbase.Lite.Support.NetDesktop\bin\Packaging\net462\arm64\LiteCore.pdb" />
   </files>
 </package>

--- a/packaging/nuget/couchbase-lite-support-uwp.nuspec
+++ b/packaging/nuget/couchbase-lite-support-uwp.nuspec
@@ -30,9 +30,9 @@
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\Couchbase.Lite.Support.UWP.dll" />
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\Couchbase.Lite.Support.UWP.pdb" />
     <file target="lib\uap10.0.19041\" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\Couchbase.Lite.Support.UWP.xml" />
-    <file target="runtimes\win10-x64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\x64\LiteCore.dll" />
-    <file target="runtimes\win10-x64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\x64\LiteCore.pdb" />
-    <file target="runtimes\win10-arm64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\arm64\LiteCore.dll" />
-    <file target="runtimes\win10-arm64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\arm64\LiteCore.pdb" />
+    <file target="runtimes\win-x64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\x64\LiteCore.dll" />
+    <file target="runtimes\win-x64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\x64\LiteCore.pdb" />
+    <file target="runtimes\win-arm64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\arm64\LiteCore.dll" />
+    <file target="runtimes\win-arm64\native" src="src\Couchbase.Lite.Support.UWP\bin\Packaging\uap10.0.19041\arm64\LiteCore.pdb" />
   </files>
 </package>

--- a/packaging/nuget/couchbase-lite-support-winui.nuspec
+++ b/packaging/nuget/couchbase-lite-support-winui.nuspec
@@ -28,9 +28,9 @@
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.Support.WinUI.dll" />
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.Support.WinUI.pdb" />
     <file target="lib\net6.0-windows10.0.19041.0\" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\Couchbase.Lite.Support.WinUI.xml" />
-    <file target="runtimes\win10-x64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\x64\LiteCore.dll" />
-    <file target="runtimes\win10-x64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\x64\LiteCore.pdb" />
-    <file target="runtimes\win10-arm64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\arm64\LiteCore.dll" />
-    <file target="runtimes\win10-arm64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\arm64\LiteCore.pdb" />
+    <file target="runtimes\win-x64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\x64\LiteCore.dll" />
+    <file target="runtimes\win-x64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\x64\LiteCore.pdb" />
+    <file target="runtimes\win-arm64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\arm64\LiteCore.dll" />
+    <file target="runtimes\win-arm64\native" src="src\Couchbase.Lite.Support.WinUI\bin\Packaging\net6.0-windows10.0.19041.0\arm64\LiteCore.pdb" />
   </files>
 </package>

--- a/src/Couchbase.Lite.Support.NetDesktop/Activate.cs
+++ b/src/Couchbase.Lite.Support.NetDesktop/Activate.cs
@@ -97,7 +97,7 @@ namespace Couchbase.Lite.Support
                 var dllPath = Path.Combine(codeBase ?? "", architecture, "LiteCore.dll");
                 var dllPathAsp = Path.Combine(codeBase ?? "", "bin", architecture, "LiteCore.dll");
                 var dllPathRuntimes =
-                    Path.Combine(codeBase ?? "", "runtimes", $"win10-{architecture}", "native", "LiteCore.dll");
+                    Path.Combine(codeBase ?? "", "runtimes", $"win-{architecture}", "native", "LiteCore.dll");
                 var foundPath = default(string);
                 foreach (var path in new[] { dllPathRuntimes, dllPath, dllPathAsp}) {
                     foundPath = File.Exists(path) ? path : null;

--- a/src/Couchbase.Lite.Support.NetDesktop/desktop.targets
+++ b/src/Couchbase.Lite.Support.NetDesktop/desktop.targets
@@ -33,11 +33,11 @@
                 <Link>libLiteCore.dylib</Link>
                 <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             </Content>
-            <Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(MSBuildThisFileDirectory)..\runtimes\win10-x64\native\LiteCore.dll">
+            <Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\LiteCore.dll">
                 <Link>x64\LiteCore.dll</Link>
                 <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             </Content>
-			<Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(MSBuildThisFileDirectory)..\runtimes\win10-arm64\native\LiteCore.dll">
+			<Content Condition=" '$(OS)' == 'Windows_NT' " Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\LiteCore.dll">
                 <Link>arm64\LiteCore.dll</Link>
                 <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             </Content>


### PR DESCRIPTION
This mechanism is deprecated by Microsoft.  This change is manually ported from d000308b3510bc356b88723e467c6c8b3f6667ea because in 3.2 the packaging files are different (csproj vs nuspec).