### PR TITLE
CBL-5727: Throw exception instead of native crash with ColumnNames

### DIFF
--- a/src/Couchbase.Lite.Shared/Query/QueryBase.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryBase.cs
@@ -68,7 +68,16 @@ namespace Couchbase.Lite.Internal.Query
 
         internal SerialQueue DispatchQueue { get; } = new SerialQueue();
 
-        internal unsafe Dictionary<string, int> ColumnNames => CreateColumnNames(_c4Query);
+        internal unsafe Dictionary<string, int> ColumnNames
+        {
+            get {
+                if(_c4Query == null) {
+                    throw new ObjectDisposedException(nameof(QueryBase));
+                }
+
+                return CreateColumnNames(_c4Query);
+            }
+        }
 
         #endregion
 

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -2808,6 +2808,16 @@ namespace Test
             dict.GetString("foo").Should().Be("bar");
         }
 
+        [Fact]
+        [ForIssue("CBL-5727")]
+        public void TestColumnNamesAfterDispose()
+        {
+            var q = Db.CreateQuery(@"select foo from _") as QueryBase;
+            q.ColumnNames.Should().HaveCount(1, "because there is one column");
+            q.Dispose();
+            FluentActions.Invoking(() => q.ColumnNames).Should().Throw<ObjectDisposedException>("because the object was disposed");
+        }
+
         private void CreateDateDocs()
         {
             using (var doc = new MutableDocument()) {


### PR DESCRIPTION
Accessing ColumnNames after dispose will cause a native null deference without this fix.