### PR TITLE
CBL-6798: Don't allocate memory for c4log_getDomain

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Log/FileLogger.cs
+++ b/src/Couchbase.Lite.Shared/API/Log/FileLogger.cs
@@ -227,17 +227,10 @@ namespace Couchbase.Lite.Logging
 
         private unsafe void SetupDomainObjects()
         {
-            var bytes = (byte *)Marshal.StringToHGlobalAnsi("Couchbase");
-            _domainObjects[LogDomain.Couchbase] = (IntPtr)Native.c4log_getDomain(bytes, true);
-
-            bytes = (byte *)Marshal.StringToHGlobalAnsi("DB");
-            _domainObjects[LogDomain.Database] = (IntPtr)Native.c4log_getDomain(bytes, true);
-
-            bytes = (byte *)Marshal.StringToHGlobalAnsi("Query");
-            _domainObjects[LogDomain.Query] = (IntPtr)Native.c4log_getDomain(bytes, true);
-
-            bytes = (byte *)Marshal.StringToHGlobalAnsi("Sync");
-            _domainObjects[LogDomain.Replicator] = (IntPtr)Native.c4log_getDomain(bytes, true);
+            _domainObjects[LogDomain.Couchbase] = (IntPtr)Native.c4log_getDomain("Couchbase", true);
+            _domainObjects[LogDomain.Database] = (IntPtr)Native.c4log_getDomain("DB", true);
+            _domainObjects[LogDomain.Query] = (IntPtr)Native.c4log_getDomain("Query", true);
+            _domainObjects[LogDomain.Replicator] = (IntPtr)Native.c4log_getDomain("Sync", true);
 
             foreach (var domain in _domainObjects) {
                 Native.c4log_setLevel((C4LogDomain *)domain.Value.ToPointer(),

--- a/src/Couchbase.Lite.Shared/Log/Log.cs
+++ b/src/Couchbase.Lite.Shared/Log/Log.cs
@@ -38,9 +38,9 @@ namespace Couchbase.Lite.Internal.Logging
         // ReSharper disable PrivateFieldCanBeConvertedToLocalVariable
         private static readonly LogTo _To;
 
-        internal static readonly C4LogDomain* LogDomainBLIP = c4log_getDomain("BLIP", false);
-        internal static readonly C4LogDomain* LogDomainWebSocket = c4log_getDomain("WS", false);
-        internal static readonly C4LogDomain* LogDomainSyncBusy = c4log_getDomain("SyncBusy", false);
+        internal static readonly C4LogDomain* LogDomainBLIP = Native.c4log_getDomain("BLIP", false);
+        internal static readonly C4LogDomain* LogDomainWebSocket = Native.c4log_getDomain("WS", false);
+        internal static readonly C4LogDomain* LogDomainSyncBusy = Native.c4log_getDomain("SyncBusy", false);
         private static LogLevel _CurrentLevel = LogLevel.Warning;
         private static AtomicBool _Initialized = new AtomicBool(false);
 
@@ -100,12 +100,6 @@ namespace Couchbase.Lite.Internal.Logging
         #endregion
 
         #region Private Methods
-
-        private static C4LogDomain* c4log_getDomain(string name, bool create)
-        {
-            var bytes = Marshal.StringToHGlobalAnsi(name);
-            return Native.c4log_getDomain((byte*) bytes, create);
-        }
 
         #if __IOS__
         [ObjCRuntime.MonoPInvokeCallback(typeof(C4LogCallback))]

--- a/src/LiteCore/src/LiteCore.Shared/Interop/Misc_native.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/Misc_native.cs
@@ -24,9 +24,8 @@ namespace LiteCore.Interop
     [ExcludeFromCodeCoverage]
     internal unsafe static partial class Native
     {
-        // NOTE: Must allocate unmanaged memory via Marshal class
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        public static extern C4LogDomain* c4log_getDomain(byte* name,
+        public static extern C4LogDomain* c4log_getDomain(string name,
             [MarshalAs(UnmanagedType.U1)] bool create);
 
     }


### PR DESCRIPTION
Now that the C API copies the domain name on input, it is no longer important for the C# side string to live pinned past the method invocation.