### PR TITLE
CBL-5781: Create a sanity suite of tests to run on tier 2 platforms

### DIFF
--- a/src/Couchbase.Lite.Tests.Android/Couchbase.Lite.Tests.Android.csproj
+++ b/src/Couchbase.Lite.Tests.Android/Couchbase.Lite.Tests.Android.csproj
@@ -27,7 +27,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
@@ -46,7 +46,7 @@
     <DebugSymbols>false</DebugSymbols>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>TRACE;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>

--- a/src/Couchbase.Lite.Tests.NetCore/Couchbase.Lite.Tests.NetCore.csproj
+++ b/src/Couchbase.Lite.Tests.NetCore/Couchbase.Lite.Tests.NetCore.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>LITECORE_PACKAGED;RELEASE;COUCHBASE_ENTERPRISE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+    <DefineConstants>$(DefineConstants);SANITY_ONLY</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="C\**" />
     <EmbeddedResource Remove="C\**" />

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -539,6 +539,7 @@ Transfer-Encoding: chunked";
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public async Task TestSerialQueue()
         {
@@ -558,6 +559,7 @@ Transfer-Encoding: chunked";
             Volatile.Write(ref testBool, true);
             (await t).Should().BeTrue();
         }
+#endif
 
         [Fact]
         public void TestAutoconvertJson()
@@ -640,7 +642,7 @@ Transfer-Encoding: chunked";
             }
         }
 
-        #if !NETCOREAPP3_1_OR_GREATER
+#if !NETCOREAPP3_1_OR_GREATER && !NET462_OR_GREATER
 
         [Fact]
         public async Task TestMainThreadScheduler()
@@ -657,7 +659,7 @@ Transfer-Encoding: chunked";
 
 #else
 
-        #endif
+#endif
 
         [Fact]
         public void TestCBDebugItemsMustNotBeNull()

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -767,13 +767,6 @@ namespace Test
         }
 
         [Fact]
-        public void TestClose()
-        {
-            Thread.Sleep(1500);
-            Db.Close();
-        }
-
-        [Fact]
         public void TestCloseTwice()
         {
             Db.Close();
@@ -917,6 +910,7 @@ namespace Test
                 "because a database can't be closed in the middle of a batch");
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestDeleteDBOpenByOtherInstance()
         {
@@ -928,6 +922,7 @@ namespace Test
                         "because an in-use database cannot be deleted");
             }
         }
+#endif
         
         [Fact]
         public void TestDeleteWithDefaultDirDB()
@@ -942,6 +937,7 @@ namespace Test
             System.IO.Directory.Exists(path).Should().BeFalse();
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestDeleteOpeningDBWithDefaultDir()
         {
@@ -954,6 +950,7 @@ namespace Test
                     e.Error == CouchbaseLiteError.Busy && e.Domain == CouchbaseLiteErrorType.CouchbaseLite);
             }
         }
+#endif
 
         [Fact]
         public void TestDeleteByStaticMethod()
@@ -971,6 +968,8 @@ namespace Test
             Database.Delete("db", dir);
             System.IO.Directory.Exists(path).Should().BeFalse("because the database was deleted");
         }
+
+#if !SANITY_ONLY
 
         [Fact]
         public void TestDeleteOpeningDBByStaticMethod()
@@ -993,6 +992,7 @@ namespace Test
                 e.Should().NotBeNull("because an exception is expected");
             }
         }
+#endif
 
         [Fact]
         public void TestDeleteNonExistingDBWithDefaultDir()
@@ -1234,17 +1234,17 @@ namespace Test
                 Directory = "/tmp/mydb"
             };
 
-            #if COUCHBASE_ENTERPRISE
+#if COUCHBASE_ENTERPRISE
             var key = new EncryptionKey("key");
             builder2.EncryptionKey = key;
-            #endif
+#endif
 
             var config2 = builder2;
             config2.Directory.Should().Be("/tmp/mydb", "because that is what was set");
 
