### PR TITLE
CBL-6073: Implement FullSync feature (and update Core to 3.2.0-223)

### DIFF
--- a/core_version.ini
+++ b/core_version.ini
@@ -1,6 +1,6 @@
 [version]
-build = 3.2.0-220
+build = 3.2.0-223
 
 [hashes]
-ce = 7f0707145d9db2af04a9494ee7e271a8302a6a7c
+ce = 0b30e0c60b89efb879109194e4281012bffbfa98
 ee = 86734653b94fa6db9af16626a340f2ae6610f9c4

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -608,6 +608,10 @@ namespace Couchbase.Lite
                 }
                 #endif
                 using (var parentDirectory = new C4String(config?.Directory)) {
+                    // NOTE: config.FullSync is ignored since it is not useful for this process.
+                    // A temporary db is used during the copy so any errors or power outages
+                    // will simply result in the db not being copied, rather than any sort of
+                    // data loss or corruption.
                     nativeConfig.parentDirectory = parentDirectory.AsFLSlice();
                     return Native.c4db_copyNamed(path, name, &nativeConfig, err);
                 }
@@ -1339,7 +1343,11 @@ namespace Couchbase.Lite
             var config = DBConfig;
             var encrypted = "";
 
-            #if COUCHBASE_ENTERPRISE
+            if (Config.FullSync) {
+                config.flags |= C4DatabaseFlags.DiskSyncFull;
+            }
+
+#if COUCHBASE_ENTERPRISE
             if (Config.EncryptionKey != null) {
                 var key = Config.EncryptionKey;
                 var i = 0;

--- a/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
@@ -40,6 +40,7 @@ namespace Couchbase.Lite
 
         private string _directory =
             Service.GetRequiredInstance<IDefaultDirectoryResolver>().DefaultDirectory();
+        private bool _fullSync;
 
         #if COUCHBASE_ENTERPRISE
         private EncryptionKey? _encryptionKey;
@@ -56,6 +57,22 @@ namespace Couchbase.Lite
         {
             get => _directory;
             set => _freezer.SetValue(ref _directory, CBDebug.MustNotBeNull(WriteLog.To.Database, Tag, "Directory", value));
+        }
+
+        /// <summary>
+        /// There is a very small (though non-zero) chance that a power 
+        /// failure at just the wrong time could cause the most recently
+        /// committed transaction's changes to be lost. This would cause the
+        /// database to appear as it did immediately before that transaction.
+        /// Setting this mode true ensures that an operating system crash or
+        /// power failure will not cause the loss of any data.  FULL
+        /// synchronous is very safe but it is also dramatically slower.
+        /// </summary>
+        /// <returns>A boolean representing whether or not full sync is enabled</returns>
+        public bool FullSync
+        {
+            get => _fullSync;
+            set => _freezer.SetValue(ref _fullSync, value);
         }
 
         /// <summary>
@@ -108,6 +125,7 @@ namespace Couchbase.Lite
             var retVal = new DatabaseConfiguration
             {
                 Directory = Directory,
+                FullSync = FullSync
             };
 
             #if COUCHBASE_ENTERPRISE

--- a/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
+++ b/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
@@ -41,6 +41,12 @@ namespace Couchbase.Lite.Info;
 public static partial class Constants {
 
 	/// <summary>
+	/// Default value for <see cref="DatabaseConfiguration.FullSync" /> (false)
+	/// Full sync is off by default because the performance hit is seldom worth the benefit
+	/// </summary>
+	public static readonly bool DefaultDatabaseFullSync = false;
+
+	/// <summary>
 	/// Default value for <see cref="LogFileConfiguration.UsePlaintext" /> (false)
 	/// Plaintext is not used, and instead binary encoding is used in log files
 	/// </summary>

--- a/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
+++ b/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ScopesCollections.ReplicationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReplicationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScopeCollectionTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SQLiteOptionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TLSIdentityTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerfTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PredictiveQueryTest.cs" />

--- a/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
@@ -1,0 +1,103 @@
+//
+//  SQLiteOptionsTest.cs
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Implements 2.0.0 of https://github.com/couchbaselabs/couchbase-lite-api/blob/f6eab19e9bd38cd8c6ca66c3c4aad4cb7b50a659/spec/tests/T0003-SQLite-Options.md
+
+
+using Couchbase.Lite;
+using FluentAssertions;
+using LiteCore;
+using LiteCore.Interop;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Test
+{
+    public class SQLiteOptionsTest : TestCase
+    {
+        public SQLiteOptionsTest(ITestOutputHelper output) : base(output)
+        {
+
+        }
+
+        /// <summary>
+        /// 1. TestSQLiteFullSyncConfig
+        /// Description
+        ///     Test that the FullSync default is as expected and that it's setter and getter work.
+
+        /// Steps
+        ///     1. Create a DatabaseConfiguration object.
+        ///     2. Get and check the value of the FullSync property: it should be false.
+        ///     3. Set the FullSync property true
+        ///     4. Get the config FullSync property and verify that it is true
+        ///     5. Set the FullSync property false
+        ///     6. Get the config FullSync property and verify that it is false
+        /// </summary>
+        [Fact]
+        public unsafe void TestSQLiteFullSyncConfig()
+        {
+            var config = new DatabaseConfiguration();
+            config.FullSync.Should().BeFalse("because the default should be false");
+
+            config.FullSync = true;
+            config.FullSync.Should().BeTrue("because C# properties should work...");
+
+            config.FullSync = false;
+            config.FullSync.Should().BeFalse("because C# properties should work...");
+        }
+
+        /// <summary>
+        /// Description
+        ///     Test that a Database respects the FullSync property
+
+        /// Steps
+        ///     1. Create a DatabaseConfiguration object and set Full Sync false
+        ///     2. Create a database with the config
+        ///     3. Get the configuration object from the Database and verify that FullSync is false
+        ///     4. Use c4db_config2(perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_DiskSyncFull flag
+        ///     5. Set the config's FullSync property true
+        ///     6. Create a database with the config
+        ///     7. Get the configuration object from the Database and verify that FullSync is true
+        ///     8. Use c4db_config2 to confirm that its config contains the kC4DB_DiskSyncFull flag
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public unsafe void TestDBWithFullSync(bool useFullSync)
+        {
+            var config = new DatabaseConfiguration()
+            {
+                FullSync = useFullSync
+            };
+
+            Database.Delete("test", null);
+            using var db = new Database("test", config);
+            var c4db = db.c4db;
+            var nativeConfig = TestNative.c4db_getConfig2(c4db);
+            var hasFlag = (nativeConfig->flags & C4DatabaseFlags.DiskSyncFull) == C4DatabaseFlags.DiskSyncFull;
+            hasFlag.Should().Be(useFullSync, "because the flag in LiteCore should match FullSync");
+        }
+    }
+
+    internal unsafe static partial class TestNative
+    {
+        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern C4DatabaseConfig2* c4db_getConfig2(C4Database* database);
+    }
+}

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4DatabaseTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4DatabaseTypes_defs.cs
@@ -47,7 +47,8 @@ namespace LiteCore.Interop
         VersionVectors  = 0x08,
         NoUpgrade       = 0x20,
         NonObservable   = 0x40,
-        FakeVectorClock = 0x80,
+        DiskSyncFull    = 0x80,
+        FakeVectorClock = 0x100,
     }
 
     internal enum C4EncryptionAlgorithm : uint


### PR DESCRIPTION
This differs moderately from the 3.1 counterpart in the following ways for the tests (the actual logic, while not cherry picked, is identical via copy/paste):

1. 3.2 and newer don't expose c4db_getConfig2 directly from the library, but the same technique can be used in the test itself to resolve the native symbol (see TestNative in the new test file)
2. Theory is used instead of local function now that UWP is gone (it used a different underlying testing framework that didn't understand Theory)