### PR TITLE
CBL-5747: Don't use default value for Index null locale

### DIFF
--- a/src/Couchbase.Lite.Shared/Query/QueryIndex.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryIndex.cs
@@ -30,7 +30,7 @@ namespace Couchbase.Lite.Internal.Query
 
         private readonly IFullTextIndexItem[]? _ftsItems;
         private bool _ignoreAccents = Constants.DefaultFullTextIndexIgnoreAccents;
-        private string _locale = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+        private string? _locale = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
         private readonly IValueIndexItem[]? _valueItems;
 
         #endregion
@@ -105,7 +105,7 @@ namespace Couchbase.Lite.Internal.Query
 
         public IFullTextIndex SetLanguage(string? language)
         {
-            _locale = language ?? CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+            _locale = language;
             return this;
         }
 


### PR DESCRIPTION
It needs to stay null otherwise the stemming might have unexpected results if the default happens to be "en".