### PR TITLE
Fix a bizarre native AOT problem with iOS

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -109,6 +109,8 @@ namespace Couchbase.Lite
             flags = C4DatabaseFlags.Create | C4DatabaseFlags.AutoCompact,
         };
 
+        private static Log? _Log;
+
         private const string DBExtension = "cblite2";
 
         private const string Tag = nameof(Database);
@@ -165,8 +167,20 @@ namespace Couchbase.Lite
         /// [DEPRECATED] Gets the object that stores the available logging methods
         /// for Couchbase Lite
         /// </summary>
-        [Obsolete("Use the new LogSinks static clas")]
-        public static Log Log { get; } = new Log();
+        [Obsolete("Use the new LogSinks static class")]
+        public static Log Log 
+        {
+            get {
+                // This is a bit weird to do, since normally you'd just say Log = new Log() above,
+                // but that doesn't play well with iOS native AOT for some reason, so lazily
+                // init this instead.
+                if(_Log == null) {
+                    _Log = new Log();
+                }
+
+                return _Log;
+            }
+        }
 
         /// <summary>
         /// Gets the database's name

--- a/src/Couchbase.Lite.Shared/API/Log/Log.cs
+++ b/src/Couchbase.Lite.Shared/API/Log/Log.cs
@@ -35,13 +35,13 @@ namespace Couchbase.Lite.Logging
         /// <summary>
         /// [DEPRECATED] Gets the logging facility that logs to a debugging console
         /// </summary>
-        [Obsolete("Use LogSinks.ConsoleLogSink instead")]
+        [Obsolete("Use LogSinks.Console instead")]
         public IConsoleLogger Console { get; } = Service.GetRequiredInstance<IConsoleLogger>();
 
         /// <summary>
         /// [DEPRECATED] Gets or sets the user defined logging facility
         /// </summary>
-        [Obsolete("Use LogSinks.CustomLogSink instead")]
+        [Obsolete("Use LogSinks.Custom instead")]
         public ILogger? Custom
         {
             get => _custom;
@@ -54,7 +54,7 @@ namespace Couchbase.Lite.Logging
         /// <summary>
         /// [DEPRECATED] Gets the logging facility that logs to files on the disk
         /// </summary>
-        [Obsolete("Use LogSinks.FileLogSink instead")]
+        [Obsolete("Use LogSinks.File instead")]
         public FileLogger File { get; } = new FileLogger();
 
         internal LogLevel OverallLogLevel


### PR DESCRIPTION
Without doing this, accessing Database.Log throws a null reference exception (or some other nonsense).

Fix some incorrect comments as well.  Note that trying to do the log initialization using atomic swaps causes a hang, and I don't think it's enough of an issue to figure out why so just do a noobie swap.