-            #if COUCHBASE_ENTERPRISE
+#if COUCHBASE_ENTERPRISE
             config2.EncryptionKey.Should().Be(key, "because that is what was set");
-            #endif
+#endif
         }
 
         [Fact]
@@ -1256,10 +1256,10 @@ namespace Test
                 db.Config.Should().NotBeSameAs(config, "because the configuration should be copied and frozen");
                 db.Config.Directory.Should().Be(config.Directory, "because the directory should be the same");
 
-                #if COUCHBASE_ENTERPRISE
+#if COUCHBASE_ENTERPRISE
                 db.Config.EncryptionKey.Should().Be(config.EncryptionKey,
                     "because the encryption key should be the same");
-                #endif
+#endif
             }
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DocumentTest.cs
@@ -1901,6 +1901,7 @@ namespace Test
             DefaultCollection.GetDocumentExpiration("doc3").Should().Be(null);
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestSetExpirationOnDoc()
         {
@@ -1939,6 +1940,7 @@ namespace Test
                     .Times(5).WriteProgress(WriteLine).Delay(TimeSpan.FromMilliseconds(500)).Go().Should().BeTrue();
             }
         }
+#endif
 
         [Fact]
         public void TestGetExpirationFromDeletedDoc()
@@ -1988,6 +1990,7 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestSetAndUnsetExpirationOnDoc()
         {
@@ -2042,6 +2045,7 @@ namespace Test
                 DefaultCollection.GetDocument("doc3").Should().BeNull();
             }).Times(5).WriteProgress(WriteLine).Delay(TimeSpan.FromMilliseconds(500)).Go().Should().BeTrue();
         }
+#endif
 
         [Fact]
         public void TestExpireNow()
@@ -2058,6 +2062,7 @@ namespace Test
             DefaultCollection.GetDocument(docId).Should().BeNull("because the purge should happen immediately");
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestPurgeEvent()
         {
@@ -2077,6 +2082,7 @@ namespace Test
                 mre.Dispose();
             }
         }
+#endif
 
         [Fact]
         public void TestRevisionIDNewDoc()

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -208,6 +208,7 @@ namespace Test
             });
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestLogFilename()
         {
@@ -220,6 +221,7 @@ namespace Test
                 allFiles.Any(x => !regex.IsMatch(x)).Should().BeFalse("because all files should match the pattern");
             });
         }
+#endif
 
         [Fact]
         public void TestLogHeader()
@@ -252,7 +254,7 @@ namespace Test
             });
         }
 
-        #if !__ANDROID__ && !__IOS__
+#if !__ANDROID__ && !__IOS__
         [Fact]
         public void TestConsoleLoggingLevels()
         {
@@ -341,7 +343,7 @@ namespace Test
             
             Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
         }
-        #endif
+#endif
 
         [Fact]
         public void TestCustomLoggingLevels()

--- a/src/Couchbase.Lite.Tests.Shared/NotificationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/NotificationTest.cs
@@ -140,6 +140,7 @@ namespace Test
             _wa.WaitForResult(TimeSpan.FromSeconds(5));
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestCollectionDocumentChange()
         {
@@ -203,6 +204,7 @@ namespace Test
                 _expectedDocumentChanges.Clear();
             }
         }
+#endif
 
         [Fact]
         public async Task TestAddSameChangeListeners()
@@ -398,6 +400,7 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public async Task TestCollectionChangeListener()
         {
@@ -477,6 +480,7 @@ namespace Test
                 _unexpectedDocumentChanges.Count.Should().Be(3);
             }
         }
