### PR TITLE
CBL-6254: NativeWrapper finalizer should not consider refCount

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -16,6 +16,11 @@
 //  limitations under the License.
 //
 
+// Jenkins is so slow that the tests often fail just because they took
+// so long to run.  If running locally on a reasonable system, comment
+// this out to make the tests run faster.
+#define EXTRA_LONG_WRAPPER_TEST
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -55,6 +60,12 @@ namespace Test
     // tests too off track.
     public sealed class CSharpTest : TestCase
     {
+#if EXTRA_LONG_WRAPPER_TEST
+        private static readonly TimeSpan WrapperThreadBlockTime = TimeSpan.FromSeconds(2);
+#else
+        private static readonly TimeSpan WrapperThreadBlockTime = TimeSpan.FromMilliseconds(500);
+#endif
+
         public CSharpTest(ITestOutputHelper output) : base(output)
         {
         }
@@ -655,7 +666,7 @@ Transfer-Encoding: chunked";
                     queryWrapper.UseSafe(q =>
                     {
                         lockEvent.Set();
-                        Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                        Thread.Sleep(WrapperThreadBlockTime);
                     }, safetyLevel);
                 });
 
@@ -678,9 +689,9 @@ Transfer-Encoding: chunked";
                 }
 
                 if (blocking) {
-                    sw.Elapsed.TotalMilliseconds.Should().BeGreaterOrEqualTo(500, "because otherwise the lock didn't block ({0})", iteration);
+                    sw.Elapsed.Should().BeGreaterOrEqualTo(WrapperThreadBlockTime, "because otherwise the lock didn't block ({0})", iteration);
                 } else {
-                    sw.Elapsed.TotalMilliseconds.Should().BeLessThan(500, "because otherwise the lock blocked ({0})", iteration);
+                    sw.Elapsed.Should().BeLessThan(WrapperThreadBlockTime, "because otherwise the lock blocked ({0})", iteration);
                 }
 
                 iteration++;
@@ -707,7 +718,7 @@ Transfer-Encoding: chunked";
                     documentWrapper.UseSafe(q =>
                     {
                         lockEvent.Set();
-                        Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                        Thread.Sleep(WrapperThreadBlockTime);
                         return true;
                     }, safetyLevel);
                 });
@@ -731,9 +742,9 @@ Transfer-Encoding: chunked";
                 }
 
                 if (blocking) {
-                    sw.Elapsed.TotalMilliseconds.Should().BeGreaterOrEqualTo(500, "because otherwise the lock didn't block ({0})", iteration);
+                    sw.Elapsed.Should().BeGreaterOrEqualTo(WrapperThreadBlockTime, "because otherwise the lock didn't block ({0})", iteration);
                 } else {
-                    sw.Elapsed.TotalMilliseconds.Should().BeLessThan(500, "because otherwise the lock blocked ({0})", iteration);
+                    sw.Elapsed.Should().BeLessThan(WrapperThreadBlockTime, "because otherwise the lock blocked ({0})", iteration);
                 }
 
                 iteration++;
@@ -760,7 +771,7 @@ Transfer-Encoding: chunked";
                     indexWrapper.UseSafe(q =>
                     {
                         lockEvent.Set();
-                        Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                        Thread.Sleep(WrapperThreadBlockTime);
                         return true;
                     }, safetyLevel);
                 });
@@ -784,9 +795,9 @@ Transfer-Encoding: chunked";
                 }
 
                 if (blocking) {
-                    sw.Elapsed.TotalMilliseconds.Should().BeGreaterOrEqualTo(500, "because otherwise the lock didn't block ({0})", iteration);
+                    sw.Elapsed.Should().BeGreaterOrEqualTo(WrapperThreadBlockTime, "because otherwise the lock didn't block ({0})", iteration);
                 } else {
-                    sw.Elapsed.TotalMilliseconds.Should().BeLessThan(500, "because otherwise the lock blocked ({0})", iteration);
+                    sw.Elapsed.Should().BeLessThan(WrapperThreadBlockTime, "because otherwise the lock blocked ({0})", iteration);
                 }
 
                 iteration++;

--- a/src/LiteCore/src/LiteCore.Shared/API/NativeWrapper.cs
+++ b/src/LiteCore/src/LiteCore.Shared/API/NativeWrapper.cs
@@ -47,11 +47,12 @@ internal abstract class NativeWrapper : IDisposable
 
     ~NativeWrapper()
     {
-        // int is safe to access here
-        var refCount = Interlocked.Decrement(ref _refCount);
-        if (refCount == 0) {
-            Dispose(disposing: false);
-        }
+        // Unlike the Dispose method, if we have reached here
+        // that means that something forgot to Dispose and
+        // then the object went out of scope.  That means
+        // it is about to be garbage collected and needs to 
+        // clean up the unmanaged resources.
+        Dispose(disposing: false);
     }
 
     protected IDisposable BeginLockedScope(bool withInstanceLock, params ThreadSafety[] additionalSafeties)


### PR DESCRIPTION
Since at this point the object is about to be collected, which means nothing is referencing it and something forgot to call "Dispose".

Also, put in some workarounds for flakiness in Jenkins tests