### PR TITLE
CBL-6329: QueryBuilder queries should dispose child objects

### DIFF
--- a/src/Couchbase.Lite.Shared/Query/From.cs
+++ b/src/Couchbase.Lite.Shared/Query/From.cs
@@ -36,7 +36,7 @@ namespace Couchbase.Lite.Internal.Query
 
         internal From(XQuery query, IDataSource impl)
         {
-            Copy(query);
+            Move(query);
 
             FromImpl = Misc.TryCast<IDataSource, QueryDataSource>(impl);
             Collection = (impl as DatabaseSource)?.Collection;

--- a/src/Couchbase.Lite.Shared/Query/Having.cs
+++ b/src/Couchbase.Lite.Shared/Query/Having.cs
@@ -41,7 +41,7 @@ namespace Couchbase.Lite.Internal.Query
 
         internal Having(XQuery source, IExpression expression)
         {
-            Copy(source);
+            Move(source);
 
             _expression = expression;
             HavingImpl = this;

--- a/src/Couchbase.Lite.Shared/Query/Join.cs
+++ b/src/Couchbase.Lite.Shared/Query/Join.cs
@@ -54,7 +54,7 @@ namespace Couchbase.Lite.Internal.Query
 
         internal QueryJoin(XQuery source, IList<IJoin> joins)
         {
-            Copy(source);
+            Move(source);
             _joins = joins; 
             JoinImpl = this;
         }

--- a/src/Couchbase.Lite.Shared/Query/QueryBase.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryBase.cs
@@ -131,7 +131,7 @@ namespace Couchbase.Lite.Internal.Query
             Dispose(false);
         }
 
-        private unsafe void Dispose(bool finalizing)
+        protected unsafe virtual void Dispose(bool finalizing)
         {
             if (!finalizing) {
                 Stop();

--- a/src/Couchbase.Lite.Shared/Query/QueryGroupBy.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryGroupBy.cs
@@ -41,22 +41,10 @@ namespace Couchbase.Lite.Internal.Query
 
         #region Constructors
 
-        internal QueryGroupBy(IList<IExpression> expressions)
-        {
-            _expressions = expressions;
-            GroupByImpl = this;
-        }
-
         internal QueryGroupBy(XQuery query, IList<IExpression> expressions)
-            : this(expressions)
         {
-            Copy(query);
-            GroupByImpl = this;
-        }
-
-        internal QueryGroupBy(IExpression expression)
-        {
-            _expressions = [expression];
+            Move(query);
+            _expressions = expressions;
             GroupByImpl = this;
         }
 

--- a/src/Couchbase.Lite.Shared/Query/QueryOrdering.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryOrdering.cs
@@ -42,7 +42,7 @@ namespace Couchbase.Lite.Internal.Query
         internal QueryOrderBy(XQuery query, IList<IOrdering> orderBy)
             : this(orderBy)
         {
-            Copy(query);
+            Move(query);
             OrderByImpl = this;
         }
 

--- a/src/Couchbase.Lite.Shared/Query/Where.cs
+++ b/src/Couchbase.Lite.Shared/Query/Where.cs
@@ -33,7 +33,7 @@ namespace Couchbase.Lite.Internal.Query
 
         internal Where(XQuery query, IExpression expression)
         {
-            Copy(query);
+            Move(query);
             WhereImpl = expression as QueryExpression;
         }
 

--- a/src/Couchbase.Lite.Shared/Query/XQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/XQuery.cs
@@ -70,18 +70,27 @@ namespace Couchbase.Lite.Internal.Query
 
         #region Protected Methods
 
-        protected void Copy(XQuery source)
+        protected void Move(XQuery source)
         {
+            // These things will be wrapped by this object now, 
+            // so the original object doesn't need to worry about
+            // the disposables anymore
             Database = source.Database;
             Collection = source.Collection;
             SelectImpl = source.SelectImpl;
+            source.SelectImpl = null;
             Distinct = source.Distinct;
             FromImpl = source.FromImpl;
             WhereImpl = source.WhereImpl;
+            source.WhereImpl = null;
             OrderByImpl = source.OrderByImpl;
+            source.OrderByImpl = null;
             JoinImpl = source.JoinImpl;
+            source.JoinImpl = null;
             GroupByImpl = source.GroupByImpl;
+            source.GroupByImpl = null;
             HavingImpl = source.HavingImpl;
+            source.HavingImpl = null;
             LimitValue = source.LimitValue;
             SkipValue = source.SkipValue;
         }
@@ -95,6 +104,31 @@ namespace Couchbase.Lite.Internal.Query
         }
 
         #endregion
+
+        protected override void Dispose(bool finalizing)
+        {
+            base.Dispose(finalizing);
+
+            if (SelectImpl != this) {
+                SelectImpl?.Dispose();
+            }
+
+            if (OrderByImpl != this) {
+                OrderByImpl?.Dispose();
+            }
+
+            if (JoinImpl != this) {
+                JoinImpl?.Dispose();
+            }
+
+            if (GroupByImpl != this) {
+                GroupByImpl?.Dispose();
+            }
+
+            if (HavingImpl != this) {
+                HavingImpl?.Dispose();
+            }
+        }
 
         #region Override Methods
 


### PR DESCRIPTION
This is slightly strange in that some of the child objects are actually the same object as the parent, so check for that as well.  Each chain in a querybuilder call chain basically creates a new object that wraps the old one and appends additional information to itself, but the appended information was not being properly disposed.