+#endif
 
         private void CollectionChanged(object sender, CollectionChangedEventArgs args)
         {

--- a/src/Couchbase.Lite.Tests.Shared/P2PTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/P2PTest.cs
@@ -72,6 +72,7 @@ namespace Test
             //Database.Log.Console.Level = LogLevel.Debug;
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestShortP2P()
         {
@@ -167,6 +168,7 @@ namespace Test
 
         [Fact]
         public void TestP2PRecoverableFailureDuringReceive() => TestP2PError(MockConnectionLifecycleLocation.Receive, true);
+#endif
 
         [Fact]
         public void TestP2PPermanentFailureDuringOpen() => TestP2PError(MockConnectionLifecycleLocation.Connect, false);
@@ -193,6 +195,7 @@ namespace Test
             RunReplication(config, (int)CouchbaseLiteError.WebSocketUserPermanent, CouchbaseLiteErrorType.CouchbaseLite, true);
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestP2PPassiveClose()
         {
@@ -230,6 +233,7 @@ namespace Test
                     .NotBeNull("because closing the passive side creates an error on the active one");
             }
         }
+#endif
 
         [Fact]
         public void TestP2PPassiveCloseAll()

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -111,6 +111,7 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestQueryDocumentExpirationAfterDocsExpired()
         {
@@ -153,6 +154,7 @@ namespace Test
                 }
             }).Times(5).Delay(TimeSpan.FromMilliseconds(500)).Go().Should().BeTrue();
         }
+#endif
 
         [Fact]
         public void TestQueryDocumentExpiration()
@@ -301,7 +303,7 @@ namespace Test
             parameters.GetValue(utcNow.ToShortDateString()).Should().Be(utcNow);
         }
 
-        #if !CBL_NO_EXTERN_FILES
+#if !CBL_NO_EXTERN_FILES
         [Fact]
         public void TestNoWhereQuery()
         {
@@ -322,7 +324,7 @@ namespace Test
                 numRows.Should().Be(100, "because otherwise the incorrect number of rows was returned");
             }
         }
-        #endif
+#endif
 
         [Fact]
         [Obsolete]
@@ -565,7 +567,7 @@ namespace Test
             RunTestWithNumbers(new[] { 5 }, cases);
         }
 
-        #if !CBL_NO_EXTERN_FILES
+#if !CBL_NO_EXTERN_FILES
         [Fact]
         public void TestWhereIn()
         {
@@ -736,7 +738,8 @@ namespace Test
                 }
             }
         }
-        
+
+#if !SANITY_ONLY
         [Fact]
         public void TestQueryObserver()
         {
@@ -749,6 +752,7 @@ namespace Test
             TestQueryObserverWithQuery(query, isLegacy: true);
             query.Dispose();
         }
+#endif
 
         [Fact]
         public void TestMultipleQueryObservers()
@@ -778,7 +782,7 @@ namespace Test
             query.Dispose();
         }
 
-        #endif
+#endif
 
         [Fact]
         public void TestSelectDistinct()
@@ -832,11 +836,13 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public async Task TestLiveQueryNoUpdate() => await TestLiveQueryNoUpdateInternal(false);
 
         [Fact]
         public async Task TestLiveQueryNoUpdateConsumeAll() => await TestLiveQueryNoUpdateInternal(true);
+#endif
 
         [Fact]
         public void TestJoin()
@@ -986,7 +992,7 @@ namespace Test
             }
         }
 
-        #if !CBL_NO_EXTERN_FILES
+#if !CBL_NO_EXTERN_FILES
         [Fact]
         public void TestGroupBy()
         {
@@ -1045,7 +1051,7 @@ namespace Test
                 numRows.Should().Be(15);
             }
         }
-        #endif
+#endif
 
         [Fact]
         public void TestParameters()
@@ -1238,7 +1244,7 @@ namespace Test
             }
         }
 
-        #if !CBL_NO_EXTERN_FILES
+#if !CBL_NO_EXTERN_FILES
         [Fact]
         public void TestQueryResult()
         {
@@ -1267,7 +1273,7 @@ namespace Test
                 numRows.Should().Be(100);
             }
         }
-        #endif
+#endif
 
         [Fact]
         public void TestQueryProjectingKeys()
@@ -1431,7 +1437,7 @@ namespace Test
             }
         }
 
