### PR TITLE
CBL-5566: Replicator ID markings in logs

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -1042,15 +1042,13 @@ namespace Couchbase.Lite.Sync
                 sb.Append("<");
             }
 
-            if (Config.Continuous) {
-                sb.Append("*");
-            }
+            sb.Append(Config.Continuous ? '*' : 'o');
 
             if (Config.ReplicatorType.HasFlag(ReplicatorType.Push)) {
                 sb.Append(">");
             }
 
-            return $"{GetType().Name}[{sb} {Config.Target}]";
+            return $"{nameof(Replicator)}[{sb} {Config.Target}]";
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Query/QueryIndex.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryIndex.cs
@@ -103,9 +103,9 @@ namespace Couchbase.Lite.Internal.Query
             return this;
         }
 
-        public IFullTextIndex SetLanguage(string language)
+        public IFullTextIndex SetLanguage(string? language)
         {
-            _locale = language;
+            _locale = language ?? CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
             return this;
         }
 


### PR DESCRIPTION
.NET was already doing most of this, aside from an o for representing "one-shot"

Along for the ride in this commit is a nullability regression fix