### PR TITLE
Update the structs for LiteCore interop

### DIFF
--- a/src/Couchbase.Lite.Shared/Query/XQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/XQuery.cs
@@ -120,7 +120,7 @@ namespace Couchbase.Lite.Internal.Query
                 }
 
                 Check();
-                return NativeSafe.c4query_run(_c4Query, (FLSlice)paramJson, err);
+                return NativeSafe.c4query_run(_c4Query!, (FLSlice)paramJson, err);
             });
 
             paramJson.Dispose();

--- a/src/Couchbase.Lite.Tests.Shared/ConcurrencyTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ConcurrencyTest.cs
@@ -384,6 +384,7 @@ namespace Test
                     enterInBatchLock.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue("because otherwise t1 didn't enter InBatch");
                     Interlocked.CompareExchange(ref stepCount, 2, 1);
                     using var rs = Db.CreateQuery("select * from _").Execute();
+                    var realized = rs.ToList();
                     enterQueryLock.Set(); // Should have already timed out but set anyway
                     Interlocked.CompareExchange(ref stepCount, 4, 3);
                 } catch (Exception e) {

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4DatabaseTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4DatabaseTypes_defs.cs
@@ -45,9 +45,11 @@ namespace LiteCore.Interop
         ReadOnly        = 0x02,
         AutoCompact     = 0x04,
         VersionVectors  = 0x08,
+        MmapDisabled    = 0x10,
         NoUpgrade       = 0x20,
         NonObservable   = 0x40,
-        FakeVectorClock = 0x80,
+        DiskSyncFull    = 0x80,
+        FakeVectorClock = 0x0100,
     }
 
     internal enum C4EncryptionAlgorithm : uint

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4IndexTypes_defs.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4IndexTypes_defs.cs
@@ -113,6 +113,7 @@ namespace LiteCore.Interop
         private byte _ignoreDiacritics;
         private byte _disableStemming;
         private IntPtr _stopWords;
+        private IntPtr _unnestPath;
         public C4VectorIndexOptions vector;
 
         public string? language
@@ -153,6 +154,17 @@ namespace LiteCore.Interop
             }
             set {
                 var old = Interlocked.Exchange(ref _stopWords, Marshal.StringToHGlobalAnsi(value));
+                Marshal.FreeHGlobal(old);
+            }
+        }
+
+        public string? unnestPath
+        {
+            get {
+                return Marshal.PtrToStringAnsi(_unnestPath);
+            }
+            set {
+                var old = Interlocked.Exchange(ref _unnestPath, Marshal.StringToHGlobalAnsi(value));
                 Marshal.FreeHGlobal(old);
             }
         }


### PR DESCRIPTION
Forgot to do this when upgrading LiteCore itself and it only manifest itself in some tests that are only run in release mode.

Nullability fix (Check() guarantees _c4Query is either null or an exception is thrown)

Fix a test for the new thread safety model (c4query_run is not blocked, just c4queryenum functionality on the query)