-        #if !CBL_NO_EXTERN_FILES
+#if !CBL_NO_EXTERN_FILES
         [Fact]
         public void TestQuantifiedOperators()
         {
@@ -1466,7 +1472,7 @@ namespace Test
                 received.Count.Should().Be(0, "because nobody likes taxes...");
             }
         }
-        #endif
+#endif
 
         [Fact]
         public void TestQuantifiedOperatorVariableKeyPath()

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -385,11 +385,13 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestReplicatorMaxAttempts() => ReplicatorMaxAttempts(3);
 
         [Fact]
         public void TestReplicatorOneMaxAttempts() => ReplicatorMaxAttempts(1);
+#endif
 
         [Fact]
         public void TestReadOnlyConfiguration()
@@ -826,6 +828,7 @@ namespace Test
             OtherDefaultCollection.GetDocument("doc1").Should().NotBeNull();
         }
 
+#if !SANITY_ONLY
         [Fact]
         public async Task TestReplicatorStopWhenClosed()
         {
@@ -891,6 +894,7 @@ namespace Test
                 }
             }
         }
+#endif
 
         [Fact]
         public void TestDocumentEndedEvent()
@@ -1585,6 +1589,7 @@ namespace Test
             q.Clear();
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestDoubleConflictResolutionOnSameConflicts()
         {
@@ -1672,6 +1677,7 @@ namespace Test
                 doc.GetBlob("blob")?.Content.Should().Contain(new byte[] { 7, 7, 7 });
             }
         }
+#endif
 
         [Fact]
         public void TestConflictResolverExceptionWhenDocumentIsPurged()
@@ -1705,6 +1711,7 @@ namespace Test
             });
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestConflictResolverExceptionsReturnDocFromOtherDBThrown()
         {
@@ -1721,6 +1728,7 @@ namespace Test
                 thirdDb.Delete();
             }
         }
+#endif
 
         [Fact]
         public void TestConflictResolverExceptionThrownInConflictResolver()
@@ -1833,6 +1841,7 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestConflictResolverReturningBlobFromDifferentDB()
         {
@@ -1847,6 +1856,7 @@ namespace Test
 
             TestConflictResolverExceptionThrown(blobFromOtherDbResolver, false, true);
         }
+#endif
 
         //CBL-623: Revision flags get cleared while saving resolved document
         [Fact]
@@ -1893,11 +1903,13 @@ namespace Test
         [Fact]
         public void TestDeleteWithActiveReplications() => WithActiveReplications(false);
 
+#if !SANITY_ONLY
         [Fact]
         public void TestCloseWithActiveReplicationAndQuery() => WithActiveReplicationAndQuery(true);
 
         [Fact]
         public void TestDeleteWithActiveReplicationAndQuery() => WithActiveReplicationAndQuery(false);
+#endif
 
         // Pending Doc Ids unit tests
 
@@ -1952,6 +1964,7 @@ namespace Test
         [Fact]
         public void TestPendingDocIDsWithFilter() => ValidatePendingDocumentIds(PENDING_DOC_ID_SEL.FILTER);
 
+#if !SANITY_ONLY
         [Fact]
         public void TestIsDocumentPendingPullOnlyException()
         {
@@ -1989,6 +2002,7 @@ namespace Test
 
             }
         }
+#endif
 
         [Fact]
         public void TestIsDocumentPendingWithCreate() => ValidateIsDocumentPending(PENDING_DOC_ID_SEL.CREATE);

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -246,6 +246,7 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestCollectionNameLength()
         {
@@ -268,6 +269,7 @@ namespace Test
             Action badAction = (() => Db.CreateCollection(str));
             badAction.Should().Throw<CouchbaseLiteException>($"Invalid collection name '{str}' in scope because the collection name length {str.Length} is over naming length limit.");
         }
+#endif
 
         [Fact] 
         public void TestCollectionNameCaseSensitive()
