### PR TITLE
CBL-6308: Implement MmapEnabled property on DatabaseConfiguration

### DIFF
--- a/core_version.ini
+++ b/core_version.ini
@@ -1,6 +1,6 @@
 [version]
-build = 3.2.1-8
+build = 3.2.1-9
 
 [hashes]
-ce = e589bd69aaad82fa44288069102b1df3b1671b1f
+ce = da8b267c0ef7ae36a814dc3f5af984f112dc2151
 ee = 86734653b94fa6db9af16626a340f2ae6610f9c4

--- a/core_version.ini
+++ b/core_version.ini
@@ -1,6 +1,6 @@
 [version]
-build = 3.2.1-5
+build = 3.2.1-8
 
 [hashes]
-ce = 55ddf2ca9410efadb88ed87b6370c07aeb908ef9
+ce = e589bd69aaad82fa44288069102b1df3b1671b1f
 ee = 86734653b94fa6db9af16626a340f2ae6610f9c4

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -1347,6 +1347,10 @@ namespace Couchbase.Lite
                 config.flags |= C4DatabaseFlags.DiskSyncFull;
             }
 
+            if(!Config.MmapEnabled) {
+                config.flags |= C4DatabaseFlags.MmapDisabled;
+            }
+
 #if COUCHBASE_ENTERPRISE
             if (Config.EncryptionKey != null) {
                 var key = Config.EncryptionKey;

--- a/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
@@ -45,8 +45,8 @@ namespace Couchbase.Lite
 
         private string _directory =
             Service.GetRequiredInstance<IDefaultDirectoryResolver>().DefaultDirectory();
-        private bool _fullSync;
-        private bool _mmapEnabled;
+        private bool _fullSync = Constants.DefaultDatabaseFullSync;
+        private bool _mmapEnabled = Constants.DefaultDatabaseMmapEnabled;
 
         #if COUCHBASE_ENTERPRISE
         private EncryptionKey? _encryptionKey;
@@ -82,8 +82,8 @@ namespace Couchbase.Lite
         }
 
         /// <summary>
-        /// Enables or disables memory-mapped I/O. By default, memory-mapped 
-        /// I/O is enabled.Disabling it may affect database performance.
+        /// Hint for enabling or disabling memory-mapped I/O. 
+        /// Disabling it may affect database performance.
         /// Typically, there is no need to modify this setting.
         /// </summary>
         /// <remarks>
@@ -124,11 +124,6 @@ namespace Couchbase.Lite
         /// </summary>
         public DatabaseConfiguration()
         {
-#if !MACCATALYST
-            if(!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                _mmapEnabled = Constants.DefaultDatabaseMmapEnabled;
-            }
-#endif
         }
 
 

--- a/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
@@ -142,11 +142,8 @@ namespace Couchbase.Lite
             {
                 Directory = Directory,
                 FullSync = FullSync,
+                MmapEnabled = MmapEnabled
             };
-
-            // Don't use the setter since it is unsupported on macOS
-            // This is a shortcut to save ifdefs and runtimeinformation checking
-            retVal._mmapEnabled = _mmapEnabled;
 
 #if COUCHBASE_ENTERPRISE
             retVal.EncryptionKey = EncryptionKey;

--- a/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
+++ b/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
@@ -47,6 +47,12 @@ public static partial class Constants {
 	public static readonly bool DefaultDatabaseFullSync = false;
 
 	/// <summary>
+	/// Default value for <see cref="DatabaseConfiguration.MmapEnabled" /> (true)
+	/// Memory mapped database files are enabled by default
+	/// </summary>
+	public static readonly bool DefaultDatabaseMmapEnabled = true;
+
+	/// <summary>
 	/// Default value for <see cref="LogFileConfiguration.UsePlaintext" /> (false)
 	/// Plaintext is not used, and instead binary encoding is used in log files
 	/// </summary>
@@ -140,7 +146,7 @@ public static partial class Constants {
 
 	/// <summary>
 	/// Default value for <see cref="VectorIndexConfiguration.DistanceMetric" /> (DistanceMetric.EuclideanSquared)
-	/// By default, vectors are compared using Squared Euclidean metrics
+	/// By default, vectors are compared using squared Euclidean metrics
 	/// </summary>
 	public static readonly DistanceMetric DefaultVectorIndexDistanceMetric = DistanceMetric.EuclideanSquared;
 

--- a/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
+++ b/src/Couchbase.Lite.Tests.Shared/Couchbase.Lite.Tests.Shared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)LoadTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LogTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MigrationTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MmapTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NotificationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)P2PTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScopesCollections.QueryTest.cs" />
@@ -42,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Util\Benchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\ForIssueAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\IMockConnectionErrorLogic.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)util\ImplementsTestSpecAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\MockConnection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\Try.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util\WaitAssert.cs" />

--- a/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
@@ -23,13 +23,12 @@ using System.Runtime.InteropServices;
 using Xunit;
 using Xunit.Abstractions;
 
