### PR TITLE
Cleanup defines in the project

### DIFF
--- a/src/Couchbase.Lite.Shared/API/DI/Service.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/Service.cs
@@ -82,9 +82,6 @@ namespace Couchbase.Lite.DI
             #endif
             #elif __IOS__
             Service.AutoRegister(typeof(Database).Assembly);
-            #elif NETSTANDARD2_0
-            throw new RuntimeException(
-                "Pure .NET Standard variant executed.  This means that Couchbase Lite is running on an unsupported platform");
             #else
             #error Unknown Platform
             #endif

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <Configurations>Debug;Release;Packaging;PackagingDebug</Configurations>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net462;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net462;net8.0</TargetFrameworks>
 	<SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -78,16 +78,6 @@
       <Link>libLiteCore.so</Link>
       <Pack>true</Pack>
       <PackagePath>runtimes/linux-x64/native/libLiteCore.so</PackagePath>
-    </None>
-    <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\linux\x86_64\lib\libstdc++.so">
-      <Link>libLiteCore.so</Link>
-      <Pack>true</Pack>
-      <PackagePath>runtimes/linux-x64/native/libstdc++.so</PackagePath>
-    </None>
-    <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\linux\x86_64\lib\libstdc++.so.6">
-      <Link>libLiteCore.so.6</Link>
-      <Pack>true</Pack>
-      <PackagePath>runtimes/linux-x64/native/libstdc++.so.6</PackagePath>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\vendor\prebuilt_core\linux\x86_64\lib\libicudata.so.71">
       <Link>libicudata.so.71</Link>

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -588,7 +588,7 @@ Transfer-Encoding: chunked";
             }
         }
 
-#if !NETCOREAPP3_1_OR_GREATER && !NET462_OR_GREATER
+#if __ANDROID__ || __IOS__ || WINUI
 
         [Fact]
         public async Task TestMainThreadScheduler()
@@ -607,7 +607,7 @@ Transfer-Encoding: chunked";
             onMainThread.Should().BeTrue();
         }
 
-        #endif
+#endif
 
         [Fact]
         public void TestCBDebugItemsMustNotBeNull()

--- a/src/Couchbase.Lite.Tests.Shared/CouchbaseTestFramework.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CouchbaseTestFramework.cs
@@ -1,4 +1,20 @@
-﻿#if !WINDOWS_UWP
+﻿//
+// CouchbaseTestFramework.cs
+//
+// Copyright (c) 2023 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;
@@ -144,5 +160,3 @@ namespace Test
         }
     }
 }
-
-#endif

--- a/src/Couchbase.Lite.Tests.Shared/LoadTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LoadTest.cs
@@ -38,27 +38,17 @@ using Couchbase.Lite.Util;
 using FluentAssertions;
 using LiteCore;
 using LiteCore.Interop;
-#if !WINDOWS_UWP
 using Xunit;
 using Xunit.Abstractions;