@@ -348,6 +350,7 @@ namespace Test
             }
         }
 
+#if !SANITY_ONLY
         [Fact]
         public void TestScopeNameLength()
         {
@@ -370,6 +373,7 @@ namespace Test
             Action badAction = (() => Db.CreateCollection("abc", str));
             badAction.Should().Throw<CouchbaseLiteException>($"Invalid scope name '{str}' because the scope name length {str.Length} is over naming length limit.");
         }
+#endif
 
         [Fact]
         public void TestScopeNameCaseSensitive()
@@ -432,7 +436,7 @@ namespace Test
             }
         }
 
-        #endregion
+#endregion
 
         #region 8.3 Collections and Cross Database Instance
 
@@ -540,8 +544,9 @@ namespace Test
 
         #endregion
 
-        #region 8.5 Use Collection APIs on Deleted Collection
+#region 8.5 Use Collection APIs on Deleted Collection
 
+#if !SANITY_ONLY
         [Fact]
         public void TestUseCollectionAPIsOnDeletedCollection()
         {
@@ -676,18 +681,21 @@ namespace Test
                     .Should().Throw<CouchbaseLiteException>("Because RemoveChangeListener after collection colA is deleted from the other db.");
             }
         }
+#endif
 
-        #endregion
+#endregion
 
-        #region 8.6 Use Collection API on Closed or Deleted Database
+#region 8.6 Use Collection API on Closed or Deleted Database
 
+#if !SANITY_ONLY
         [Fact]
         public void TestUseCollectionAPIsWhenDatabaseIsClosed() => TestUseCollectionAPIs(() => Db.Close());
 
         [Fact]
         public void TestUseCollectionAPIsWhenDatabaseIsDeleted() => TestUseCollectionAPIs(() => Db.Delete());
+#endif
 
-        #endregion
+#endregion
 
         #region 8.7 Use Scope API on Closed or Deleted Database
 

--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.QueryTest.cs
@@ -62,6 +62,7 @@ namespace Test
 
 #if !CBL_NO_EXTERN_FILES
 
+#if !SANITY_ONLY
         [Fact]
         public void TestQueryObserver()
         {
@@ -75,6 +76,7 @@ namespace Test
             TestQueryObserverWithQuery(query, isLegacy: false);
             query.Dispose();
         }
+#endif
 
         [Fact]
         public void TestMultipleQueryObservers()

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -591,7 +591,10 @@ namespace Test
                     wait2.Set();
                 });
 
-                WaitHandle.WaitAll(new[] { wait1.WaitHandle, wait2.WaitHandle }, TimeSpan.FromSeconds(2)).Should().BeTrue();
+                foreach (var handle in new[] { wait1, wait2 }) {
+                    handle.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+                }
+
                 qCount.Should().Be(1, "because we should have received a callback");
                 qResultCnt.Should().Be(8);
                 q1Count.Should().Be(1, "because we should have received a callback");

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -303,7 +303,8 @@ namespace Test
             wrongPwSecureString.Dispose();
         }
 
-        #if !NET_ANDROID
+#if !NET_ANDROID
+#if !SANITY_ONLY
         [Fact]
         public void TestClientCertAuthWithCallback()
         {
@@ -371,8 +372,10 @@ namespace Test
             TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
             
         }
-        #endif
-        
+#endif
+#endif
+
+#if !SANITY_ONLY
         [Fact]
         public void TestClientCertAuthRootCertsError()
         {
@@ -405,18 +408,20 @@ namespace Test
             TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
             _listener.Stop();
         }
+#endif
 
