### PR TITLE
CBL-6540: AllowReplicatingInBackground behavior is opposite of what is documented

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -317,7 +317,7 @@ namespace Couchbase.Lite.Sync
                         Config.DatabaseInternal.AddActiveStoppable(this);
                         status = Native.c4repl_getStatus(_repl);
 #if __IOS__ && !MACCATALYST
-                        if(Config.AllowReplicatingInBackground) {
+                        if(!Config.AllowReplicatingInBackground) {
                             if (ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.DEVICE) {
                                 StartBackgroundingMonitor();
                             } else {

--- a/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/ReplicatorConfiguration.cs
@@ -124,6 +124,12 @@ namespace Couchbase.Lite.Sync
         /// If setting the value to <c>true</c>, please ensure that your application delegate
         /// requests background time from the OS until the replication finishes.
         /// </summary>
+        /// <remarks>
+        /// > [!WARNING]
+        /// > There is a bug in 3.2.1 in which the functionality is reversed from
+        /// > what the documentation says, so please upgrade from that version 
+        /// > to get the correct behavior
+        /// </remarks>
         public bool AllowReplicatingInBackground
         {
             get => _allowReplicatingInBackground;


### PR DESCRIPTION
The replicator automatically stop when going in the background and the value of the property is false (the default).  Currently, it is reversed and only automatically stops when the property is true.