-#if !__IOS__
-
 namespace Test
 {
     [ImplementsTestSpec("T0006-MMap-Config", "1.0.0")]
 #if NET6_0_OR_GREATER
     [System.Runtime.Versioning.UnsupportedOSPlatform("osx")]
+    [System.Runtime.Versioning.UnsupportedOSPlatform("maccatalyst")]
 #endif
     public sealed class MmapTest : TestCase
     {
@@ -53,31 +52,33 @@ namespace Test
         {
             Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), "Not supported on macOS");
 
+#if MACCATALYST
+            throw new SkipException("Not supported on Mac Catalyst");
+#else
             var config = new DatabaseConfiguration();
             config.MmapEnabled.Should().BeTrue();
-            config.FullSync.Should().BeFalse("because the default should be true");
+            config.MmapEnabled.Should().BeTrue("because the default should be true");
 
-            config.FullSync = false;
-            config.FullSync.Should().BeFalse("because C# properties should work...");
+            config.MmapEnabled = false;
+            config.MmapEnabled.Should().BeFalse("because C# properties should work...");
 
-            config.FullSync = true;
-            config.FullSync.Should().BeTrue("because C# properties should work...");
+            config.MmapEnabled = true;
+            config.MmapEnabled.Should().BeTrue("because C# properties should work...");
+#endif
         }
 
         /// <summary>
         /// Description
         ///     Test that a Database respects the mmap property
         /// Steps
-        ///     1. Create a DatabaseConfiguration object and set mmap to false
-        ///     2. Create a database with the config
-        ///     3. Get the configuration object from the Database and verify that mmap is false
-        ///     4. Use c4db_config2(perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_MMap(tenative) flag
-        ///     5. Set the config's mmap property true.
-        ///     6. Create a database with the config
-        ///         - For macOS, the database should be failed to create.
-        ///         - For nonMacOS, the database should be successfully created.
-        ///     7. Get the configuration object from the Database and verify that mmap is true
-        ///     8. Use c4db_config2 to confirm that its config contains the kC4DB_MMap flag
+        ///     1. Create a DatabaseConfiguration object and set mmapEnabled to false.
+        ///     2. Create a database with the config.
+        ///     3. Get the configuration object from the database and check that the mmapEnabled is false.
+        ///     4. Use c4db_config2 to confirm that its config contains the kC4DB_MmapDisabled flag
+        ///     5. Set the config's mmapEnabled property true
+        ///     6. Create a database with the config.
+        ///     7. Get the configuration object from the database and verify that mmapEnabled is true
+        ///     8. Use c4db_config2 to confirm that its config doesn't contains the kC4DB_MmapDisabled flag
         /// </summary>
         [SkippableTheory]
         [InlineData(true)]
@@ -86,6 +87,10 @@ namespace Test
         {
             Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), "Not supported on macOS");
 
+#if MACCATALYST
+            throw new SkipException("Not supported on Mac Catalyst");
+#else
+
             var config = new DatabaseConfiguration()
             {
                 MmapEnabled = useMmap
@@ -93,12 +98,12 @@ namespace Test
 
             Database.Delete("test", null);
             using var db = new Database("test", config);
+            db.Config.MmapEnabled.Should().Be(useMmap, "because otherwise MmapEnabled was not saved to the db's config");
             var c4db = db.c4db;
             var nativeConfig = TestNative.c4db_getConfig2(c4db);
             var hasFlag = (nativeConfig->flags & C4DatabaseFlags.MmapDisabled) == C4DatabaseFlags.MmapDisabled;
             hasFlag.Should().Be(!useMmap, "because the flag in LiteCore should match MmapEnabled (but flipped)");
         }
+#endif
     }
 }
-
-#endif