-        #if !NET_ANDROID
+#if !NET_ANDROID
+#if !SANITY_ONLY
         [Fact]
         public void TestClientCertAuthenticatorRootCerts()
         {
             byte[] caData = GetFileByteArray("client-ca.der", typeof(URLEndpointListenerTest));
 
-            #if NET_ANDROID
+#if NET_ANDROID
             byte[] clientData = GetFileByteArray("client.pfx", typeof(URLEndpointListenerTest));
-            #else
+#else
             byte[] clientData = GetFileByteArray("client.p12", typeof(URLEndpointListenerTest)); 
-            #endif
+#endif
 
             var rootCert = new X509Certificate2(caData);
             var auth = new ListenerCertificateAuthenticator(new X509Certificate2Collection(rootCert));
@@ -443,15 +448,16 @@ namespace Test
             TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
             _listener.Stop();
         }
+#endif
 
         [Fact]
         public void TestListenerWithImportIdentity()
         {
-			#if NET_ANDROID
+#if NET_ANDROID
             byte[] serverData = GetFileByteArray("client.pfx", typeof(URLEndpointListenerTest));
-			#else 
+#else
             byte[] serverData = GetFileByteArray("client.p12", typeof(URLEndpointListenerTest)); 
-            #endif
+#endif
 
             // Cleanup
             TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
@@ -598,8 +604,8 @@ namespace Test
 
             _listener.Stop();
         }
-        #endif
-        
+#endif
+
         [Fact]
         public void TestEmptyNetworkInterface()
         {
@@ -670,6 +676,7 @@ namespace Test
             OtherDefaultCollection.Count.Should().Be(2);
         }
 
+#if !SANITY_ONLY
         // A three way replication with one database acting as both a listener
         // and a replicator
         [Fact]
@@ -741,7 +748,8 @@ namespace Test
             Thread.Sleep(500); // wait for everything to stop
         }
 #endif
-        
+#endif
+
         [Fact]
         public void TestReadOnlyListener()
         {
@@ -783,6 +791,7 @@ namespace Test
         [Fact]
         public void TestReplicatorServerCertWithTLSError() => CheckReplicatorServerCert(true, false);
 
+#if !SANITY_ONLY
         [Fact] //hang maui android
         public void TestMultipleReplicatorsToListener()
         {
@@ -795,6 +804,7 @@ namespace Test
 
             ValidateMultipleReplications(ReplicatorType.PushAndPull, 3, 3);
         }
+#endif
 
 #if NET6_0_OR_GREATER
         [Fact] // Looks like MSBuild doesn't understand RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 
@@ -816,11 +826,14 @@ namespace Test
         }
 #endif
 
+#if !SANITY_ONLY
         [Fact] //hang maui android
         public void TestCloseWithActiveReplicationsAndURLEndpointListener() => WithActiveReplicationsAndURLEndpointListener(true);
 
         [Fact]//hang maui android
         public void TestDeleteWithActiveReplicationsAndURLEndpointListener() => WithActiveReplicationsAndURLEndpointListener(false);
+#endif
+
 #endif
 
         [Fact]

--- a/src/Couchbase.Lite.Tests.iOS/Couchbase.Lite.Tests.iOS.csproj
+++ b/src/Couchbase.Lite.Tests.iOS/Couchbase.Lite.Tests.iOS.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
-    <DefineConstants>DEBUG;__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>DEBUG;__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -58,7 +58,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -74,7 +74,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
-    <DefineConstants>DEBUG;__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>DEBUG;__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -92,7 +92,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Packaging|iPhoneSimulator'">
     <OutputPath>bin\iPhoneSimulator\Packaging\</OutputPath>
-    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -116,7 +116,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Packaging|iPhone'">
     <OutputPath>bin\iPhone\Packaging\</OutputPath>
-    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;LITECORE_PACKAGED;COUCHBASE_ENTERPRISE;SANITY_ONLY</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
The tests to exclude are only about 40, but those 40 account for about half of the test runtime (usually due to artificial thread sleeping and such).

Tier 2 platforms are largely judged by their re-use of an identical LiteCore on another platform:

Xamarin Android -> Same as .NET Android
Xamarin iOS -> Same as .NET iOS
.NET Mac Catalyst -> Same as .NET iOS
.NET WinUI -> Same as .NET 6
.NET Framework -> Same as .NET 6