### PR TITLE
CBL-6348:  Implement RevisionIDs API (unsupported, for testing only)

### DIFF
--- a/core_version.ini
+++ b/core_version.ini
@@ -1,6 +1,6 @@
 [version]
-build = 3.2.1-9
+build = 3.2.1-12
 
 [hashes]
-ce = da8b267c0ef7ae36a814dc3f5af984f112dc2151
-ee = 86734653b94fa6db9af16626a340f2ae6610f9c4
+ce = fb6e666c1adebd873872540c7e0ffe0cc01320a3
+ee = 6cc2f7f1e2a097679d2e08ab86369707324faacf

--- a/src/Couchbase.Lite.Shared/API/Document/Document+private.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/Document+private.cs
@@ -1,0 +1,27 @@
+// 
+//  Document+private.cs
+// 
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// 
+
+namespace Couchbase.Lite.Unsupported;
+
+public static class DocumentExtensions
+{
+    public static string? RevisionIDs(this Document doc)
+    {
+        return doc.RevisionIDs;
+    }
+}

--- a/src/Couchbase.Lite.Shared/API/Document/Document.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/Document.cs
@@ -106,6 +106,20 @@ namespace Couchbase.Lite
             }
         }
 
+        internal string? RevisionIDs
+        {
+            get {
+                return ThreadSafety.DoLocked(() =>
+                {
+                    if (c4Doc == null) {
+                        return null;
+                    }
+                    var fullC4Doc = (C4Document *)LiteCoreBridge.Check(err => Native.c4coll_getDoc(c4Coll, Id, true, C4DocContentLevel.DocGetAll, err))!;
+                    return Native.c4doc_getRevisionHistory(fullC4Doc);
+                });
+            }
+        }
+
         /// <summary>
         /// Gets the Collection that this document belongs to, if any
         /// </summary>

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\ArrayObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\Blob.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\DictionaryObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)api\document\Document+private.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\Document.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\DocumentFragment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)API\Document\IArray.cs" />

--- a/src/LiteCore/binding_list/c4.def
+++ b/src/LiteCore/binding_list/c4.def
@@ -63,6 +63,7 @@ c4doc_resolveConflict
 c4doc_save
 c4doc_dictContainsBlobs
 c4doc_getRevisionBody
+c4doc_getRevisionHistory
 c4doc_bodyAsJSON
 c4doc_getProperties
 

--- a/src/LiteCore/parse/config_c4.py
+++ b/src/LiteCore/parse/config_c4.py
@@ -1,6 +1,6 @@
 skip_files = []
 excluded = ["c4log", "c4vlog", "c4error_getMessageC", "c4str", "c4log_getDomain","c4repl_parseURL","c4SliceEqual","c4slice_free"]
-force_no_bridge = ["c4repl_getResponseHeaders","c4repl_new","c4socket_gotHTTPResponse"]
+force_no_bridge = ["c4repl_getResponseHeaders","c4repl_new","c4socket_gotHTTPResponse","c4doc_getRevisionHistory"]
 default_param_name = {"C4SliceResult":"slice","C4WriteStream*":"stream","C4ReadStream*":"stream","C4Error*":"outError",
 "C4BlobStore*":"store","C4BlobKey":"key","C4Slice":"slice","C4Key*":"key","bool":"b","double":"d","C4KeyReader*":"reader",
 "C4DatabaseObserver*":"observer","C4DocumentObserver*":"observer","C4View*":"view","C4OnCompactCallback":"callback",

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Document.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Document.cs
@@ -44,7 +44,7 @@ namespace LiteCore.Interop
 
     internal static unsafe partial class Native
     {
-        // This is only used for internal testing in version vector mode
+        // This is only used for internal testing
         // where the last three arguments are always the same
         public static string? c4doc_getRevisionHistory(C4Document* doc)
         {

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Document.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Document.cs
@@ -21,7 +21,7 @@
 #pragma warning disable CS0649  // Member never assigned to
 #pragma warning disable CS0169  // Member never used
 
-
+using System;
 
 namespace LiteCore.Interop
 {
@@ -40,6 +40,17 @@ namespace LiteCore.Interop
         public ulong sequence;
         public C4Revision selectedRev;
         public C4ExtraInfo extraInfo;
+    }
+
+    internal static unsafe partial class Native
+    {
+        // This is only used for internal testing in version vector mode
+        // where the last three arguments are always the same
+        public static string? c4doc_getRevisionHistory(C4Document* doc)
+        {
+            using var result = c4doc_getRevisionHistory(doc, UInt32.MaxValue, [], 0U);
+            return result.CreateString();
+        }
     }
 }
 

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Document_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Document_native.cs
@@ -45,6 +45,9 @@ namespace LiteCore.Interop
         }
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern FLSliceResult c4doc_getRevisionHistory(C4Document* doc, uint maxRevs, FLSlice[] backToRevs, uint backToRevsCount);
+
+        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool c4doc_selectNextLeafRevision(C4Document* doc, [MarshalAs(UnmanagedType.U1)]bool includeDeleted, [MarshalAs(UnmanagedType.U1)]bool withBody, C4Error* outError);
 

--- a/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
@@ -226,6 +226,11 @@ namespace LiteCore.Interop
         {
             Native.FLSliceResult_Release(this);
         }
+
+        public string? CreateString()
+        {
+            return ((FLSlice)this).CreateString();
+        }
     }
 
     internal static unsafe class FLSlotSetExt


### PR DESCRIPTION
This is just for parity so the testing server can build against both 3.2 and 4.0