--- a/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
@@ -1,0 +1,104 @@
+//
+//  MmapTest.cs
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+using Couchbase.Lite;
+using FluentAssertions;
+using LiteCore.Interop;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+#if !__IOS__
+
+namespace Test
+{
+    [ImplementsTestSpec("T0006-MMap-Config", "1.0.0")]
+#if NET6_0_OR_GREATER
+    [System.Runtime.Versioning.UnsupportedOSPlatform("osx")]
+#endif
+    public sealed class MmapTest : TestCase
+    {
+        public MmapTest(ITestOutputHelper output) : base(output)
+        {
+
+        }
+
+        /// <summary>
+        /// Test that the mmap default value is as expected and that it's setter and getter work.
+        /// Steps
+        ///     1. Create a DatabaseConfiguration object.
+        ///     2. Get and check the value of the property: it should be true unless the OS is macOS.
+        ///     3. Set the mmap property true
+        ///     4. Get the config mmap property and verify that it is true
+        ///     5. Set the mmap property false
+        ///     6. Get the config mmap property and verify that it is false
+        /// </summary>
+        [SkippableFact]
+        public unsafe void TestDefaultMMapConfig()
+        {
+            Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), "Not supported on macOS");
+
+            var config = new DatabaseConfiguration();
+            config.MmapEnabled.Should().BeTrue();
+            config.FullSync.Should().BeFalse("because the default should be true");
+
+            config.FullSync = false;
+            config.FullSync.Should().BeFalse("because C# properties should work...");
+
+            config.FullSync = true;
+            config.FullSync.Should().BeTrue("because C# properties should work...");
+        }
+
+        /// <summary>
+        /// Description
+        ///     Test that a Database respects the mmap property
+        /// Steps
+        ///     1. Create a DatabaseConfiguration object and set mmap to false
+        ///     2. Create a database with the config
+        ///     3. Get the configuration object from the Database and verify that mmap is false
+        ///     4. Use c4db_config2(perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_MMap(tenative) flag
+        ///     5. Set the config's mmap property true.
+        ///     6. Create a database with the config
+        ///         - For macOS, the database should be failed to create.
+        ///         - For nonMacOS, the database should be successfully created.
+        ///     7. Get the configuration object from the Database and verify that mmap is true
+        ///     8. Use c4db_config2 to confirm that its config contains the kC4DB_MMap flag
+        /// </summary>
+        [SkippableTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public unsafe void TestDatabaseWithConfiguredMMap(bool useMmap)
+        {
+            Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), "Not supported on macOS");
+
+            var config = new DatabaseConfiguration()
+            {
+                MmapEnabled = useMmap
+            };
+
+            Database.Delete("test", null);
+            using var db = new Database("test", config);
+            var c4db = db.c4db;
+            var nativeConfig = TestNative.c4db_getConfig2(c4db);
+            var hasFlag = (nativeConfig->flags & C4DatabaseFlags.MmapDisabled) == C4DatabaseFlags.MmapDisabled;
+            hasFlag.Should().Be(!useMmap, "because the flag in LiteCore should match MmapEnabled (but flipped)");
+        }
+    }
+}
+
+#endif

--- a/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
@@ -16,9 +16,6 @@
 //  limitations under the License.
 //
 
-// Implements 2.0.0 of https://github.com/couchbaselabs/couchbase-lite-api/blob/f6eab19e9bd38cd8c6ca66c3c4aad4cb7b50a659/spec/tests/T0003-SQLite-Options.md
-
-
 using Couchbase.Lite;
 using FluentAssertions;
 using LiteCore;
@@ -29,6 +26,8 @@ using Xunit.Abstractions;
 
 namespace Test
 {
+
+    [ImplementsTestSpec("T0003-SQLite-Options", "2.0.0")]
     public class SQLiteOptionsTest : TestCase
     {
         public SQLiteOptionsTest(ITestOutputHelper output) : base(output)

--- a/src/Couchbase.Lite.Tests.Shared/Util/ImplementsTestSpecAttribute.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/ImplementsTestSpecAttribute.cs
@@ -1,0 +1,40 @@
+//
+//  ImplementsTestSpecAttribute.cs
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#nullable disable
+
+using System;
+
+namespace Couchbase.Lite
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class ImplementsTestSpecAttribute : Attribute
+    {
+        public string TestSpec { get; }
+
+        public string Version { get; }
+
+        public Version GetVersion() => new Version(Version);
+
+        public ImplementsTestSpecAttribute(string testSpec, string version)
+        {
+            TestSpec = testSpec;
+            Version = version;
+        }
+    }
+}

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4DatabaseTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4DatabaseTypes_defs.cs
@@ -45,6 +45,7 @@ namespace LiteCore.Interop
         ReadOnly        = 0x02,
         AutoCompact     = 0x04,
         VersionVectors  = 0x08,
+        MmapDisabled    = 0x10,
         NoUpgrade       = 0x20,
         NonObservable   = 0x40,
         DiskSyncFull    = 0x80,

--- a/src/LiteCore/src/LiteCore.Shared/Interop/FLBase_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/FLBase_defs.cs
@@ -58,7 +58,8 @@ namespace LiteCore.Interop
         
         Untrusted,
         
-        Trusted
+        Trusted,
+        _TrustInternalUseOnly = -1
     }
 
 	internal unsafe struct FLValue

--- a/src/LiteCore/src/LiteCore.Shared/Interop/FLSlice_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/FLSlice_defs.cs
@@ -57,18 +57,6 @@ namespace LiteCore.Interop
 
 	internal unsafe partial struct FLSliceResult
     {
-        public void* buf;
-        private UIntPtr _size;
-
-        public ulong size
-        {
-            get {
-                return _size.ToUInt64();
-            }
-            set {
-                _size = (UIntPtr)value;
-            }
-        }
     }
 }
 

--- a/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
@@ -198,6 +198,19 @@ namespace LiteCore.Interop
 
     internal unsafe partial struct FLSliceResult : IDisposable
     {
+        public void* buf;
+        private UIntPtr _size;
+
+        public ulong size
+        {
+            get {
+                return _size.ToUInt64();
+            }
+            set {
+                _size = (UIntPtr)value;
+            }
+        }
+
         public FLSliceResult(void* buf, ulong size)
         {
             this.buf = buf;


### PR DESCRIPTION
Also sneaking in a few other small things here:

- Support for tool based test spec verification (ImplementsTestSpecAttribute)
- Complete ArrayIndexTest now that c4index_getOptions returns unnestPath
- Update LiteCore to 3.2.1-8