### PR TITLE
Fix up issues that probably came in during a rebase

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,47 +38,7 @@ pipeline {
                         }
                         stage(".NET 6 Windows") {
                             steps {
-                                catchError {
-                                    powershell 'jenkins\\run_net6_tests.ps1'
-                                }
-								
-                                echo currentBuild.result
-                            }
-                        }
-                    }
-                }
-	            stage("Mac Node") {
-		            agent { label 'dotnet-mobile-mac-mini'  }
-			        environment {
-				        KEYCHAIN_PWD = credentials("mobile-mac-mini-keychain")
-                    }
-				    stages {
-				        stage("Checkout") {
-					        steps {
-						        sh '''#!/bin/bash
-                                set -e
-                                shopt -s extglob dotglob
-                                mkdir tmp
-                                mv !(tmp) tmp
-                                git clone git@github.com:couchbaselabs/couchbase-lite-net-ee --branch $BRANCH_NAME --depth 1 couchbase-lite-net-ee || \
-                                    git clone git@github.com:couchbaselabs/couchbase-lite-net-ee --branch $CHANGE_TARGET --depth 1 couchbase-lite-net-ee
-                                mv couchbase-lite-net-ee/* .
-                                mkdir couchbase-lite-net
-                                mv tmp/* couchbase-lite-net
-                                rmdir tmp couchbase-lite-net-ee
-
-                                # Make sure the latest tools are checked out
-                                git submodule update --init
-
-                                pushd jenkins
-                                git clone https://github.com/couchbaselabs/couchbase-lite-net-validation --depth 1 proj
-                                popd
-                                '''
-                            }
-                        }
-                        stage("Maui iOS") {
-                            steps {
-                                sh 'jenkins/run_net_ios_tests.sh'
+                                powershell 'jenkins\\run_net_console_tests.ps1'
                             }
                         }
                     }

--- a/core_version.ini
+++ b/core_version.ini
@@ -1,6 +1,6 @@
 [version]
-build = 3.3.0-37
+build = 3.3.0-45
 
 [hashes]
-ce = d5a2ecf7d4e6b237e07faad15e2022705aff10c0
+ce = 4cc44642384a951a66dcd65e98766b492db24169
 ee = 96ec113429275d21b7088e368c9e82ae84a0def7

--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -736,7 +736,7 @@ namespace Couchbase.Lite
         private void PostDocChanged(string documentID)
         {
             using var scope = ThreadSafety.BeginLockedScope();
-            if (!IsClosed && !_docObs.ContainsKey(documentID)) {
+            if (!IsClosed && _docObs.ContainsKey(documentID)) {
                 var change = new DocumentChangedEventArgs(documentID, this);
                 _documentChanged.Fire(documentID, this, change);
             }

--- a/src/Couchbase.Lite.Shared/Query/NQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/NQuery.cs
@@ -44,7 +44,7 @@ namespace Couchbase.Lite.Internal.Query
             _n1qlQueryExpression = n1qlQueryExpression;
 
             // Catch N1QL compile error sooner
-            _c4Query = Compile();
+            Compile();
         }
         #endregion
 
@@ -89,9 +89,9 @@ namespace Couchbase.Lite.Internal.Query
             return NativeSafe.c4query_explain(_c4Query) ?? defaultString;
         }
 
-        protected override unsafe C4QueryWrapper CreateQuery()
+        protected override unsafe void CreateQuery()
         {
-            return _c4Query ?? LiteCoreBridge.CheckTyped(err =>
+            _c4Query ??= LiteCoreBridge.CheckTyped(err =>
             {
                 Debug.Assert(Database?.c4db != null);
                 return NativeSafe.c4query_new2(Database!.c4db!, C4QueryLanguage.N1QLQuery, _n1qlQueryExpression, null, err);
@@ -124,11 +124,11 @@ namespace Couchbase.Lite.Internal.Query
 
         #region Private Methods
 
-        private unsafe C4QueryWrapper Compile()
+        private unsafe void Compile()
         {
             using var threadSafetyScope = ThreadSafety.BeginLockedScope();
             _disposalWatchdog.CheckDisposed();
-            return CreateQuery();
+            CreateQuery();
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/Query/QueryBase.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryBase.cs
@@ -189,7 +189,7 @@ namespace Couchbase.Lite.Internal.Query
 
         #region QueryBase
 
-        protected abstract C4QueryWrapper CreateQuery();
+        protected abstract void CreateQuery();
 
         protected abstract Dictionary<string, int> CreateColumnNames(C4QueryWrapper query);
 

--- a/src/Couchbase.Lite.Shared/Query/XQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/XQuery.cs
@@ -119,7 +119,7 @@ namespace Couchbase.Lite.Internal.Query
                     return null;
                 }
 
-                _c4Query = Check();
+                Check();
                 return NativeSafe.c4query_run(_c4Query, (FLSlice)paramJson, err);
             });
 
@@ -138,15 +138,15 @@ namespace Couchbase.Lite.Internal.Query
             _disposalWatchdog.CheckDisposed();
 
             // Used for debugging
-            _c4Query = Check();
+            Check();
 
             return NativeSafe.c4query_explain(_c4Query!) ?? defaultVal;
         }
 
-        protected override unsafe C4QueryWrapper CreateQuery()
+        protected override unsafe void CreateQuery()
         {
             if(_c4Query != null) {
-                return _c4Query;
+                return;
             }
 
             if (Database == null) {
@@ -154,7 +154,7 @@ namespace Couchbase.Lite.Internal.Query
                 Database = Collection!.Database;
             }
 
-            return LiteCoreBridge.CheckTyped(err =>
+            _c4Query = LiteCoreBridge.CheckTyped(err =>
             {
                 Debug.Assert(Database?.c4db != null);
                 _queryExpression = EncodeAsJSON();
@@ -253,7 +253,7 @@ namespace Couchbase.Lite.Internal.Query
             return JsonConvert.SerializeObject(parameters);
         }
 
-        private unsafe C4QueryWrapper Check()
+        private unsafe void Check()
         {
             var from = FromImpl;
             Debug.Assert(from != null, "Reached Check() without receiving a FROM clause!");
@@ -263,7 +263,7 @@ namespace Couchbase.Lite.Internal.Query
             _queryExpression = EncodeAsJSON();
             WriteLog.To.Query.I(Tag, $"Query encoded as {_queryExpression}");
 
-            return CreateQuery();
+            CreateQuery();
         }
 
         #endregion

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -672,7 +672,7 @@ Transfer-Encoding: chunked";
                         : queryWrapper.InstanceSafety;
                 }
 
-                lockEvent.WaitOne(TimeSpan.FromMilliseconds(100)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
+                lockEvent.WaitOne(TimeSpan.FromMilliseconds(500)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
                 using (var threadSafetyScope = threadSafety.BeginLockedScope()) {
                     sw.Stop();
                 }
@@ -725,7 +725,7 @@ Transfer-Encoding: chunked";
                         : documentWrapper.InstanceSafety;
                 }
 
-                lockEvent.WaitOne(TimeSpan.FromMilliseconds(100)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
+                lockEvent.WaitOne(TimeSpan.FromMilliseconds(500)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
                 using (var threadSafetyScope = threadSafety.BeginLockedScope()) {
                     sw.Stop();
                 }

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -672,7 +672,7 @@ Transfer-Encoding: chunked";
                         : queryWrapper.InstanceSafety;
                 }
 
-                lockEvent.WaitOne(TimeSpan.FromMilliseconds(500)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
+                lockEvent.WaitOne(TimeSpan.FromMinutes(1)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
                 using (var threadSafetyScope = threadSafety.BeginLockedScope()) {
                     sw.Stop();
                 }
@@ -725,7 +725,7 @@ Transfer-Encoding: chunked";
                         : documentWrapper.InstanceSafety;
                 }
 
-                lockEvent.WaitOne(TimeSpan.FromMilliseconds(500)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
+                lockEvent.WaitOne(TimeSpan.FromMinutes(1)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
                 using (var threadSafetyScope = threadSafety.BeginLockedScope()) {
                     sw.Stop();
                 }
@@ -778,7 +778,7 @@ Transfer-Encoding: chunked";
                         : documentWrapper.InstanceSafety;
                 }
 
-                lockEvent.WaitOne(TimeSpan.FromMilliseconds(100)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
+                lockEvent.WaitOne(TimeSpan.FromMinutes(1)).Should().BeTrue("because otherwise UseSafe was not entered {0}", iteration);
                 using (var threadSafetyScope = threadSafety.BeginLockedScope()) {
                     sw.Stop();
                 }

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -40,8 +40,15 @@ using Xunit.Abstractions;
 
 namespace Test
 {
+
     public class QueryTest : TestCase
     {
+        public enum QueryTestMode
+        {
+            SQL,
+            QueryBuilder
+        }
+
         Type queryTypeExpressionType = typeof(QueryTypeExpression);
 
         public QueryTest(ITestOutputHelper output) : base(output)
@@ -762,17 +769,17 @@ namespace Test
 
         // How to use N1QL Query Parameter
         // https://docs.couchbase.com/couchbase-lite/3.0/csharp/query-n1ql-mobile.html#lbl-query-params
-        [Fact]
-        public void TestQueryObserverWithChangingQueryParameters()
+        [Theory]
+        [InlineData(QueryTestMode.SQL)]
+        [InlineData(QueryTestMode.QueryBuilder)]
+        public void TestQueryObserverWithChangingQueryParameters(QueryTestMode mode)
         {
-            var n1qlQ = Db.CreateQuery("SELECT META().id, contact FROM _ WHERE contact.address.state = $state");
-            TestQueryObserverWithChangingQueryParametersWithQuery(n1qlQ);
-            n1qlQ.Dispose();
-            var query = QueryBuilder.Select(DocID, SelectResult.Expression(Expression.Property("contact")))
-                .From(DataSource.Collection(DefaultCollection))
-                .Where(Expression.Property("contact.address.state").EqualTo(Expression.Parameter("state")));
+            using var query = mode == QueryTestMode.SQL
+                ? Db.CreateQuery("SELECT META().id, contact FROM _ WHERE contact.address.state = $state")
+                : QueryBuilder.Select(DocID, SelectResult.Expression(Expression.Property("contact")))
+                    .From(DataSource.Collection(DefaultCollection))
+                    .Where(Expression.Property("contact.address.state").EqualTo(Expression.Parameter("state")));
             TestQueryObserverWithChangingQueryParametersWithQuery(query);
-            query.Dispose();
         }
 
 #endif

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -531,7 +531,8 @@ namespace Test
                     colATheSecondinOtherDb.Should().NotBeNull();
                     colATheSecondinOtherDb.Should().NotBe(colAinOtherDb, "because this is a recreated collection");
                     //Ensure that the collection is included when getting all collections from the database instance B by using database.getCollections(scope: "scopeA").
-                    otherDB.GetCollections("scopeA").Should().Contain(colATheSecond);
+                    otherDB.GetCollections("scopeA").Any(x => x.FullName == colATheSecond.FullName).Should()
+                        .BeTrue("because the other DB should also be able to see the recreated collection");
                 }  
             }
         }

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -602,7 +602,7 @@ namespace Test
 
         protected void TestQueryObserverWithChangingQueryParametersWithQuery(IQuery query, bool isLegacy = true)
         {
-            LoadJSONResource("names_100", coll: isLegacy == true ? null : CollA);
+            LoadJSONResource("names_100", coll: isLegacy ? null : CollA);
             var qParameters = new Parameters().SetString("state", "CA");
             query.Parameters = qParameters;
             //query.Parameters.SetString("state", "CA"); //This works as well

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -73,8 +73,8 @@ namespace Test
     {
         #region Constants
 
-        private const ushort WsPort = 4984;
-        private const ushort WssPort = 4985;
+        private const ushort WsPort = 5984;
+        private const ushort WssPort = 5985;
         private const string ServerCertLabel = "CBL-Server-Cert";
         private const string ClientCertLabel = "CBL-Client-Cert";
 

--- a/src/LiteCore/src/LiteCore.Shared/API/NativeWrapper.cs
+++ b/src/LiteCore/src/LiteCore.Shared/API/NativeWrapper.cs
@@ -28,7 +28,7 @@ namespace LiteCore.Interop;
 internal abstract class NativeWrapper : IDisposable
 {
     protected readonly IntPtr _nativeInstance;
-    private int _refCount;
+    private int _refCount = 1;
     private AtomicBool _disposed = false;
 
     public ThreadSafety InstanceSafety { get; }

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Collection_native_safe.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Collection_native_safe.cs
@@ -40,6 +40,9 @@ internal unsafe sealed class C4CollectionWrapper : NativeWrapper
     public C4CollectionWrapper(C4Collection* c, C4DatabaseWrapper parent)
         : base((IntPtr)c, parent.InstanceSafety)
     {
+        // We don't own the collection objects from Core, so let's retain them
+        // so that we can better predict their lifecycle
+        Native.c4coll_retain(c);
         Parent = parent;
     }
 

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Socket_native_safe.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Socket_native_safe.cs
@@ -69,7 +69,8 @@ internal static unsafe partial class NativeSafe
             return null;
         }
 
-        return new C4SocketWrapper(rawSocket);
+        // Noted in LiteCore headers, this return value must be immediately retained
+        return new C4SocketWrapper(Native.c4socket_retain(rawSocket));
     }
 
     // Socket Exclusive Methods


### PR DESCRIPTION
There are a lot of things going on here but this gives me a green test run:

1. Incorrect logic for firing document changed listener
2. Revert to NQuery and XQuery that create the internal C4Query in a void method, rather than returning
3. Database test for query listener has redundant logic that seems to prove nothing
4. Migrate two tests that were testing two modes each into one test each with two variants to be more clear about which one failed
5. Fix a test issue comparing collections from different databases since that was changed to not be allowed
6. Change ports on TestBusyPort so that it doesn't fail when I happen to have Sync Gateway running (which uses the same port)
7. Fix awful error where nativewrapper will never free any native objects because it's ref count starts at 0 instead of 1
8. Retain C4Collection and C4Socket's that don't get created just for the platform side
9. Bump LiteCore to 3.3.0-45
10. Get rid of Jenkins dead weight that is not helping much.  This will give more green PR validations, but the post build tests will still be a pain to work with.