-#else
-using Fact = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
-#endif
 
 namespace Test
 {
-#if WINDOWS_UWP
-    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
-#endif
     public sealed class LoadTest : TestCase
     {
-#if !WINDOWS_UWP
-
         public LoadTest(ITestOutputHelper output) : base(output)
         {
 
         }
-#endif
 
         [Fact]
         public void TestCreate()

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -38,7 +38,7 @@ namespace Test
 {
     public sealed class LogTest
     {
-        #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__ && !__IOS__ && !WINUI
+        #if NET6_0_OR_GREATER && !CBL_NO_VERSION_CHECK && !__ANDROID__ && !__IOS__ && !WINUI
         static LogTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -27,54 +27,32 @@ using Couchbase.Lite;
 using Couchbase.Lite.Logging;
 using FluentAssertions;
 using Test.Util;
-#if !WINDOWS_UWP
 using Xunit;
 using Xunit.Abstractions;
-#else
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Fact = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
-#endif
 
 namespace Test
 {
-    #if WINDOWS_UWP
-    [TestClass]
-    #endif
     public abstract class PerfTest
     {
-        #if !WINDOWS_UWP
         private ITestOutputHelper _output;
-        #else 
-        private TestContext _output;
-        public virtual TestContext TestContext
-        {
-            get => _output;
-            set {
-                _output = value;
-                Database.Log.Custom = new MSTestLogger(value) { Level = LogLevel.Info };
-            }
-        }
-        #endif
         public static string ResourceDir;
         private DatabaseConfiguration _dbConfiguration;
         private string _dbName;
 
         public Database Db { get; private set; }
 
-        #if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !NET_ANDROID && !__IOS__ && !WINUI
+        #if NET6_0_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET_ANDROID && !__IOS__ && !WINUI
         static PerfTest()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();
         }
         #endif
 
-        #if !WINDOWS_UWP
         protected PerfTest(ITestOutputHelper output)
         {
             _output = output;
             Database.Log.Custom = new XunitLogger(output) { Level = LogLevel.Info };
         }
-        #endif
 
         protected void SetOptions(DatabaseConfiguration dbConfiguration)
         {

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -253,19 +253,14 @@ namespace Test
         }
     }
 
-#if WINDOWS_UWP
-    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
-#endif
     public sealed class ReplicatorTest : ReplicatorTestBase
     {
         private bool _isFilteredCallback;
         private List<DocumentReplicationEventArgs> _replicationEvents = new List<DocumentReplicationEventArgs>();
 
-#if !WINDOWS_UWP
         public ReplicatorTest(ITestOutputHelper output) : base(output)
         {
         }
-#endif
 
 #if COUCHBASE_ENTERPRISE
 

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -84,7 +84,7 @@ namespace Test
         protected static string Directory => Path.Combine(Path.GetTempPath().Replace("cache", "files"), "CouchbaseLite");
 
 
-#if NETCOREAPP3_1_OR_GREATER && !CBL_NO_VERSION_CHECK && !NET6_0_WINDOWS10 && !__ANDROID__ && !__IOS__ && !WINUI
+#if NET6_0_OR_GREATER && !CBL_NO_VERSION_CHECK && !__ANDROID__ && !__IOS__ && !WINUI
         static TestCase()
         {
             Couchbase.Lite.Support.NetDesktop.CheckVersion();

--- a/src/Couchbase.Lite.Tests.Shared/TunesPerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TunesPerfTest.cs
@@ -31,18 +31,11 @@ using FluentAssertions;
 
 using Newtonsoft.Json;
 using Test.Util;
-#if !WINDOWS_UWP
 using Xunit;
 using Xunit.Abstractions;
-#else
-using Fact = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
-#endif
 
 namespace Test
 {
-#if WINDOWS_UWP
-    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
-#endif
     public sealed class TunesPerfTest : PerfTest
     {
         private int _documentCount;
@@ -59,7 +52,6 @@ namespace Test
         private Benchmark _indexFTSBench;
         private Benchmark _queryFTSBench;
 
-#if !WINDOWS_UWP
         public TunesPerfTest(ITestOutputHelper output) : base(output)
         {
             _importBench = new Benchmark(output);
@@ -73,25 +65,6 @@ namespace Test
             _indexFTSBench = new Benchmark(output);
             _queryFTSBench = new Benchmark(output);
         }
-#else
-        public override Microsoft.VisualStudio.TestTools.UnitTesting.TestContext TestContext
-        {
-            get => base.TestContext;
-            set {
-                base.TestContext = value;
-                _importBench = new Benchmark(value);
-                _updatePlayCountBench = new Benchmark(value);
-                _updateArtistsBench = new Benchmark(value);
-                _indexArtistsBench = new Benchmark(value);
-                _queryArtistsBench = new Benchmark(value);
-                _queryIndexedArtistsBench = new Benchmark(value);
-                _queryAlbumsBench = new Benchmark(value);
-                _queryIndexedAlbumsBench = new Benchmark(value);
-                _indexFTSBench = new Benchmark(value);
-                _queryFTSBench = new Benchmark(value);
-            }
-        }
-#endif
 
         [Fact]
         public void TestPerformance()

--- a/src/Couchbase.Lite.Tests.Shared/Util/Benchmark.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/Benchmark.cs
@@ -22,23 +22,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-#if !WINDOWS_UWP
 using Xunit;
 using Xunit.Abstractions;
-#else
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Fact = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
-#endif
 
 namespace Test.Util
 {
     internal sealed class Benchmark
     {
-#if !WINDOWS_UWP
         private readonly ITestOutputHelper _output;
-#else
-        private readonly TestContext _output;
-#endif
         private Stopwatch _st = new Stopwatch();
         private List<TimeSpan> _times = new List<TimeSpan>();
 
@@ -49,11 +40,7 @@ namespace Test.Util
             }
         }
 
-#if !WINDOWS_UWP
         public Benchmark(ITestOutputHelper output)
-#else 
-        public Benchmark(TestContext output)
-#endif
         {
             _output = output;
         }

--- a/src/Couchbase.Lite.Tests.Shared/Util/Try.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/Try.cs
@@ -23,11 +23,7 @@ using System.Threading;
 
 using FluentAssertions.Execution;
 
-#if !WINDOWS_UWP
 using Xunit.Sdk;
-#else
-using XunitException = Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException;
-#endif
 
 namespace Test.Util
 {

--- a/src/Couchbase.Lite.Tests.Shared/Util/XunitLogger.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/XunitLogger.cs
@@ -17,7 +17,6 @@
 // 
 #nullable disable
 
-#if !WINDOWS_UWP
 using System;
 
 using Couchbase.Lite.Logging;
@@ -67,50 +66,3 @@ namespace Test.Util
         #endregion
     }
 }
-#else
-using System;
-
-using Couchbase.Lite.DI;
-using Couchbase.Lite.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace Test.Util
-{
-    internal sealed class MSTestLogger : ILogger
-    {
-        #region Variables
-
-        private readonly TestContext _output;
-
-        #endregion
-
-        #region Properties
-
-        public LogLevel Level { get; set; } = LogLevel.Warning;
-
-        #endregion
-
-        #region Constructors
-
-        public MSTestLogger(TestContext output)
-        {
-            _output = output;
-        }
-
-        #endregion
-
-        #region ILogger
-
-        public void Log(LogLevel level, LogDomain domain, string message)
-        {
-            if (level < Level) {
-                return;
-            }
-
-            _output.WriteLine($"{level.ToString().ToUpperInvariant()}) {domain} {message}");
-        }
-
-        #endregion
-    }
-}
-#endif

--- a/src/Couchbase.Lite.Tests.Shared/WebSocketTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/WebSocketTest.cs
@@ -33,12 +33,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Net.NetworkInformation;
 
-#if !WINDOWS_UWP
 using Xunit;
 using Xunit.Abstractions;
-#else
-using Fact = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
-#endif
 
 namespace Test
 {
@@ -51,9 +47,6 @@ namespace Test
         void Write(byte[] data);
     }
 
-#if WINDOWS_UWP
-    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
-#endif
     public sealed unsafe class WebSocketTest : TestCase
     {
         Type WebSocketWrapperType = typeof(WebSocketWrapper);
@@ -62,11 +55,7 @@ namespace Test
         WebSocketWrapper webSocketWrapper;
         HTTPLogic hTTPLogic = new HTTPLogic(new Uri("ws://localhost:4984"));
 
-#if !WINDOWS_UWP
         public WebSocketTest(ITestOutputHelper output) : base(output)
-#else
-        public WebSocketTest()
-#endif
         {
             var dict = new ReplicatorOptionsDictionary();
             var authDict = new AuthOptionsDictionary();

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <MauiDotNetVersion>net8.0</MauiDotNetVersion>
-    <ConsoleDotNetVersion>net6.0</ConsoleDotNetVersion>
+    <ConsoleDotNetVersion>net8.0</ConsoleDotNetVersion>
     <DotNetFrameworkVersion>net462</DotNetFrameworkVersion>
     <Configurations>Debug;Release;Packaging;Debug_Coverage;Release_Coverage</Configurations>
     <TargetFrameworks>$(ConsoleDotNetVersion);$(MauiDotNetVersion)-android;$(MauiDotNetVersion)-ios;$(MauiDotNetVersion)-maccatalyst</TargetFrameworks>

--- a/src/LiteCore/src/LiteCore.Shared/Interop/NativeActivate.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/NativeActivate.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿//
+// NativeActivate.cs
+//
+// Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -25,9 +43,6 @@ namespace LiteCore.Interop
                     return System.Runtime.InteropServices.NativeLibrary.Load(libraryName);
                 });
             }
-#elif NETSTANDARD2_0
-            throw new PlatformNotSupportedException(
-                "Pure .NET Standard variant executed.  This means that Couchbase Lite is running on an unsupported platform");
 #endif
 
 #if NEEDS_LITECORE_LOAD


### PR DESCRIPTION
Remove defunct WINDOWS_UWP and NETSTANDARD2_0
Bump to net8.0 console since net6.0 support is ending in Nov 2024