### PR TITLE
Fix an apparently longstanding issue with core boolean methods

### DIFF
--- a/src/LiteCore/src/LiteCore.Shared/Interop/NativeHandler.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/NativeHandler.cs
@@ -151,9 +151,10 @@ namespace LiteCore.Interop
         public unsafe bool Execute(C4TryLogicDelegate1 block)
         {
             C4Error err;
-            if(block!(&err) || err.code == 0) {
+            var retVal = block(&err);
+            if (retVal || err.code == 0) {
                 Exception = null;
-                return true;
+                return retVal;
             }
 
             Exception = CouchbaseException.Create(err);


### PR DESCRIPTION
If they return false with an error code of 0, the platform interprets that (incorrectly) as true