### PR TITLE
CBL-7052: Completely remove FluentAssertions from testing

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -107,7 +107,7 @@ namespace Couchbase.Lite
         #region Constants
 
         private static readonly C4DatabaseConfig2 DBConfig = new C4DatabaseConfig2 {
-            flags = C4DatabaseFlags.Create | C4DatabaseFlags.AutoCompact | C4DatabaseFlags.VersionVectors,
+            flags = C4DatabaseFlags.Create | C4DatabaseFlags.AutoCompact
         };
 
         private const string DBExtension = "cblite2";

--- a/src/Couchbase.Lite.Tests.NetCore/Couchbase.Lite.Tests.NetCore.csproj
+++ b/src/Couchbase.Lite.Tests.NetCore/Couchbase.Lite.Tests.NetCore.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Couchbase.Lite.Enterprise" Version="3.2.0-b0014" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
 	<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -1499,7 +1499,7 @@ namespace Test
             using (var otherDb = new Database("closeDB", Db.Config)) {
                 var otherDefaultColl = otherDb.GetDefaultCollection();
                 var query = QueryBuilder.Select(SelectResult.Expression(Meta.ID)).From(DataSource.Collection(otherDefaultColl));
-                var doc1Listener = new WaitAssert();
+                using var doc1Listener = new WaitAssert();
                 var token = query.AddChangeListener(null, (sender, args) => {
                     foreach (var row in args.Results) {
                         if (row.GetString("id") == "doc1") {

--- a/src/Couchbase.Lite.Tests.Shared/DocPerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DocPerfTest.cs
@@ -21,9 +21,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Couchbase.Lite;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using Shouldly;
 
 namespace Test
 {
@@ -59,7 +59,7 @@ namespace Test
         private void AddRevisions(uint count)
         {
             var doc = Db.GetDefaultCollection().GetDocument("doc")?.ToMutable();
-            doc.Should().NotBeNull("because otherwise the save of the perf test failed");
+            doc.ShouldNotBeNull("because otherwise the save of the perf test failed");
             Db.InBatch(() =>
             {
                 for (int i = 0; i < count; i++) {

--- a/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
@@ -17,7 +17,7 @@
 //
 
 using Couchbase.Lite;
-using FluentAssertions;
+using Shouldly;
 using LiteCore.Interop;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -56,14 +56,14 @@ namespace Test
             throw new SkipException("Not supported on Mac Catalyst");
 #else
             var config = new DatabaseConfiguration();
-            config.MmapEnabled.Should().BeTrue();
-            config.MmapEnabled.Should().BeTrue("because the default should be true");
+            config.MmapEnabled.ShouldBeTrue();
+            config.MmapEnabled.ShouldBeTrue("because the default should be true");
 
             config.MmapEnabled = false;
-            config.MmapEnabled.Should().BeFalse("because C# properties should work...");
+            config.MmapEnabled.ShouldBeFalse("because C# properties should work...");
 
             config.MmapEnabled = true;
-            config.MmapEnabled.Should().BeTrue("because C# properties should work...");
+            config.MmapEnabled.ShouldBeTrue("because C# properties should work...");
 #endif
         }
 
@@ -98,12 +98,12 @@ namespace Test
 
             Database.Delete("test", null);
             using var db = new Database("test", config);
-            db.Config.MmapEnabled.Should().Be(useMmap, "because otherwise MmapEnabled was not saved to the db's config");
+            db.Config.MmapEnabled.ShouldBe(useMmap, "because otherwise MmapEnabled was not saved to the db's config");
             var c4db = db.c4db;
-            c4db.Should().NotBeNull();
+            c4db.ShouldNotBeNull();
             var nativeConfig = TestNative.c4db_getConfig2(c4db!.RawDatabase);
             var hasFlag = (nativeConfig->flags & C4DatabaseFlags.MmapDisabled) == C4DatabaseFlags.MmapDisabled;
-            hasFlag.Should().Be(!useMmap, "because the flag in LiteCore should match MmapEnabled (but flipped)");
+            hasFlag.ShouldBe(!useMmap, "because the flag in LiteCore should match MmapEnabled (but flipped)");
         }
 #endif
     }

--- a/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/PerfTest.cs
@@ -25,7 +25,7 @@ using System.IO;
 using System.Text;
 using Couchbase.Lite;
 using Couchbase.Lite.Logging;
-using FluentAssertions;
+using Shouldly;
 using Test.Util;
 using Xunit;
 using Xunit.Abstractions;
@@ -69,8 +69,8 @@ namespace Test
 
         protected void OpenDB()
         {
-            _dbName.Should().NotBeNull("because otherwise we cannot open the database");
-            Db.Should().BeNull("because otherwise we are trying to reopen the database incorrectly");
+            _dbName.ShouldNotBeNull("because otherwise we cannot open the database");
+            Db.ShouldBeNull("because otherwise we are trying to reopen the database incorrectly");
             Db = new Database(_dbName, _dbConfiguration);
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/QueryTest.cs
@@ -29,8 +29,7 @@ using Couchbase.Lite;
 using Couchbase.Lite.Internal.Query;
 using Couchbase.Lite.Query;
 
-using FluentAssertions;
-using FluentAssertions.Execution;
+using Shouldly;
 
 using Newtonsoft.Json;
 
@@ -71,7 +70,7 @@ namespace Test
                     .Where(Meta.ID.EqualTo(Expression.String(docId)))) {
 
                     VerifyQuery(q, (n, row) => {
-                        row.GetString(0).Should().Be(doc.RevisionID!.ToString());
+                        row.GetString(0).ShouldBe(doc.RevisionID!.ToString());
                     });
 
                     // Update doc:
@@ -79,7 +78,7 @@ namespace Test
                     DefaultCollection.Save(doc);
 
                     VerifyQuery(q, (n, row) => {
-                        row.GetString(0).Should().Be(doc.RevisionID!.ToString());
+                        row.GetString(0).ShouldBe(doc.RevisionID!.ToString());
                     });
                 }
 
@@ -89,7 +88,7 @@ namespace Test
                 .Where(Meta.RevisionID.EqualTo(Expression.String(docId)))) {
 
                     VerifyQuery(q, (n, row) => {
-                        row.GetString(0).Should().Be(docId.ToString());
+                        row.GetString(0).ShouldBe(docId.ToString());
                     });
                 }
 
@@ -100,7 +99,7 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .Where(Meta.IsDeleted.EqualTo(Expression.Boolean(true)))) {
                     VerifyQuery(q, (n, row) => {
-                        row.GetString(0).Should().Be(doc.RevisionID!.ToString());
+                        row.GetString(0).ShouldBe(doc.RevisionID!.ToString());
                     });
                 }
             }
@@ -130,9 +129,9 @@ namespace Test
                 doc1c.SetString("c", "string");
                 DefaultCollection.Save(doc1c);
 
-                DefaultCollection.SetDocumentExpiration("doc1", dto2).Should().Be(true);
-                DefaultCollection.SetDocumentExpiration("doc2", dto3).Should().Be(true);
-                DefaultCollection.SetDocumentExpiration("doc3", dto4).Should().Be(true);
+                DefaultCollection.SetDocumentExpiration("doc1", dto2).ShouldBe(true);
+                DefaultCollection.SetDocumentExpiration("doc2", dto3).ShouldBe(true);
+                DefaultCollection.SetDocumentExpiration("doc3", dto4).ShouldBe(true);
             }
 
             Thread.Sleep(4100);
@@ -145,9 +144,9 @@ namespace Test
                         .LessThan(Expression.Long(dto6InMS)))) {
 
                     var b = r.Execute().AllResults();
-                    b.Count.Should().Be(0);
+                    b.Count.ShouldBe(0);
                 }
-            }).Times(5).Delay(TimeSpan.FromMilliseconds(500)).Go().Should().BeTrue();
+            }).Times(5).Delay(TimeSpan.FromMilliseconds(500)).Go().ShouldBeTrue();
         }
 #endif
 
@@ -174,9 +173,9 @@ namespace Test
                 doc1c.SetString("c", "string");
                 DefaultCollection.Save(doc1c);
 
-                DefaultCollection.SetDocumentExpiration("doc1", dto20).Should().Be(true);
-                DefaultCollection.SetDocumentExpiration("doc2", dto30).Should().Be(true);
-                DefaultCollection.SetDocumentExpiration("doc3", dto40).Should().Be(true);
+                DefaultCollection.SetDocumentExpiration("doc1", dto20).ShouldBe(true);
+                DefaultCollection.SetDocumentExpiration("doc2", dto30).ShouldBe(true);
+                DefaultCollection.SetDocumentExpiration("doc3", dto40).ShouldBe(true);
             }
 
             using (var r = QueryBuilder.Select(DocID, Expiration)
@@ -185,7 +184,7 @@ namespace Test
                 .LessThan(Expression.Long(dto60InMS)))) {
 
                 var b = r.Execute().AllResults();
-                b.Should().HaveCount(3);
+                b.Count.ShouldBe(3);
             }
         }
 
@@ -210,10 +209,10 @@ namespace Test
                  .Where(Meta.IsDeleted.EqualTo(Expression.Boolean(false)))) {
                 var count = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetString(0).Should().Be("doc1");
-                    r.GetBoolean(1).Should().BeFalse();
+                    r.GetString(0).ShouldBe("doc1");
+                    r.GetBoolean(1).ShouldBeFalse();
                 });
-                count.Should().Be(1);
+                count.ShouldBe(1);
             }
         }
 
@@ -238,10 +237,10 @@ namespace Test
                  .Where(Meta.IsDeleted.EqualTo(Expression.Boolean(true)))) {
                 var count = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetString(0).Should().Be("doc2");
-                    r.GetBoolean(1).Should().BeTrue();
+                    r.GetString(0).ShouldBe("doc2");
+                    r.GetBoolean(1).ShouldBeTrue();
                 });
-                count.Should().Be(1);
+                count.ShouldBe(1);
             }
         }
 
@@ -264,15 +263,15 @@ namespace Test
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
                 .From(DataSource.Collection(DefaultCollection))) {
-                var count = VerifyQuery(q, (n, r) => { r.GetString(0).Should().Be("doc2"); });
-                count.Should().Be(1);
+                var count = VerifyQuery(q, (n, r) => { r.GetString(0).ShouldBe("doc2"); });
+                count.ShouldBe(1);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
                 .From(DataSource.Collection(DefaultCollection))
                 .Where(Meta.IsDeleted.EqualTo(Expression.Boolean(true)))) {
-                var count = VerifyQuery(q, (n, r) => throw new AssertionFailedException("No results should be present"));
-                count.Should().Be(0);
+                var count = VerifyQuery(q, (n, r) => throw new ShouldAssertException("No results should be present"));
+                count.ShouldBe(0);
             }
         }
 
@@ -282,9 +281,9 @@ namespace Test
             using (var q = QueryBuilder.Select(DocID, Sequence).From(DataSource.Collection(DefaultCollection))) {
                 var parameters = new Parameters().SetString("foo", "bar");
                 q.Parameters = parameters;
-                q.Parameters.GetValue("foo").Should().Be("bar");
-                q.Invoking(q2 => q2.Parameters.SetValue("foo2", "bar2"))
-                    .Should().Throw<InvalidOperationException>("because the parameters are read only once in use");
+                q.Parameters.GetValue("foo").ShouldBe("bar");
+                Should.Throw<InvalidOperationException>(() => q.Parameters.SetValue("foo2", "bar2"),
+                        "because the parameters are read only once in use");
             }
         }
 
@@ -295,7 +294,7 @@ namespace Test
             var utcNow = DateTime.UtcNow;
             dict.Add(utcNow.ToShortDateString(), utcNow);
             var parameters = new Parameters(dict);
-            parameters.GetValue(utcNow.ToShortDateString()).Should().Be(utcNow);
+            parameters.GetValue(utcNow.ToShortDateString()).ShouldBe(utcNow);
         }
 
 #if !CBL_NO_EXTERN_FILES
@@ -307,17 +306,17 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
                     var expectedID = $"doc-{n:D3}";
-                    row.GetString(0).Should().Be(expectedID, "because otherwise the IDs were out of order");
-                    row.GetLong(1).Should().Be(n, "because otherwise the sequences were out of order");
+                    row.GetString(0).ShouldBe(expectedID, "because otherwise the IDs were out of order");
+                    row.GetLong(1).ShouldBe(n, "because otherwise the sequences were out of order");
 
                     var doc = DefaultCollection.GetDocument(row.GetString(0)!);
-                    doc.Should().NotBeNull("because the document should be retrievable");
-                    doc!.Id.Should().Be(expectedID, "because the document ID on the row should match the document");
-                    doc.Sequence.Should()
-                        .Be((ulong)n, "because the sequence on the row should match the document");
+                    doc.ShouldNotBeNull("because the document should be retrievable");
+                    doc!.Id.ShouldBe(expectedID, "because the document ID on the row should match the document");
+                    doc.Sequence
+                        .ShouldBe((ulong)n, "because the sequence on the row should match the document");
                 });
 
-                numRows.Should().Be(100, "because otherwise the incorrect number of rows was returned");
+                numRows.ShouldBe(100, "because otherwise the incorrect number of rows was returned");
             }
         }
 #endif
@@ -362,12 +361,12 @@ namespace Test
                     {
                         if (n <= expectedDocs.Length) {
                             var doc = expectedDocs[n - 1];
-                            row.GetString("id").Should()
-                                .Be(doc.Id, $"because otherwise the row results were different than expected ({testNum})");
+                            row.GetString("id")
+                                .ShouldBe(doc.Id, $"because otherwise the row results were different than expected ({testNum})");
                         }
                     });
 
-                    numRows.Should().Be(expectedDocs.Length, "because otherwise too many rows were returned");
+                    numRows.ShouldBe(expectedDocs.Length, "because otherwise too many rows were returned");
                 }
 
                 testNum++;
@@ -416,12 +415,12 @@ namespace Test
                         if (n <= expectedDocs.Length)
                         {
                             var doc = expectedDocs[n - 1];
-                            row.GetString("id").Should()
-                                .Be(doc.Id, $"because otherwise the row results were different than expected ({testNum})");
+                            row.GetString("id")
+                                .ShouldBe(doc.Id, $"because otherwise the row results were different than expected ({testNum})");
                         }
                     });
 
-                    numRows.Should().Be(expectedDocs.Length, "because otherwise too many rows were returned");
+                    numRows.ShouldBe(expectedDocs.Length, "because otherwise too many rows were returned");
                 }
 
                 testNum++;
@@ -529,13 +528,13 @@ namespace Test
 
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().NotBeNull("because otherwise the query didn't get correct results");
+                    row.GetString(0).ShouldNotBeNull("because otherwise the query didn't get correct results");
                     var doc = DefaultCollection.GetDocument(row.GetString(0)!);
-                    doc.Should().NotBeNull("because otherwise the save failed");
-                    doc!.Id.Should().Be(doc1.Id, "because otherwise the wrong document ID was populated");
-                    doc["string"].ToString().Should().Be("string", "because otherwise garbage data was inserted");
+                    doc.ShouldNotBeNull("because otherwise the save failed");
+                    doc!.Id.ShouldBe(doc1.Id, "because otherwise the wrong document ID was populated");
+                    doc["string"].ToString().ShouldBe("string", "because otherwise garbage data was inserted");
                 });
-                numRows.Should().Be(1, "beacuse one row matches the given query");
+                numRows.ShouldBe(1, "beacuse one row matches the given query");
             }
 
             using (var q = QueryBuilder.Select(DocID)
@@ -544,13 +543,13 @@ namespace Test
 
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().NotBeNull("because otherwise the query didn't get correct results");
+                    row.GetString(0).ShouldNotBeNull("because otherwise the query didn't get correct results");
                     var doc = DefaultCollection.GetDocument(row.GetString(0)!);
-                    doc.Should().NotBeNull("because otherwise the save failed");
-                    doc!.Id.Should().Be(doc1.Id, "because otherwise the wrong document ID was populated");
-                    doc["string"].ToString().Should().Be("string", "because otherwise garbage data was inserted");
+                    doc.ShouldNotBeNull("because otherwise the save failed");
+                    doc!.Id.ShouldBe(doc1.Id, "because otherwise the wrong document ID was populated");
+                    doc["string"].ToString().ShouldBe("string", "because otherwise garbage data was inserted");
                 });
-                numRows.Should().Be(1, "because one row matches the 'IS NOT' query");
+                numRows.ShouldBe(1, "because one row matches the 'IS NOT' query");
             }
         }
 
@@ -586,10 +585,10 @@ namespace Test
                 {
 
                     var name = row.GetString(0);
-                    name.Should().Be(expected[n - 1], "because otherwise incorrect rows were returned");
+                    name.ShouldBe(expected[n - 1], "because otherwise incorrect rows were returned");
                 });
 
-                numRows.Should().Be(expected.Length, "because otherwise an incorrect number of rows were returned");
+                numRows.ShouldBe(expected.Length, "because otherwise an incorrect number of rows were returned");
             }
         }
 
@@ -613,9 +612,8 @@ namespace Test
                     }
                 });
 
-                numRows.Should().Be(5, "because there are 5 rows like that in the data source");
-                firstNames.Should()
-                    .OnlyContain(str => str.Contains("Mar"), "because otherwise an incorrect entry came in");
+                numRows.ShouldBe(5, "because there are 5 rows like that in the data source");
+                firstNames.All(x => x.Contains("Mar")).ShouldBeTrue("because otherwise an incorrect entry came in");
             }
         }
 
@@ -639,10 +637,9 @@ namespace Test
                     }
                 });
 
-                numRows.Should().Be(5, "because there are 5 rows like that in the data source");
+                numRows.ShouldBe(5, "because there are 5 rows like that in the data source");
                 var regex = new Regex("^Mar.*");
-                firstNames.Should()
-                    .OnlyContain(str => regex.IsMatch(str), "because otherwise an incorrect entry came in");
+                firstNames.All(x => regex.IsMatch(x)).ShouldBeTrue("because otherwise an incorrect entry came in");
             }
         }
 
@@ -659,7 +656,7 @@ namespace Test
 
                 });
 
-                numRows.Should().Be(2, "because two rows in the data match the query");
+                numRows.ShouldBe(2, "because two rows in the data match the query");
             }
 
             using(var db = new Database("testN1QLDB")) {
@@ -672,7 +669,7 @@ namespace Test
 
                     });
 
-                    numRows.Should().Be(2, "because two rows in the data match the query");
+                    numRows.ShouldBe(2, "because two rows in the data match the query");
                 }
             }
         }
@@ -699,7 +696,7 @@ namespace Test
                     
                 });
 
-                numRows.Should().Be(2, "because two rows in the data match the query");
+                numRows.ShouldBe(2, "because two rows in the data match the query");
             }
         }
 
@@ -726,15 +723,15 @@ namespace Test
                         }
                     });
 
-                    numRows.Should().Be(100, "because otherwise the wrong number of rows was retrieved");
-                    firstNames.Should().HaveCount(numRows, "because otherwise some rows were null");
+                    numRows.ShouldBe(100, "because otherwise the wrong number of rows was retrieved");
+                    firstNames.Count.ShouldBe(numRows, "because otherwise some rows were null");
                     var firstNamesCopy = new List<object>(firstNames);
                     firstNames.Sort();
                     if (!ascending) {
                         firstNames.Reverse();
                     }
 
-                    firstNames.Should().ContainInOrder(firstNamesCopy, "because otherwise the results were not sorted");
+                    firstNames.ShouldBeEquivalentToFluent(firstNamesCopy, "because otherwise the results were not sorted");
                 }
             }
         }
@@ -801,10 +798,10 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
                     var number = row.GetInt(0);
-                    number.Should().Be(1);
+                    number.ShouldBe(1);
                 });
 
-                numRows.Should().Be(1, "because there is only one distinct row");
+                numRows.ShouldBe(1, "because there is only one distinct row");
             }
         }
 
@@ -814,8 +811,8 @@ namespace Test
             LoadNumbers(100);
             using (var q = QueryBuilder.Select(SelectResult.Expression(Expression.Property("number1"))).From(DataSource.Collection(DefaultCollection))
                 .Where(Expression.Property("number1").LessThan(Expression.Int(10))).OrderBy(Ordering.Property("number1"))) {
-                var wa = new WaitAssert();
-                var wa2 = new WaitAssert();
+                using var wa = new WaitAssert();
+                using var wa2 = new WaitAssert();
                 var count = 1;
                 q.AddChangeListener(null, (sender, args) =>
                 {
@@ -858,8 +855,8 @@ namespace Test
                     .On(Expression.Property("number1").From("main")
                         .EqualTo(Expression.Property("theone").From("secondary"))))) {
                 var results = q.Execute().ToList();
-                results.Should().HaveCount(1, "because only one document should match 42");
-                results.First().GetInt(0).Should().Be(58,
+                results.Count.ShouldBe(1, "because only one document should match 42");
+                results.First().GetInt(0).ShouldBe(58,
                     "because that was the number stored in 'number2' of the matching doc");
             }
 
@@ -869,8 +866,8 @@ namespace Test
                     .On(Expression.Property("number1").From("main")
                         .EqualTo(Expression.Property("theone").From("secondary"))))) {
                 var results = q.Execute().ToList();
-                results.Should().HaveCount(1, "because only one document should match 42");
-                results.First().Keys.FirstOrDefault().Should().Be("main");
+                results.Count.ShouldBe(1, "because only one document should match 42");
+                results.First().Keys.FirstOrDefault().ShouldBe("main");
             }
         }
 
@@ -888,11 +885,11 @@ namespace Test
                     .On(Expression.Property("number1").From("main")
                         .EqualTo(Expression.Property("theone").From("secondary"))))) {
                 var results = q.Execute().ToList();
-                results.Should().HaveCount(101);
-                results[41].GetInt(0).Should().Be(58);
-                results[41].GetInt(1).Should().Be(42);
-                results[42].GetInt(0).Should().Be(57);
-                results[42].GetValue(1).Should().BeNull();
+                results.Count.ShouldBe(101);
+                results[41].GetInt(0).ShouldBe(58);
+                results[41].GetInt(1).ShouldBe(42);
+                results[42].GetInt(0).ShouldBe(57);
+                results[42].GetValue(1).ShouldBeNull();
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(number2Prop.From("main")), SelectResult.Expression(Expression.Property("theone").From("secondary")))
@@ -901,11 +898,11 @@ namespace Test
                     .On(Expression.Property("number1").From("main")
                         .EqualTo(Expression.Property("theone").From("secondary"))))) {
                 var results = q.Execute().ToList();
-                results.Should().HaveCount(101);
-                results[41].GetInt(0).Should().Be(58);
-                results[41].GetInt(1).Should().Be(42);
-                results[42].GetInt(0).Should().Be(57);
-                results[42].GetValue(1).Should().BeNull();
+                results.Count.ShouldBe(101);
+                results[41].GetInt(0).ShouldBe(58);
+                results[41].GetInt(1).ShouldBe(42);
+                results[42].GetInt(0).ShouldBe(57);
+                results[42].GetValue(1).ShouldBeNull();
             }
         }
 
@@ -931,18 +928,18 @@ namespace Test
                 {
                     var main = r.GetDictionary(0);
                     var secondary = r.GetDictionary(1);
-                    main.Should().NotBeNull("because otherwise main wasn't present in the results");
+                    main.ShouldNotBeNull("because otherwise main wasn't present in the results");
 
                     var number1 = main!.GetInt("number1");
                     if (number1 == 42) {
-                        secondary.Should().NotBeNull("because the JOIN matched");
-                        secondary!.GetInt("theone").Should().Be(number1, "because this is the join entry");
+                        secondary.ShouldNotBeNull("because the JOIN matched");
+                        secondary!.GetInt("theone").ShouldBe(number1, "because this is the join entry");
                     } else {
-                        secondary.Should().BeNull("because the JOIN didn't match");
+                        secondary.ShouldBeNull("because the JOIN didn't match");
                     }
                 });
 
-                numRows.Should().Be(101);
+                numRows.ShouldBe(101);
             }
 
         }
@@ -960,11 +957,11 @@ namespace Test
                 .OrderBy(Ordering.Expression(num2))) {
                 var count = VerifyQuery(q, (n, row) =>
                 {
-                    ((row.GetInt(0) - 1) % 10).Should().Be((n - 1) % 10);
-                    row.GetInt(1).Should().Be((n - 1) / 10);
+                    ((row.GetInt(0) - 1) % 10).ShouldBe((n - 1) % 10);
+                    row.GetInt(1).ShouldBe((n - 1) / 10);
                 });
 
-                count.Should().Be(100);
+                count.ShouldBe(100);
             }
         }
 
@@ -982,14 +979,14 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetDouble(0).Should().BeApproximately(50.5, Double.Epsilon);
-                    row.GetInt(1).Should().Be(100);
-                    row.GetInt(2).Should().Be(1);
-                    row.GetInt(3).Should().Be(100);
-                    row.GetInt(4).Should().Be(5050);
+                    row.GetDouble(0).ShouldBe(50.5, Double.Epsilon);
+                    row.GetInt(1).ShouldBe(100);
+                    row.GetInt(2).ShouldBe(1);
+                    row.GetInt(3).ShouldBe(100);
+                    row.GetInt(4).ShouldBe(5050);
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
         }
 
@@ -1020,12 +1017,12 @@ namespace Test
                     var count = row.GetInt(1);
                     var maxZip = row.GetString(2);
                     if (n - 1 < expectedStates.Length) {
-                        state.Should().Be(expectedStates[n - 1]);
-                        count.Should().Be(expectedCounts[n - 1]);
-                        maxZip.Should().Be(expectedZips[n - 1]);
+                        state.ShouldBe(expectedStates[n - 1]);
+                        count.ShouldBe(expectedCounts[n - 1]);
+                        maxZip.ShouldBe(expectedZips[n - 1]);
                     }
                 });
-                numRows.Should().Be(31);
+                numRows.ShouldBe(31);
             }
 
             expectedStates = new[] { "CA", "IA", "IN" };
@@ -1044,12 +1041,12 @@ namespace Test
                     var count = row.GetInt(1);
                     var maxZip = row.GetString(2);
                     if (n - 1 < expectedStates.Length) {
-                        state.Should().Be(expectedStates[n - 1]);
-                        count.Should().Be(expectedCounts[n - 1]);
-                        maxZip.Should().Be(expectedZips[n - 1]);
+                        state.ShouldBe(expectedStates[n - 1]);
+                        count.ShouldBe(expectedCounts[n - 1]);
+                        maxZip.ShouldBe(expectedZips[n - 1]);
                     }
                 });
-                numRows.Should().Be(15);
+                numRows.ShouldBe(15);
             }
         }
 #endif
@@ -1074,10 +1071,10 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
                     var number = row.GetInt(0);
-                    number.Should().Be(expectedNumbers[n - 1]);
+                    number.ShouldBe(expectedNumbers[n - 1]);
                 });
 
-                numRows.Should().Be(4);
+                numRows.ShouldBe(4);
             }
         }
 
@@ -1117,14 +1114,14 @@ namespace Test
                 foreach (var r in res) {
                     totalBooksCnt++;
                     var p = r.GetString("$price")?.Remove(0, 1);
-                    p.Should().NotBeNull("because otherwise the query didn't return correct results");
+                    p.ShouldNotBeNull("because otherwise the query didn't return correct results");
                     if (Convert.ToInt32(p) < 100)
                         bookPriceLessThan100Cnt++;
                 }
             }
 
-            totalBooksCnt.Should().Be(2);
-            bookPriceLessThan100Cnt.Should().Be(1);
+            totalBooksCnt.ShouldBe(2);
+            bookPriceLessThan100Cnt.ShouldBe(1);
         }
 
         [Fact]
@@ -1146,25 +1143,25 @@ namespace Test
                 {
                     var docID = row.GetString(0);
                     var docID2 = row.GetString("id");
-                    docID.Should().Be(docID2, "because these calls are two ways of accessing the same info");
+                    docID.ShouldBe(docID2, "because these calls are two ways of accessing the same info");
                     var seq = row.GetInt(1);
                     var seq2 = row.GetInt("sequence");
-                    seq.Should().Be(seq2, "because these calls are two ways of accessing the same info");
+                    seq.ShouldBe(seq2, "because these calls are two ways of accessing the same info");
                     var revID1 = row.GetString(2);
                     var revID2 = row.GetString("revisionID");
-                    revID1.Should().Be(revID2, "because these calls are two ways of accessing the same info");
+                    revID1.ShouldBe(revID2, "because these calls are two ways of accessing the same info");
                     var number = row.GetInt(3);
 
-                    docID.Should().Be(expectedDocIDs[n - 1]);
-                    seq.Should().Be(expectedSeqs[n - 1]);
+                    docID.ShouldBe(expectedDocIDs[n - 1]);
+                    seq.ShouldBe(expectedSeqs[n - 1]);
                     using (var d = DefaultCollection.GetDocument(docID!)) {
-                        d.Should().NotBeNull("because otherwise the document '{doc}' was missing", docID);
-                        revID1.Should().Be(d!.RevisionID);
+                        d.ShouldNotBeNull($"because otherwise the document '{docID}' was missing");
+                        revID1.ShouldBe(d!.RevisionID);
                     }
-                    number.Should().Be(expectedNumbers[n - 1]);
+                    number.ShouldBe(expectedNumbers[n - 1]);
                 });
 
-                numRows.Should().Be(5);
+                numRows.ShouldBe(5);
             }
         }
 
@@ -1184,10 +1181,10 @@ namespace Test
                 var expectedNumbers = new[] {1, 2, 3, 4, 5};
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetInt(0).Should().Be(expectedNumbers[n - 1]);
+                    row.GetInt(0).ShouldBe(expectedNumbers[n - 1]);
                 });
 
-                numRows.Should().Be(5);
+                numRows.ShouldBe(5);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Property("number1"))
@@ -1200,10 +1197,10 @@ namespace Test
                 var expectedNumbers = new[] {1, 2, 3};
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetInt(0).Should().Be(expectedNumbers[n - 1]);
+                    row.GetInt(0).ShouldBe(expectedNumbers[n - 1]);
                 });
 
-                numRows.Should().Be(3);
+                numRows.ShouldBe(3);
             }
         }
 
@@ -1224,10 +1221,10 @@ namespace Test
                 var expectedNumbers = new[] {4, 5, 6, 7, 8};
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetInt(0).Should().Be(expectedNumbers[n - 1]);
+                    row.GetInt(0).ShouldBe(expectedNumbers[n - 1]);
                 });
 
-                numRows.Should().Be(5);
+                numRows.ShouldBe(5);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Property("number1"))
@@ -1240,10 +1237,10 @@ namespace Test
                 var expectedNumbers = new[] {6, 7, 8};
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetInt(0).Should().Be(expectedNumbers[n - 1]);
+                    row.GetInt(0).ShouldBe(expectedNumbers[n - 1]);
                 });
 
-                numRows.Should().Be(3);
+                numRows.ShouldBe(3);
             }
         }
 
@@ -1267,13 +1264,13 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetValue("firstname").Should().Be(r.GetValue(0));
-                    r.GetValue("lastname").Should().Be(r.GetValue(1));
-                    r.GetValue("gender").Should().Be(r.GetValue(2));
-                    r.GetValue("city").Should().Be(r.GetValue(3));
+                    r.GetValue("firstname").ShouldBe(r.GetValue(0));
+                    r.GetValue("lastname").ShouldBe(r.GetValue(1));
+                    r.GetValue("gender").ShouldBe(r.GetValue(2));
+                    r.GetValue("city").ShouldBe(r.GetValue(3));
                 });
 
-                numRows.Should().Be(100);
+                numRows.ShouldBe(100);
             }
         }
 #endif
@@ -1292,11 +1289,11 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetDouble("$1").Should().Be(r.GetDouble(0));
-                    r.GetInt("$2").Should().Be(r.GetInt(1));
-                    r.GetInt("min").Should().Be(r.GetInt(2));
-                    r.GetInt("$3").Should().Be(r.GetInt(3));
-                    r.GetInt("sum").Should().Be(r.GetInt(4));
+                    r.GetDouble("$1").ShouldBe(r.GetDouble(0));
+                    r.GetInt("$2").ShouldBe(r.GetInt(1));
+                    r.GetInt("min").ShouldBe(r.GetInt(2));
+                    r.GetInt("$3").ShouldBe(r.GetInt(3));
+                    r.GetInt("sum").ShouldBe(r.GetInt(4));
                 });
             }
         }
@@ -1316,10 +1313,10 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetInt(0).Should().Be(2);
+                    r.GetInt(0).ShouldBe(2);
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(ArrayFunction.Contains(Expression.Property("array"), Expression.String("650-123-0001"))),
@@ -1327,11 +1324,11 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetBoolean(0).Should().BeTrue();
-                    r.GetBoolean(1).Should().BeFalse();
+                    r.GetBoolean(0).ShouldBeTrue();
+                    r.GetBoolean(1).ShouldBeFalse();
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
         }
 
@@ -1369,10 +1366,10 @@ namespace Test
                     .From(DataSource.Collection(DefaultCollection))) {
                     var numRows = VerifyQuery(q, (n, r) =>
                     {
-                        r.GetDouble(0).Should().Be(expectedValues[index++]);
+                        r.GetDouble(0).ShouldBe(expectedValues[index++]);
                     });
 
-                    numRows.Should().Be(1);
+                    numRows.ShouldBe(1);
                 }
             }
 
@@ -1381,11 +1378,11 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetDouble(0).Should().Be(Math.E * 2);
-                    r.GetDouble(1).Should().Be(Math.PI * 2);
+                    r.GetDouble(0).ShouldBe(Math.E * 2);
+                    r.GetDouble(1).ShouldBe(Math.PI * 2);
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
         }
 
@@ -1404,21 +1401,21 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetBoolean(0).Should().BeTrue();
-                    r.GetBoolean(1).Should().BeFalse();
+                    r.GetBoolean(0).ShouldBeTrue();
+                    r.GetBoolean(1).ShouldBeFalse();
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Function.Length(prop)))
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetInt(0).Should().Be(str.Length);
+                    r.GetInt(0).ShouldBe(str.Length);
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Function.Lower(prop)),
@@ -1429,14 +1426,14 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetString(0).Should().Be(str.ToLowerInvariant());
-                    r.GetString(1).Should().Be(str.TrimStart());
-                    r.GetString(2).Should().Be(str.TrimEnd());
-                    r.GetString(3).Should().Be(str.Trim());
-                    r.GetString(4).Should().Be(str.ToUpperInvariant());
+                    r.GetString(0).ShouldBe(str.ToLowerInvariant());
+                    r.GetString(1).ShouldBe(str.TrimStart());
+                    r.GetString(2).ShouldBe(str.TrimEnd());
+                    r.GetString(3).ShouldBe(str.Trim());
+                    r.GetString(4).ShouldBe(str.ToUpperInvariant());
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
         }
 
@@ -1453,7 +1450,7 @@ namespace Test
                 var expected = new[] {"doc-017", "doc-021", "doc-023", "doc-045", "doc-060"};
                 var results = q.Execute();
                 var received = results.Select(x => x.GetString("id"));
-                received.Should().BeEquivalentTo(expected);
+                received.ShouldBeEquivalentToFluent(expected);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
@@ -1462,8 +1459,8 @@ namespace Test
                     .Satisfies(ArrayExpression.Variable("like").EqualTo(Expression.String("taxes"))))) {
                 var results = q.Execute();
                 var received = results.Select(x => x.GetString("id")).ToList();
-                received.Count.Should().Be(42, "because empty array results are included");
-                received[0].Should().Be("doc-007");
+                received.Count.ShouldBe(42, "because empty array results are included");
+                received[0].ShouldBe("doc-007");
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
@@ -1472,7 +1469,7 @@ namespace Test
                     .Satisfies(ArrayExpression.Variable("like").EqualTo(Expression.String("taxes"))))) {
                 var results = q.Execute();
                 var received = results.Select(x => x.GetString("id")).ToList();
-                received.Count.Should().Be(0, "because nobody likes taxes...");
+                received.Count.ShouldBe(0, "because nobody likes taxes...");
             }
         }
 #endif
@@ -1524,8 +1521,8 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .Where(where)) {
                 var expected = new[] { "doc-0", "doc-2" };
-                var numRows = VerifyQuery(q, (n, row) => { row.GetString(0).Should().Be(expected[n - 1]); });
-                numRows.Should().Be(expected.Length);
+                var numRows = VerifyQuery(q, (n, row) => { row.GetString(0).ShouldBe(expected[n - 1]); });
+                numRows.ShouldBe(expected.Length);
             }
         }
 
@@ -1538,13 +1535,13 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
                     var all = r.GetDictionary(0);
-                    all.Should().NotBeNull("because otherwise the query returned incorrect results");
-                    all!.GetInt("number1").Should().Be(n);
-                    all.GetInt("number2").Should().Be(100 - n);
-                    r.GetInt(1).Should().Be(n);
+                    all.ShouldNotBeNull("because otherwise the query returned incorrect results");
+                    all!.GetInt("number1").ShouldBe(n);
+                    all.GetInt("number2").ShouldBe(100 - n);
+                    r.GetInt(1).ShouldBe(n);
                 });
 
-                numRows.Should().Be(100);
+                numRows.ShouldBe(100);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.All().From("db"), SelectResult.Expression(Expression.Property("number1").From("db")))
@@ -1552,13 +1549,13 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
                     var all = r.GetDictionary(0);
-                    all.Should().NotBeNull("because otherwise the query returned incorrect results");
-                    all!.GetInt("number1").Should().Be(n);
-                    all.GetInt("number2").Should().Be(100 - n);
-                    r.GetInt(1).Should().Be(n);
+                    all.ShouldNotBeNull("because otherwise the query returned incorrect results");
+                    all!.GetInt("number1").ShouldBe(n);
+                    all.GetInt("number2").ShouldBe(100 - n);
+                    r.GetInt(1).ShouldBe(n);
                 });
 
-                numRows.Should().Be(100);
+                numRows.ShouldBe(100);
             }
         }
         
@@ -1584,38 +1581,38 @@ namespace Test
             asciiNoSensitive.SetOperand(expr);
             locale.SetOperand(expr);
 
-            bothSensitive.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object> {
+            bothSensitive.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object> {
                 ["UNICODE"] = true,
 				["LOCALE"] = Collation.DefaultLocale
             }, new[] { ".test" }});
-            accentSensitive.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object>
+            accentSensitive.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object>
             {
                 ["UNICODE"] = true,
                 ["CASE"] = false,
 				["LOCALE"] = Collation.DefaultLocale
             }, new[] { ".test" }});
-            caseSensitive.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object>
+            caseSensitive.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object>
             {
                 ["UNICODE"] = true,
                 ["DIAC"] = false,
 				["LOCALE"] = Collation.DefaultLocale
             }, new[] { ".test" }});
-            noSensitive.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object>
+            noSensitive.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object>
             {
                 ["UNICODE"] = true,
                 ["DIAC"] = false,
                 ["CASE"] = false,
 				["LOCALE"] = Collation.DefaultLocale
             }, new[] { ".test" }});
-            ascii.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object>
+            ascii.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object>
             {
             }, new[] { ".test" }});
-            asciiNoSensitive.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object>
+            asciiNoSensitive.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object>
             {
                 ["CASE"] = false
             }, new[] { ".test" }});
 
-            locale.ConvertToJSON().Should().BeEquivalentTo(new object[] { "COLLATE", new Dictionary<string, object>
+            locale.ConvertToJSON().ShouldBeEquivalentToFluent(new object[] { "COLLATE", new Dictionary<string, object>
             {
                 ["UNICODE"] = true,
                 ["LOCALE"] = "ja"
@@ -1638,7 +1635,7 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .OrderBy(Ordering.Expression(stringProp.Collate(Collation.Unicode())))) {
                 var results = q.Execute();
-                results.Select(x => x.GetString(0)).Should().BeEquivalentTo(new[] {"A", "Å", "B", "Z"},
+                results.Select(x => x.GetString(0)).ShouldBeEquivalentToFluent(new[] {"A", "Å", "B", "Z"},
                     "because by default Å comes between A and B");
             }
 
@@ -1646,7 +1643,7 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .OrderBy(Ordering.Expression(stringProp.Collate(Collation.Unicode().Locale("se"))))) {
                 var results = q.Execute();
-                results.Select(x => x.GetString(0)).Should().BeEquivalentTo(new[] { "A", "B", "Z", "Å" },
+                results.Select(x => x.GetString(0)).ShouldBeEquivalentToFluent(new[] { "A", "B", "Z", "Å" },
                     "because in Swedish Å comes after Z");
             }
         }
@@ -1737,7 +1734,7 @@ namespace Test
                         .From(DataSource.Collection(DefaultCollection))
                         .Where(comparison)) {
                         var result = q.Execute();
-                        result.Should().HaveCount(1,
+                        result.Count().ShouldBe(1,
                             $"because otherwise the comparison failed for {data.Item1} and {data.Item2} (position {i})");
                     }
 
@@ -1783,7 +1780,7 @@ namespace Test
                     .From(DataSource.Collection(DefaultCollection))
                     .OrderBy(Ordering.Expression(property.Collate(data.Item2)))) {
                     var results = q.Execute();
-                    results.Select(x => x.GetString(0)).Should().ContainInOrder(data.Item3);
+                    results.Select(x => x.GetString(0)).ShouldBeEquivalentToFluent(data.Item3);
                 }
             }
         }
@@ -1798,8 +1795,8 @@ namespace Test
             var cnt = Function.Count(Expression.Property("number1"));
             var rsCnt = SelectResult.Expression(cnt);
             using (var q = QueryBuilder.Select(rsCnt).From(ds)) {
-                var numRows = VerifyQuery(q, (n, row) => { row.GetInt(0).Should().Be(100); });
-                numRows.Should().Be(1);
+                var numRows = VerifyQuery(q, (n, row) => { row.GetInt(0).ShouldBe(100); });
+                numRows.ShouldBe(1);
             }
         }
 
@@ -1876,22 +1873,22 @@ namespace Test
                         counter++;
                     }
 
-                    counter.Should().Be(2);
+                    counter.ShouldBe(2);
 
-                    task1.IsDeleted.Should().BeFalse();
+                    task1.IsDeleted.ShouldBeFalse();
                     DefaultCollection.Delete(task1);
-                    DefaultCollection.Count.Should().Be(1);
-                    DefaultCollection.GetDocument(task1.Id).Should().BeNull();
+                    DefaultCollection.Count.ShouldBe(1UL);
+                    DefaultCollection.GetDocument(task1.Id).ShouldBeNull();
 
                     rs = q.Execute();
                     counter = 0;
                     foreach (var r in rs) {
-                        r.GetString(0).Should().Be(task2.Id);
+                        r.GetString(0).ShouldBe(task2.Id);
                         WriteLine($"Round 2: Result -> {JsonConvert.SerializeObject(r.ToDictionary())}");
                         counter++;
                     }
 
-                    counter.Should().Be(1);
+                    counter.ShouldBe(1);
                 }
             }
         }
@@ -1903,7 +1900,7 @@ namespace Test
             using (var task1 = CreateTaskDocument("Task 1", false))
             using (var task2 = CreateTaskDocument("Task 2", true))
             using (var task3 = CreateTaskDocument("Task 3", true)) {
-                DefaultCollection.Count.Should().Be(3);
+                DefaultCollection.Count.ShouldBe(3UL);
 
                 var exprType = Expression.Property("type");
                 var exprComplete = Expression.Property("complete");
@@ -1915,13 +1912,13 @@ namespace Test
                     {
                         WriteLine($"res -> {JsonConvert.SerializeObject(row.ToDictionary())}");
                         var dict = row.GetDictionary("_default");
-                        dict.Should().NotBeNull("because otherwise the query returned incorrect data");
-                        dict!.GetBoolean("complete").Should().BeTrue();
-                        dict.GetString("type").Should().Be("task");
-                        dict.GetString("title").Should().StartWith("Task ");
+                        dict.ShouldNotBeNull("because otherwise the query returned incorrect data");
+                        dict!.GetBoolean("complete").ShouldBeTrue();
+                        dict.GetString("type").ShouldBe("task");
+                        dict.GetString("title").ShouldStartWith("Task ");
                     });
 
-                    numRows.Should().Be(2);
+                    numRows.ShouldBe(2);
                 }
 
                 using (var q = QueryBuilder.Select(SelectResult.All())
@@ -1931,13 +1928,13 @@ namespace Test
                     {
                         WriteLine($"res -> {JsonConvert.SerializeObject(row.ToDictionary())}");
                         var dict = row.GetDictionary("_default");
-                        dict.Should().NotBeNull("because otherwise the query returned incorrect data");
-                        dict!.GetBoolean("complete").Should().BeFalse();
-                        dict.GetString("type").Should().Be("task");
-                        dict.GetString("title").Should().StartWith("Task ");
+                        dict.ShouldNotBeNull("because otherwise the query returned incorrect data");
+                        dict!.GetBoolean("complete").ShouldBeFalse();
+                        dict.GetString("type").ShouldBe("task");
+                        dict.GetString("title").ShouldStartWith("Task ");
                     });
 
-                    numRows.Should().Be(1);
+                    numRows.ShouldBe(1);
                 }
 
                 using (var q = QueryBuilder.Select(srCount)
@@ -1946,10 +1943,10 @@ namespace Test
                     var numRows = VerifyQuery(q, (n, row) =>
                     {
                         WriteLine($"res -> {JsonConvert.SerializeObject(row.ToDictionary())}");
-                        row.GetInt(0).Should().Be(2);
+                        row.GetInt(0).ShouldBe(2);
                     });
 
-                    numRows.Should().Be(1);
+                    numRows.ShouldBe(1);
                 }
 
                 using (var q = QueryBuilder.Select(srCount)
@@ -1958,10 +1955,10 @@ namespace Test
                     var numRows = VerifyQuery(q, (n, row) =>
                     {
                         WriteLine($"res -> {JsonConvert.SerializeObject(row.ToDictionary())}");
-                        row.GetInt(0).Should().Be(1);
+                        row.GetInt(0).ShouldBe(1);
                     });
 
-                    numRows.Should().Be(1);
+                    numRows.ShouldBe(1);
                 }
             }
         }
@@ -2002,15 +1999,15 @@ namespace Test
                     WriteLine($"secondAll1 -> {JsonConvert.SerializeObject(secondAll1)}");
                     WriteLine($"secondAll2 -> {JsonConvert.SerializeObject(secondAll2)}");
 
-                    mainAll1?.GetInt("number1").Should().Be(42);
-                    mainAll2?.GetInt("number1").Should().Be(42);
-                    mainAll1?.GetInt("number2").Should().Be(58);
-                    mainAll1?.GetInt("number2").Should().Be(58);
-                    secondAll1?.GetInt("theone").Should().Be(42);
-                    secondAll2?.GetInt("theone").Should().Be(42);
+                    mainAll1?.GetInt("number1").ShouldBe(42);
+                    mainAll2?.GetInt("number1").ShouldBe(42);
+                    mainAll1?.GetInt("number2").ShouldBe(58);
+                    mainAll1?.GetInt("number2").ShouldBe(58);
+                    secondAll1?.GetInt("theone").ShouldBe(42);
+                    secondAll2?.GetInt("theone").ShouldBe(42);
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
         }
 
@@ -2043,20 +2040,20 @@ namespace Test
                 .Join(join)) {
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
-                    n.Should().Be(1);
+                    n.ShouldBe(1);
                     var docID = row.GetString("mainDocID");
-                    docID.Should().NotBeNull("because otherwise the query returned incorrect results");
+                    docID.ShouldNotBeNull("because otherwise the query returned incorrect results");
                     using (var doc = DefaultCollection.GetDocument(docID!)) {
-                        doc.Should().NotBeNull("because otherwise the document disappeared from the database");
-                        doc!.GetInt("number1").Should().Be(1);
-                        doc.GetInt("number2").Should().Be(99);
+                        doc.ShouldNotBeNull("because otherwise the document disappeared from the database");
+                        doc!.GetInt("number1").ShouldBe(1);
+                        doc.GetInt("number2").ShouldBe(99);
 
-                        row.GetString("secondaryDocID").Should().Be("joinme");
-                        row.GetInt("theone").Should().Be(42);
+                        row.GetString("secondaryDocID").ShouldBe("joinme");
+                        row.GetInt("theone").ShouldBe(42);
                     }
                 });
 
-                numRows.Should().Be(1);
+                numRows.ShouldBe(1);
             }
         }
 
@@ -2074,20 +2071,20 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 var results = q.Execute();
                 foreach (var result in results) {
-                    result.Count.Should().Be(1);
-                    result.Contains("name").Should().BeFalse();
-                    result.GetString("name").Should().BeNull();
-                    result.GetValue("name").Should().BeNull();
-                    result.GetString(0).Should().BeNull();
-                    result.GetValue(0).Should().BeNull();
-                    result.Contains("nullval").Should().BeTrue();
-                    result.GetString("nullval").Should().BeNull();
-                    result.GetValue("nullval").Should().BeNull();
-                    result.GetString(1).Should().BeNull();
-                    result.GetValue(1).Should().BeNull();
+                    result.Count.ShouldBe(1);
+                    result.Contains("name").ShouldBeFalse();
+                    result.GetString("name").ShouldBeNull();
+                    result.GetValue("name").ShouldBeNull();
+                    result.GetString(0).ShouldBeNull();
+                    result.GetValue(0).ShouldBeNull();
+                    result.Contains("nullval").ShouldBeTrue();
+                    result.GetString("nullval").ShouldBeNull();
+                    result.GetValue("nullval").ShouldBeNull();
+                    result.GetString(1).ShouldBeNull();
+                    result.GetValue(1).ShouldBeNull();
 
-                    result?.ToList<object?>().Should().ContainInOrder(new object?[] { null });
-                    result?.ToDictionary().Should().BeEquivalentTo(new Dictionary<string, object?>
+                    result?.ToList<object?>().ShouldBeEquivalentToFluent(new object?[] { null });
+                    result?.ToDictionary().ShouldBeEquivalentToFluent(new Dictionary<string, object?>
                     {
                         ["nullval"] = null
                     });
@@ -2108,12 +2105,14 @@ namespace Test
                 .SetString("name", "Jim");
 
             var parameters = builder;
-            parameters.GetValue("true").As<bool>().Should().BeTrue();
-            parameters.GetValue("now").As<DateTimeOffset>().Should().Be(now);
-            parameters.GetValue("pi").As<double>().Should().Be(Math.PI);
-            parameters.GetValue("simple_pi").As<float>().Should().Be(3.14159f);
-            parameters.GetValue("big_num").As<long>().Should().Be(Int64.MaxValue);
-            parameters.GetValue("name").As<string>().Should().Be("Jim");
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+            ((bool)parameters.GetValue("true")).ShouldBeTrue();
+            ((DateTimeOffset)parameters.GetValue("now")).ShouldBe(now);
+            ((double)parameters.GetValue("pi")).ShouldBe(Math.PI);
+            ((float)parameters.GetValue("simple_pi")).ShouldBe(3.14159f);
+            ((long)parameters.GetValue("big_num")).ShouldBe(Int64.MaxValue);
+            ((string?)parameters.GetValue("name")).ShouldBe("Jim");
+#pragma warning restore CS8605 // Unboxing a possibly null value.
         }
 
         [Fact]
@@ -2141,25 +2140,25 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))) {
                 VerifyQuery(q, (n, row) =>
                 {
-                    row.GetArray(0).Should().ContainInOrder(1L, 2L, 3L);
-                    row.GetArray("array").Should().ContainInOrder(1L, 2L, 3L);
-                    row.GetBlob(1)?.Content.Should().ContainInOrder(blobContent);
-                    row.GetBlob("blob")?.Content.Should().ContainInOrder(blobContent);
-                    row.GetDate(2).Should().Be(now);
-                    row.GetDate("created_at").Should().Be(now);
-                    row.GetFloat(3).Should().Be(3.14159f);
-                    row.GetFloat("simple_pi").Should().Be(3.14159f);
-                    row.GetLong(4).Should().Be(Int64.MaxValue);
-                    row.GetLong("big_num").Should().Be(Int64.MaxValue);
+                    row.GetArray(0).ShouldBeEquivalentToFluent(new[] { 1L, 2L, 3L });
+                    row.GetArray("array").ShouldBeEquivalentToFluent(new[] { 1L, 2L, 3L });
+                    row.GetBlob(1)?.Content.ShouldBeEquivalentToFluent(blobContent);
+                    row.GetBlob("blob")?.Content.ShouldBeEquivalentToFluent(blobContent);
+                    row.GetDate(2).ShouldBe(now);
+                    row.GetDate("created_at").ShouldBe(now);
+                    row.GetFloat(3).ShouldBe(3.14159f);
+                    row.GetFloat("simple_pi").ShouldBe(3.14159f);
+                    row.GetLong(4).ShouldBe(Int64.MaxValue);
+                    row.GetLong("big_num").ShouldBe(Int64.MaxValue);
 
-                    row[4].Long.Should().Be(Int64.MaxValue);
-                    row["big_num"].Long.Should().Be(Int64.MaxValue);
-                    row.GetBoolean(5).Should().Be(true);
-                    row.GetBoolean("boolean").Should().Be(true);
+                    row[4].Long.ShouldBe(Int64.MaxValue);
+                    row["big_num"].Long.ShouldBe(Int64.MaxValue);
+                    row.GetBoolean(5).ShouldBe(true);
+                    row.GetBoolean("boolean").ShouldBe(true);
 
                     var resultList = row.ToList();
-                    resultList.Count.Should().Be(6);
-                    resultList.ElementAtOrDefault(2).Should().Be(now.ToString("o"));
+                    resultList.Count.ShouldBe(6);
+                    resultList.ElementAtOrDefault(2).ShouldBe(now.ToString("o"));
                 });
             }
         }
@@ -2186,9 +2185,9 @@ namespace Test
                 .Where(FullTextFunction.Match(Expression.FullTextIndex("passageIndex"), "cat"))) {
                 var count = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().Be($"doc{n}");
+                    row.GetString(0).ShouldBe($"doc{n}");
                 });
-                count.Should().Be(2);
+                count.ShouldBe(2);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
@@ -2196,9 +2195,9 @@ namespace Test
                 .Where(FullTextFunction.Match(Expression.FullTextIndex("passageIndexStemless"), "cat"))) {
                 var count = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().Be($"doc{n}");
+                    row.GetString(0).ShouldBe($"doc{n}");
                 });
-                count.Should().Be(1);
+                count.ShouldBe(1);
             }
         }
 
@@ -2267,10 +2266,10 @@ namespace Test
                 resultsValue = query.Execute().Select(r => r.GetDictionary(Db.Name)).ToArray();
             }
 
-            resultsDouble.Length.Should().Be(1);
-            resultsFloat.Length.Should().Be(1);
-            resultsLong.Length.Should().Be(1);
-            resultsValue.Length.Should().Be(1);
+            resultsDouble.Length.ShouldBe(1);
+            resultsFloat.Length.ShouldBe(1);
+            resultsLong.Length.ShouldBe(1);
+            resultsValue.Length.ShouldBe(1);
         }
 
         [Fact]
@@ -2291,7 +2290,7 @@ namespace Test
                 .Select(SelectResult.All())
                 .From(DataSource.Collection(DefaultCollection))) {
                 var l = from.Execute().ToArray();
-                l.Count().Should().Be(1);
+                l.Count().ShouldBe(1);
             }
 ;
             using (var query = QueryBuilder
@@ -2312,8 +2311,8 @@ namespace Test
                 results2 = query.Execute().Select(r => r.GetDictionary(Db.Name)).ToArray();
             }
 
-            results1.Length.Should().Be(1);
-            results2.Length.Should().Be(1);
+            results1.Length.ShouldBe(1);
+            results2.Length.ShouldBe(1);
         }
 
         [Fact]
@@ -2332,9 +2331,9 @@ namespace Test
                     Expression.Property("timestamp").EqualTo(Expression.Date(dto1))
                 )) {
                 resultset = (QueryResultSet)query.Execute();
-                resultset.Collection.Should().Be(DefaultCollection);
+                resultset.Collection.ShouldBe(DefaultCollection);
                 List<Result> allRes = resultset.AllResults();
-                allRes.Count.Should().Be(1);
+                allRes.Count.ShouldBe(1);
                 var columnName = resultset.ColumnNames;
             }
             resultset.Refresh();
@@ -2392,9 +2391,9 @@ namespace Test
                 results3 = query.Execute().Select(r => r.GetDictionary(Db.Name)).ToArray();
             }
 
-            results1.Length.Should().Be(1);
-            results2.Length.Should().Be(1);
-            results3.Length.Should().Be(1);
+            results1.Length.ShouldBe(1);
+            results2.Length.ShouldBe(1);
+            results3.Length.ShouldBe(1);
         }
 
         [ForIssue("couchbase-lite-core/497")]
@@ -2426,16 +2425,16 @@ namespace Test
                 {
                     if (n == 41) {
                         WriteLine($"41: {JsonConvert.SerializeObject(row.ToDictionary())}");
-                        row.GetDictionary("main")?.GetInt("number2").Should().Be(59);
-                        row.GetDictionary("secondary").Should().BeNull();
+                        row.GetDictionary("main")?.GetInt("number2").ShouldBe(59);
+                        row.GetDictionary("secondary").ShouldBeNull();
                     } else if (n == 42) {
                         WriteLine($"42: {JsonConvert.SerializeObject(row.ToDictionary())}");
-                        row.GetDictionary("main")?.GetInt("number2").Should().Be(58);
-                        row.GetDictionary("secondary")?.GetInt("theone").Should().Be(42);
+                        row.GetDictionary("main")?.GetInt("number2").ShouldBe(58);
+                        row.GetDictionary("secondary")?.GetInt("theone").ShouldBe(42);
                     }
                 });
 
-                numRows.Should().Be(101);
+                numRows.ShouldBe(101);
             }
         }
 
@@ -2476,12 +2475,12 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .OrderBy(Ordering.Property("local").Ascending())) {
                 foreach (var result in q.Execute()) {
-                    result.GetLong(0).Should().Be(expectedLocal[i]);
-                    result.GetLong(1).Should().Be(expectedJST[i]);
-                    result.GetLong(2).Should().Be(expectedJST[i]);
-                    result.GetLong(3).Should().Be(expectedPST[i]);
-                    result.GetLong(4).Should().Be(expectedPST[i]);
-                    result.GetLong(5).Should().Be(expectedUTC[i]);
+                    result.GetLong(0).ShouldBe(expectedLocal[i]);
+                    result.GetLong(1).ShouldBe(expectedJST[i]);
+                    result.GetLong(2).ShouldBe(expectedJST[i]);
+                    result.GetLong(3).ShouldBe(expectedPST[i]);
+                    result.GetLong(4).ShouldBe(expectedPST[i]);
+                    result.GetLong(5).ShouldBe(expectedUTC[i]);
                     i++;
                 }
             }
@@ -2519,12 +2518,12 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .OrderBy(Ordering.Property("local").Ascending())) {
                 foreach (var result in q.Execute()) {
-                    result.GetString(0).Should().Be(expectedLocal.ElementAt(i));
-                    result.GetString(1).Should().Be(expectedJST[i]);
-                    result.GetString(2).Should().Be(expectedJST[i]);
-                    result.GetString(3).Should().Be(expectedPST[i]);
-                    result.GetString(4).Should().Be(expectedPST[i]);
-                    result.GetString(5).Should().Be(expectedUTC[i]);
+                    result.GetString(0).ShouldBe(expectedLocal.ElementAt(i));
+                    result.GetString(1).ShouldBe(expectedJST[i]);
+                    result.GetString(2).ShouldBe(expectedJST[i]);
+                    result.GetString(3).ShouldBe(expectedPST[i]);
+                    result.GetString(4).ShouldBe(expectedPST[i]);
+                    result.GetString(5).ShouldBe(expectedUTC[i]);
                     i++;
                 }
             }
@@ -2570,8 +2569,8 @@ namespace Test
                 .From(DataSource.Collection(DefaultCollection))
                 .OrderBy(Ordering.Property("timestamp").Ascending())) {
                 foreach (var result in q.Execute()) {
-                    result.GetString(0).Should().Be(expectedLocal.ElementAt(i));
-                    result.GetString(1).Should().Be(expectedUTC[i]);
+                    result.GetString(0).ShouldBe(expectedLocal.ElementAt(i));
+                    result.GetString(1).ShouldBe(expectedUTC[i]);
                     i++;
                 }
             }
@@ -2585,8 +2584,8 @@ namespace Test
                 .Where(Expression.Property("number1").LessThan(Expression.Int(10))).OrderBy(Ordering.Property("number1"))) {
                 var res = q.Execute();
                 foreach(var result in res) {
-                    result.Keys.ElementAt(0).Should().Be("_id");
-                    result.Keys.ElementAt(1).Should().Be("_sequence");
+                    result.Keys.ElementAt(0).ShouldBe("_id");
+                    result.Keys.ElementAt(1).ShouldBe("_sequence");
                 }
             }
         }
@@ -2638,7 +2637,7 @@ namespace Test
                 `13`,`14`,`15`,`16`,`17`,`18`,`19`,`20`,`21`,`22`,`23`,`24`,
                 `25`,`26`,`27`,`28`,`29`,`30`,`31`,`32`, `key` from _ limit 1")) {
                 //ColumnNames is an internal property.
-                ((QueryBase)q).ColumnNames.Count.Should().BeGreaterOrEqualTo(32);
+                ((QueryBase)q).ColumnNames.Count.ShouldBeGreaterThanOrEqualTo(32);
             }
         }
 
@@ -2670,9 +2669,9 @@ namespace Test
                 .Where(FullTextFunction.Match(plainIndex, "cat"))) {
                 var count = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().Be($"doc{n}");
+                    row.GetString(0).ShouldBe($"doc{n}");
                 });
-                count.Should().Be(2);
+                count.ShouldBe(2);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
@@ -2680,9 +2679,9 @@ namespace Test
                 .Where(FullTextFunction.Match(qualifiedIndex, "cat"))) {
                 var count = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().Be($"doc{n}");
+                    row.GetString(0).ShouldBe($"doc{n}");
                 });
-                count.Should().Be(2);
+                count.ShouldBe(2);
             }
         }
 
@@ -2720,7 +2719,7 @@ namespace Test
             //    {
             //        row.GetString(0).Should().StartWith("doc");
             //    });
-            //    count.Should().Be(4);
+            //    count.ShouldBe(4);
             //}
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID.From("main")))
@@ -2731,9 +2730,9 @@ namespace Test
                 .OrderBy(Ordering.Expression(Meta.ID.From("main")))) {
                 var count = VerifyQuery(q, (n, row) =>
                 {
-                    row.GetString(0).Should().StartWith("doc");
+                    row.GetString(0).ShouldStartWith("doc");
                 });
-                count.Should().Be(4);
+                count.ShouldBe(4);
             }
         }
 
@@ -2775,13 +2774,13 @@ namespace Test
             foreach (var pair in sqlInputAndResult) {
                 using var q = Db.CreateQuery($"SELECT * FROM {pair.queryID}");
                 var results = q.Execute();
-                results.First()[pair.resultName].Exists.Should().BeTrue($"because otherwise the result column name {pair.resultName} was not present");
+                results.First()[pair.resultName].Exists.ShouldBeTrue($"because otherwise the result column name {pair.resultName} was not present");
             }
 
             foreach (var pair in queryBuilderInputAndResult) {
                 using var q = QueryBuilder.Select(SelectResult.All()).From(pair.querySource);
                 var results = q.Execute();
-                results.First()[pair.resultName].Exists.Should().BeTrue($"because otherwise the result column name {pair.resultName} was not present");
+                results.First()[pair.resultName].Exists.ShouldBeTrue($"because otherwise the result column name {pair.resultName} was not present");
             }
         }
 
@@ -2806,21 +2805,21 @@ namespace Test
             var rs = query.Execute();
             var r = rs.First();
             var arr1 = r.GetArray("arr");
-            arr1.Should().NotBeNull("because otherwise the query didn't contain 'arr'");
+            arr1.ShouldNotBeNull("because otherwise the query didn't contain 'arr'");
             var dict1 = r.GetDictionary("dict");
-            dict1.Should().NotBeNull("because otherwise the query didn't contain 'dict'");
+            dict1.ShouldNotBeNull("because otherwise the query didn't contain 'dict'");
 
             rs.Dispose();
 
-            FluentActions.Invoking(() => r.GetArray("arr")).Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(() => r.GetDictionary("dict")).Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(() => r.GetBlob("blob")).Should().Throw<ObjectDisposedException>();
-            r.GetInt("int").Should().Be(42);
+            Should.Throw<ObjectDisposedException>(() => r.GetArray("arr"));
+            Should.Throw<ObjectDisposedException>(() => r.GetDictionary("dict"));
+            Should.Throw<ObjectDisposedException>(() => r.GetBlob("blob"));
+            r.GetInt("int").ShouldBe(42);
 
-            FluentActions.Invoking(() => arr1!.GetValue(0)).Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(() => dict1!.GetValue("foo")).Should().Throw<ObjectDisposedException>();
-            arr.GetInt(0).Should().Be(1);
-            dict.GetString("foo").Should().Be("bar");
+            Should.Throw<ObjectDisposedException>(() => arr1!.GetValue(0));
+            Should.Throw<ObjectDisposedException>(() => dict1!.GetValue("foo"));
+            arr.GetInt(0).ShouldBe(1);
+            dict.GetString("foo").ShouldBe("bar");
         }
 
         [Fact]
@@ -2828,9 +2827,10 @@ namespace Test
         public void TestColumnNamesAfterDispose()
         {
             var q = Db.CreateQuery(@"select foo from _") as QueryBase;
-            q.ColumnNames.Should().HaveCount(1, "because there is one column");
+            q.ShouldNotBeNull();
+            q.ColumnNames.Count.ShouldBe(1, "because there is one column");
             q.Dispose();
-            FluentActions.Invoking(() => q.ColumnNames).Should().Throw<ObjectDisposedException>("because the object was disposed");
+            Should.Throw<ObjectDisposedException>(() => q.ColumnNames, "because the object was disposed");
         }
 
         private void CreateDateDocs()
@@ -2881,7 +2881,7 @@ namespace Test
                 {
                     if (consumeAll) {
                         var rs = args.Results;
-                        rs.ToArray().Should().NotBeNull(); // No-op
+                        rs.ToArray().ShouldNotBeNull(); // No-op
                     }
 
                     are.Set();
@@ -2893,9 +2893,9 @@ namespace Test
                     // This change will not affect the query results because 'number1 < 10' 
                     // is not true
                     CreateDocInSeries(111, 100);
-                    are.WaitOne(5000).Should()
-                        .BeTrue("because the Changed event should fire once for the initial results");
-                    are.WaitOne(5000).Should().BeFalse("because the Changed event should not fire needlessly");
+                    are.WaitOne(5000)
+                        .ShouldBeTrue("because the Changed event should fire once for the initial results");
+                    are.WaitOne(5000).ShouldBeFalse("because the Changed event should not fire needlessly");
                 } finally {
                     token.Remove();
                 }
@@ -2941,16 +2941,16 @@ namespace Test
                     var lastN = 0;
                     VerifyQuery(q, (n, row) =>
                     {
-                        row.GetString(0).Should().NotBeNull("because otherwise the query returned incorrect information");
+                        row.GetString(0).ShouldNotBeNull("because otherwise the query returned incorrect information");
                         var doc = DefaultCollection.GetDocument(row.GetString(0)!);
-                        doc.Should().NotBeNull("because otherwise document '{doc}' didn't exist", row.GetString(0));
+                        doc.ShouldNotBeNull($"because otherwise document '{row.GetString(0)}' didn't exist");
                         var props = doc!.ToDictionary();
-                        c.Item2(props, c.Item3).Should().BeTrue("because otherwise the row failed validation");
+                        c.Item2(props, c.Item3).ShouldBeTrue("because otherwise the row failed validation");
                         lastN = n;
                     });
 
-                    lastN.Should()
-                        .Be(expectedResultCount[index++], "because otherwise there was an incorrect number of rows");
+                    lastN
+                        .ShouldBe(expectedResultCount[index++], "because otherwise there was an incorrect number of rows");
                 }
             }
         }

--- a/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
@@ -17,7 +17,7 @@
 //
 
 using Couchbase.Lite;
-using FluentAssertions;
+using Shouldly;
 using LiteCore;
 using LiteCore.Interop;
 using System.Runtime.InteropServices;
@@ -52,13 +52,13 @@ namespace Test
         public unsafe void TestSQLiteFullSyncConfig()
         {
             var config = new DatabaseConfiguration();
-            config.FullSync.Should().BeFalse("because the default should be false");
+            config.FullSync.ShouldBeFalse("because the default should be false");
 
             config.FullSync = true;
-            config.FullSync.Should().BeTrue("because C# properties should work...");
+            config.FullSync.ShouldBeTrue("because C# properties should work...");
 
             config.FullSync = false;
-            config.FullSync.Should().BeFalse("because C# properties should work...");
+            config.FullSync.ShouldBeFalse("because C# properties should work...");
         }
 
         /// <summary>
@@ -88,10 +88,10 @@ namespace Test
             Database.Delete("test", null);
             using var db = new Database("test", config);
             var c4db = db.c4db;
-            c4db.Should().NotBeNull("because the database is in use");
+            c4db.ShouldNotBeNull("because the database is in use");
             var nativeConfig = TestNative.c4db_getConfig2(c4db!.RawDatabase);
             var hasFlag = (nativeConfig->flags & C4DatabaseFlags.DiskSyncFull) == C4DatabaseFlags.DiskSyncFull;
-            hasFlag.Should().Be(useFullSync, "because the flag in LiteCore should match FullSync");
+            hasFlag.ShouldBe(useFullSync, "because the flag in LiteCore should match FullSync");
         }
     }
 

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -18,7 +18,7 @@
 
 using Couchbase.Lite;
 using Couchbase.Lite.Query;
-using FluentAssertions;
+using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,17 +40,17 @@ namespace Test
         public void TestDefaultCollectionExists()
         {
             using (var defaultColl = Db.GetDefaultCollection()) {
-                defaultColl.Should().NotBeNull("default collection is not null");
-                defaultColl.Name.Should().Be(Database._defaultCollectionName, $"default collection name is {Database._defaultCollectionName}");
+                defaultColl.ShouldNotBeNull("default collection is not null");
+                defaultColl.Name.ShouldBe(Database._defaultCollectionName, $"default collection name is {Database._defaultCollectionName}");
                 var collections = Db.GetCollections();
-                collections.Contains(defaultColl).Should().BeTrue("the default collection is included in the collection list when calling Database.GetCollections()");
+                collections.Contains(defaultColl).ShouldBeTrue("the default collection is included in the collection list when calling Database.GetCollections()");
                 var scope = defaultColl.Scope;
-                scope.Should().NotBeNull("the scope of the default collection is not null");
-                scope.Name.Should().Be(Database._defaultScopeName, $"default collection name is {Database._defaultScopeName}");
+                scope.ShouldNotBeNull("the scope of the default collection is not null");
+                scope.Name.ShouldBe(Database._defaultScopeName, $"default collection name is {Database._defaultScopeName}");
                 using (var col = Db.GetCollection(Database._defaultCollectionName))
-                    col.Should().Be(defaultColl);
+                    col.ShouldBe(defaultColl);
 
-                defaultColl.Count.Should().Be(0, "default collection’s count is 0");
+                defaultColl.Count.ShouldBe(0UL, "default collection’s count is 0");
             }
         }
 
@@ -58,21 +58,21 @@ namespace Test
         public void TestDefaultScopeExists()
         {
             var defaultScope = Db.GetDefaultScope();
-            defaultScope.Should().NotBeNull("default scope is not null");
-            defaultScope.Name.Should().Be(Database._defaultScopeName, $"default scope name is {Database._defaultScopeName}");
+            defaultScope.ShouldNotBeNull("default scope is not null");
+            defaultScope.Name.ShouldBe(Database._defaultScopeName, $"default scope name is {Database._defaultScopeName}");
             var scopes = Db.GetScopes();
-            scopes.Contains(defaultScope).Should().BeTrue("the default scope is included in the scope list when calling Database.GetScopes()");
+            scopes.Contains(defaultScope).ShouldBeTrue("the default scope is included in the scope list when calling Database.GetScopes()");
         }
 
         [Fact]
         public void TestDeleteDefaultCollection()
         {
             Action badAction = (() => Db.DeleteCollection(Database._defaultCollectionName));
-            badAction.Should().Throw<CouchbaseLiteException>("Cannot delete the default collection.");
+            Should.Throw<CouchbaseLiteException>(badAction, "Cannot delete the default collection.");
 
             Db.CreateCollection(Database._defaultCollectionName); //no-op since default collection is already existed and cannot be deleted
             using (var defaultColl = Db.GetDefaultCollection())
-                defaultColl.Should().NotBeNull("default collection cannot be deleted, so the value is none null");
+                defaultColl.ShouldNotBeNull("default collection cannot be deleted, so the value is none null");
         }
 
         #endregion
@@ -86,48 +86,48 @@ namespace Test
             using(var colB = Db.CreateCollection("colB"))
             using(var colC = Db.CreateCollection("colC")) {
                 //the created collection objects have the correct name and scope.
-                colA.Name.Should().Be("colA", "object colA has the correct name colA");
-                colA.Scope.Name.Should().Be(Database._defaultScopeName, $"objects colA has the correct scope {Database._defaultScopeName}");
-                colB.Name.Should().Be("colB", "object colB has the correct name colB");
-                colB.Scope.Name.Should().Be(Database._defaultScopeName, $"objects colB has the correct scope {Database._defaultScopeName}");
-                colC.Name.Should().Be("colC", "object colC has the correct name colC");
-                colC.Scope.Name.Should().Be(Database._defaultScopeName, $"objects colC has the correct scope {Database._defaultScopeName}");
+                colA.Name.ShouldBe("colA", "object colA has the correct name colA");
+                colA.Scope.Name.ShouldBe(Database._defaultScopeName, $"objects colA has the correct scope {Database._defaultScopeName}");
+                colB.Name.ShouldBe("colB", "object colB has the correct name colB");
+                colB.Scope.Name.ShouldBe(Database._defaultScopeName, $"objects colB has the correct scope {Database._defaultScopeName}");
+                colC.Name.ShouldBe("colC", "object colC has the correct name colC");
+                colC.Scope.Name.ShouldBe(Database._defaultScopeName, $"objects colC has the correct scope {Database._defaultScopeName}");
                 
                 //the created collections exist when calling database.GetCollection(name: String)
-                Db.GetCollection("colA").Should().Be(colA);
-                Db.GetCollection("colB").Should().Be(colB);
-                Db.GetCollection("colC").Should().Be(colC);
+                Db.GetCollection("colA").ShouldBe(colA);
+                Db.GetCollection("colB").ShouldBe(colB);
+                Db.GetCollection("colC").ShouldBe(colC);
 
                 //the created collections are in the list when calling database.GetCollections().
                 var colls = Db.GetCollections();
-                colls.Contains(colA).Should().BeTrue();
-                colls.Contains(colB).Should().BeTrue();
-                colls.Contains(colC).Should().BeTrue();
+                colls.Contains(colA).ShouldBeTrue();
+                colls.Contains(colB).ShouldBeTrue();
+                colls.Contains(colC).ShouldBeTrue();
             }
         }
 
         [Fact]
         public void TestCreateAndGetCollectionsInNamedScope()
         {
-            Db.GetScope("scopeA").Should().BeNull("Because there is no scope scopeA in Database");
+            Db.GetScope("scopeA").ShouldBeNull("Because there is no scope scopeA in Database");
             Db.CreateCollection("colA", "scopeA");
             var scopeA = Db.GetScope("scopeA");
-            scopeA.Should().NotBeNull("Because scope scopeA was created in Database two lines ago.");
-            scopeA!.Name.Should().Be("scopeA", "the created collection has the correct scope scopeA");
+            scopeA.ShouldNotBeNull("Because scope scopeA was created in Database two lines ago.");
+            scopeA!.Name.ShouldBe("scopeA", "the created collection has the correct scope scopeA");
             var colA = scopeA.GetCollection("colA");
-            colA.Should().NotBeNull("because it was created with scopeA");
-            colA!.Name.Should().Be("colA", "the created collections have the correct name colA");
+            colA.ShouldNotBeNull("because it was created with scopeA");
+            colA!.Name.ShouldBe("colA", "the created collections have the correct name colA");
             var scopes = Db.GetScopes();
-            scopes.Contains(scopeA).Should().BeTrue("the created collection’s scope is in the list when calling Database.GetScopes()");
+            scopes.Contains(scopeA).ShouldBeTrue("the created collection’s scope is in the list when calling Database.GetScopes()");
             var collections = Db.GetCollections("scopeA");
-            collections.Contains(colA).Should().BeTrue("the created collection is in the list from Database.GetCollections with scopeA");
+            collections.Contains(colA).ShouldBeTrue("the created collection is in the list from Database.GetCollections with scopeA");
         }
 
         [Fact]
         public void TestGetNonExistingCollection()
         {
             var col = Db.GetCollection("colA", "scoppeA");
-            col.Should().BeNull("No collection colA existed");
+            col.ShouldBeNull("No collection colA existed");
         }
 
         [Fact]
@@ -136,14 +136,14 @@ namespace Test
             var colA = Db.CreateCollection("colA", "scopeA");
             var colB = Db.CreateCollection("colB", "scopeA");
             var scope = Db.GetScope("scopeA");
-            scope?.GetCollection("colA").Should().Be(colA, "Because collection colA is in scopeA");
-            scope?.GetCollection("colB").Should().Be(colB, "Because collection colB is in scopeA");
+            scope?.GetCollection("colA").ShouldBe(colA, "Because collection colA is in scopeA");
+            scope?.GetCollection("colB").ShouldBe(colB, "Because collection colB is in scopeA");
             //Get all of the created collections by using scope.getCollections() API. Ensure that the collections are returned correctly.
             var cols = Db.GetCollections("scopeA");
-            cols.Count.Should().Be(2, "total 2 collection is added in the Database");
+            cols.Count.ShouldBe(2, "total 2 collection is added in the Database");
             // Check if collections order is required
-            cols.Contains(colA).Should().BeTrue();
-            cols.Contains(colB).Should().BeTrue();
+            cols.Contains(colA).ShouldBeTrue();
+            cols.Contains(colB).ShouldBeTrue();
         }
 
         [Fact]
@@ -152,20 +152,20 @@ namespace Test
             using (var colA = Db.CreateCollection("colA", "scopeA"))
             using (var colB = Db.CreateCollection("colB", "scopeA")) {
                 var scopeA = Db.GetScope("scopeA");
-                scopeA.Should().NotBeNull("because it was just created");
+                scopeA.ShouldNotBeNull("because it was just created");
                 var collectionsInScopeA = scopeA!.GetCollections();
-                collectionsInScopeA.Count.Should().Be(2, "Because 2 collections were just added in the Database.");
-                collectionsInScopeA.Contains(colA).Should().BeTrue("Because collecton colA is in scopeA");
-                collectionsInScopeA.Contains(colB).Should().BeTrue("Because collecton colB is in scopeA");
+                collectionsInScopeA.Count.ShouldBe(2, "Because 2 collections were just added in the Database.");
+                collectionsInScopeA.Contains(colA).ShouldBeTrue("Because collecton colA is in scopeA");
+                collectionsInScopeA.Contains(colB).ShouldBeTrue("Because collecton colB is in scopeA");
                 Db.DeleteCollection("colA", "scopeA");
-                scopeA.GetCollections().Count.Should().Be(1, "Collections count should be 1 because colA is deleted from scopeA");
+                scopeA.GetCollections().Count.ShouldBe(1, "Collections count should be 1 because colA is deleted from scopeA");
                 Db.DeleteCollection("colB", "scopeA");
-                Db.GetScope("scopeA").Should().BeNull();
+                Db.GetScope("scopeA").ShouldBeNull();
                 using (var col = Db.GetCollection("colA", "scopeA"))
-                    col.Should().BeNull("because colA is deleted from scopeA");
+                    col.ShouldBeNull("because colA is deleted from scopeA");
 
                 using (var col = Db.GetCollection("colB", "scopeA"))
-                    col.Should().BeNull("because colB is deleted from scopeA");
+                    col.ShouldBeNull("because colB is deleted from scopeA");
             }
         }
 
@@ -177,21 +177,21 @@ namespace Test
             var str = "_%";
             for (char letter = 'A'; letter <= 'Z'; letter++) {
                 using (var col = Db.CreateCollection(letter + str))
-                    col.Should().NotBeNull($"Valid collection name '{letter + str}'.");
+                    col.ShouldNotBeNull($"Valid collection name '{letter + str}'.");
             }
 
             for (char letter = 'a'; letter <= 'z'; letter++) {
                 using(var col = Db.CreateCollection(letter + str))
-                    col.Should().NotBeNull($"Valid collection name '{letter + str}'.");
+                    col.ShouldNotBeNull($"Valid collection name '{letter + str}'.");
             }
 
             for (char letter = '0'; letter <= '9'; letter++) {
                 using (var col = Db.CreateCollection(letter + str))
-                    col.Should().NotBeNull($"Valid collection name '{letter + str}'.");
+                    col.ShouldNotBeNull($"Valid collection name '{letter + str}'.");
             }
 
             using (var col = Db.CreateCollection("-" + str))
-                col.Should().NotBeNull($"Valid collection name '{"-" + str}'.");
+                col.ShouldNotBeNull($"Valid collection name '{"-" + str}'.");
         }
 
         [Fact]
@@ -199,9 +199,9 @@ namespace Test
         {
             // None default Collection and Scope Names start with _ and % are prohibited
             Action badAction = (() => Db.CreateCollection("_"));
-            badAction.Should().Throw<CouchbaseLiteException>("Invalid collection name '_' in scope '_default'.");
+            Should.Throw<CouchbaseLiteException>(badAction, "Invalid collection name '_' in scope '_default'.");
             badAction = (() => Db.CreateCollection("%"));
-            badAction.Should().Throw<CouchbaseLiteException>("Invalid collection name '%' in scope '_default'.");
+            Should.Throw<CouchbaseLiteException>(badAction, "Invalid collection name '%' in scope '_default'.");
         }
 
         [Fact]
@@ -215,12 +215,12 @@ namespace Test
                     continue;
 
                 Action badAction = (() => Db.CreateCollection(str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid collection name '{str + letter}' in scope '_default'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid collection name '{str + letter}' in scope '_default'.");
             }
 
             for (char letter = ':'; letter <= '@'; letter++) {
                 Action badAction = (() => Db.CreateCollection(str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid collection name '{str + letter}' in scope '_default'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid collection name '{str + letter}' in scope '_default'.");
             }
 
             for (char letter = '['; letter <= '`'; letter++) {
@@ -228,12 +228,12 @@ namespace Test
                     continue;
 
                 Action badAction = (() => Db.CreateCollection(str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid collection name '{str + letter}' in scope '_default'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid collection name '{str + letter}' in scope '_default'.");
             }
 
             for (char letter = '{'; letter <= '~'; letter++) {
                 Action badAction = (() => Db.CreateCollection(str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid collection name '{str + letter}' in scope '_default'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid collection name '{str + letter}' in scope '_default'.");
             }
         }
 
@@ -245,20 +245,20 @@ namespace Test
             var collName = "";
             for (int i = 0; i < 251; i++) {
                 collName += 'c';
-                collName.Length.Should().Be(i + 1);
+                collName.Length.ShouldBe(i + 1);
                 using (var col = Db.CreateCollection(collName))
-                    col.Should().NotBeNull($"Valid collection '{collName}' length {collName.Length}.");
+                    col.ShouldNotBeNull($"Valid collection '{collName}' length {collName.Length}.");
             }
 
             var str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_%-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
-            str.Length.Should().Be(251);
+            str.Length.ShouldBe(251);
             using (var col = Db.CreateCollection(str))
-                col.Should().NotBeNull($"because the collection name can be length at {str.Length}");
+                col.ShouldNotBeNull($"because the collection name can be length at {str.Length}");
 
             str += "e";
-            str.Length.Should().Be(252);
+            str.Length.ShouldBe(252);
             Action badAction = (() => Db.CreateCollection(str));
-            badAction.Should().Throw<CouchbaseLiteException>($"Invalid collection name '{str}' in scope because the collection name length {str.Length} is over naming length limit.");
+            Should.Throw<CouchbaseLiteException>(badAction, $"Invalid collection name '{str}' in scope '_default' because the collection name length {str.Length} is over naming length limit.");
         }
 #endif
 
@@ -267,9 +267,9 @@ namespace Test
         {
             using (var collCap = Db.CreateCollection("COLLECTION1"))
             using (var coll = Db.CreateCollection("collection1")) {
-                collCap.Should().NotBeNull();
-                coll.Should().NotBeNull("Should be able to be created because collection name is case sensitive.");
-                coll.Should().NotBeSameAs(collCap);
+                collCap.ShouldNotBeNull();
+                coll.ShouldNotBeNull("Should be able to be created because collection name is case sensitive.");
+                coll.ShouldNotBeSameAs(collCap);
             }
         }
 
@@ -281,21 +281,21 @@ namespace Test
             var str = "_%";
             for (char letter = 'A'; letter <= 'Z'; letter++) {
                 using (var col = Db.CreateCollection("abc", letter + str))
-                    col.Should().NotBeNull($"Valid scope name '{letter + str}'.");
+                    col.ShouldNotBeNull($"Valid scope name '{letter + str}'.");
             }
 
             for (char letter = 'a'; letter <= 'z'; letter++) {
                 using (var col = Db.CreateCollection("abc", letter + str))
-                    col.Should().NotBeNull($"Valid scope name '{letter + str}'.");
+                    col.ShouldNotBeNull($"Valid scope name '{letter + str}'.");
             }
 
             for (char letter = '0'; letter <= '9'; letter++) {
                 using (var col = Db.CreateCollection("abc", letter + str))
-                    col.Should().NotBeNull($"Valid scope name '{letter + str}'.");
+                    col.ShouldNotBeNull($"Valid scope name '{letter + str}'.");
             }
 
             using (var col = Db.CreateCollection("abc", "-" + str))
-                col.Should().NotBeNull($"Valid scope name '{"-" + str}'.");
+                col.ShouldNotBeNull($"Valid scope name '{"-" + str}'.");
         }
 
         [Fact]
@@ -303,9 +303,9 @@ namespace Test
         {
             // None default Collection and Scope Names start with _ and % are prohibited
             Action badAction = (() => Db.CreateCollection("abc", "_"));
-            badAction.Should().Throw<CouchbaseLiteException>("Invalid scope name '_'.");
+            Should.Throw<CouchbaseLiteException>(badAction, "Invalid scope name '_'.");
             badAction = (() => Db.CreateCollection("abc", "%"));
-            badAction.Should().Throw<CouchbaseLiteException>("Invalid scope name '%'.");
+            Should.Throw<CouchbaseLiteException>(badAction, "Invalid scope name '%'.");
         }
 
         [Fact]
@@ -319,12 +319,12 @@ namespace Test
                     continue;
 
                 Action badAction = (() => Db.CreateCollection("abc", str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid scope name '{str + letter}'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid scope name '{str + letter}'.");
             }
 
             for (char letter = ':'; letter <= '@'; letter++) {
                 Action badAction = (() => Db.CreateCollection("abc", str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid scope name '{str + letter}'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid scope name '{str + letter}'.");
             }
 
             for (char letter = '['; letter <= '`'; letter++) {
@@ -332,12 +332,12 @@ namespace Test
                     continue;
 
                 Action badAction = (() => Db.CreateCollection("abc", str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid scope name '{str + letter}'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid scope name '{str + letter}'.");
             }
 
             for (char letter = '{'; letter <= '~'; letter++) {
                 Action badAction = (() => Db.CreateCollection("abc", str + letter));
-                badAction.Should().Throw<CouchbaseLiteException>($"Invalid scope name '{str + letter}'.");
+                Should.Throw<CouchbaseLiteException>(badAction, $"Invalid scope name '{str + letter}'.");
             }
         }
 
@@ -349,20 +349,20 @@ namespace Test
             var collName = "";
             for (int i = 0; i < 251; i++) {
                 collName += 'c';
-                collName.Length.Should().Be(i + 1);
+                collName.Length.ShouldBe(i + 1);
                 using (var col = Db.CreateCollection("abc", collName))
-                    col.Should().NotBeNull($"Valid scope '{collName}' length {collName.Length}.");
+                    col.ShouldNotBeNull($"Valid scope '{collName}' length {collName.Length}.");
             }
 
             var str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_%-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
-            str.Length.Should().Be(251);
+            str.Length.ShouldBe(251);
             using (var col = Db.CreateCollection("abc", str))
-                col.Should().NotBeNull($"because the scope name can be length at {str.Length}");
+                col.ShouldNotBeNull($"because the scope name can be length at {str.Length}");
 
             str += "e";
-            str.Length.Should().Be(252);
+            str.Length.ShouldBe(252);
             Action badAction = (() => Db.CreateCollection("abc", str));
-            badAction.Should().Throw<CouchbaseLiteException>($"Invalid scope name '{str}' because the scope name length {str.Length} is over naming length limit.");
+            Should.Throw<CouchbaseLiteException>(badAction, $"Invalid scope name '{str}' because the scope name length {str.Length} is over naming length limit.");
         }
 #endif
 
@@ -371,9 +371,9 @@ namespace Test
         {
             using (var scopeCap = Db.CreateCollection("abc", "SCOPE1"))  
             using (var scope = Db.CreateCollection("abc", "scope1")) {
-                scopeCap.Should().NotBeNull();
-                scope.Should().NotBeNull("Should be able to be created because scope name is case sensitive.");
-                scope.Should().NotBeSameAs(scopeCap);
+                scopeCap.ShouldNotBeNull();
+                scope.ShouldNotBeNull("Should be able to be created because scope name is case sensitive.");
+                scope.ShouldNotBeSameAs(scopeCap);
             }
         }
 
@@ -394,9 +394,9 @@ namespace Test
             }
 
             using (var colASame = Db.CreateCollection("colA", "scopeA")) {
-                colASame.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colASame.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colASame.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
+                colASame.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colASame.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colASame.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
             }
         }
 
@@ -416,14 +416,14 @@ namespace Test
                     colA.Save(doc2);
                 }
 
-                colA.Count.Should().Be(3, "3 docs were added into colA");
+                colA.Count.ShouldBe(3UL, "3 docs were added into colA");
                 Db.DeleteCollection("colA", "scopeA");
-                Db.GetCollection("colA", "scopeA").Should().BeNull("colA is deleted.");
+                Db.GetCollection("colA", "scopeA").ShouldBeNull("colA is deleted.");
                 var colls = Db.GetCollections("scopeA");
-                colls.Contains(colA).Should().BeFalse("the collection colA is already deleted.");
+                colls.Contains(colA).ShouldBeFalse("the collection colA is already deleted.");
                 var colANew = Db.CreateCollection("colA", "scopeA");
-                colANew.Should().NotBeNull("collection colA should create successfully");
-                colANew.Count.Should().Be(0, "no doc were added in the newly created collection");
+                colANew.ShouldNotBeNull("collection colA should create successfully");
+                colANew.Count.ShouldBe(0UL, "no doc were added in the newly created collection");
             }
         }
 
@@ -448,15 +448,15 @@ namespace Test
 
                 using (var otherDB = OpenDB(Db.Name)) {
                     var colAInOtherDb = otherDB.GetCollection("colA");
-                    colAInOtherDb.Should().NotBeNull("because it was created previously");
-                    colAInOtherDb!.Count.Should().Be(3);
+                    colAInOtherDb.ShouldNotBeNull("because it was created previously");
+                    colAInOtherDb!.Count.ShouldBe(3UL);
                     var docOfColAInOtherDb = colAInOtherDb.GetDocument("doc");
-                    docOfColAInOtherDb.Should().NotBeNull("because it was saved previously");
-                    docOfColAInOtherDb!.GetString("str").Should().Be("string");
+                    docOfColAInOtherDb.ShouldNotBeNull("because it was saved previously");
+                    docOfColAInOtherDb!.GetString("str").ShouldBe("string");
                     colAInOtherDb.Delete(docOfColAInOtherDb);
                 }
 
-                colA.GetDocument("doc").Should().BeNull();
+                colA.GetDocument("doc").ShouldBeNull();
             }
         }
 
@@ -466,9 +466,9 @@ namespace Test
             using (var colA = Db.CreateCollection("colA", "scopeA"))
             using (var otherDB = OpenDB(Db.Name)) {
                 var cols = otherDB.GetCollections(scope: "scopeA");
-                cols.FirstOrDefault(x => x.Name == colA.Name).Should().NotBeNull();
+                cols.FirstOrDefault(x => x.Name == colA.Name).ShouldNotBeNull();
                 using (var col = otherDB.GetCollection("colA", "scopeA"))
-                    col.Should().NotBeNull();
+                    col.ShouldNotBeNull();
             }
         }
 
@@ -489,14 +489,14 @@ namespace Test
 
                 using (var otherDB = OpenDB(Db.Name)) {
                     var colAinOtherDb = otherDB.GetCollection("colA", "scopeA");
-                    colAinOtherDb.Should().NotBeNull("because it was created previously");
-                    colAinOtherDb!.Count.Should().Be(3);
+                    colAinOtherDb.ShouldNotBeNull("because it was created previously");
+                    colAinOtherDb!.Count.ShouldBe(3UL);
                     Db.DeleteCollection("colA", "scopeA");
-                    colAinOtherDb.Count.Should().Be(0);
+                    colAinOtherDb.Count.ShouldBe(0UL);
                     colAinOtherDb = otherDB.GetCollection("colA", "scopeA");
-                    colAinOtherDb.Should().BeNull();
+                    colAinOtherDb.ShouldBeNull();
                     var collsInOtherDb = otherDB.GetCollections("scopeA");
-                    collsInOtherDb.Contains(colA).Should().BeFalse();
+                    collsInOtherDb.Contains(colA).ShouldBeFalse();
                 }
             }
         }
@@ -518,21 +518,21 @@ namespace Test
 
                 using (var otherDB = OpenDB(Db.Name)) {
                     var colAinOtherDb = otherDB.GetCollection("colA", "scopeA");
-                    colAinOtherDb.Should().NotBeNull("because it was created previously");
-                    colAinOtherDb!.Count.Should().Be(3);
+                    colAinOtherDb.ShouldNotBeNull("because it was created previously");
+                    colAinOtherDb!.Count.ShouldBe(3UL);
                     Db.DeleteCollection("colA", "scopeA");
-                    colAinOtherDb.Count.Should().Be(0);
+                    colAinOtherDb.Count.ShouldBe(0UL);
                     colAinOtherDb = otherDB.GetCollection("colA", "scopeA");
-                    colAinOtherDb.Should().BeNull();
+                    colAinOtherDb.ShouldBeNull();
                     // Re-create Collection
                     var colATheSecond = Db.CreateCollection("colA", "scopeA");
                     var colATheSecondinOtherDb = otherDB.GetCollection("colA", "scopeA");
                     //Ensure that the collection is not null and is different from the instance gotten before from the instanceB when getting the collection from the database instance B by using database.getCollection(name: "colA", scope: "scopeA").
-                    colATheSecondinOtherDb.Should().NotBeNull();
-                    colATheSecondinOtherDb.Should().NotBe(colAinOtherDb, "because this is a recreated collection");
+                    colATheSecondinOtherDb.ShouldNotBeNull();
+                    colATheSecondinOtherDb.ShouldNotBe(colAinOtherDb, "because this is a recreated collection");
                     //Ensure that the collection is included when getting all collections from the database instance B by using database.getCollections(scope: "scopeA").
-                    otherDB.GetCollections("scopeA").Any(x => x.FullName == colATheSecond.FullName).Should()
-                        .BeTrue("because the other database instance should be able to see the recreated collection");
+                    otherDB.GetCollections("scopeA").Any(x => x.FullName == colATheSecond.FullName)
+                        .ShouldBeTrue("because the other database instance should be able to see the recreated collection");
                 }  
             }
         }
@@ -551,59 +551,57 @@ namespace Test
                     colA.Save(doc);
                 }
 
-                colA.GetDocument("doc")?.GetString("str").Should().Be("string");
+                colA.GetDocument("doc")?.GetString("str").ShouldBe("string");
 
                 Db.DeleteCollection("colA", "scopeA");
 
-                colA.Invoking(d => d.GetDocument("doc"))
-                    .Should().Throw<CouchbaseLiteException>("Because GetDocument after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.GetDocument("doc"),
+                    "Because GetDocument after collection colA is deleted.");
 
                 var dto30 = DateTimeOffset.UtcNow.AddSeconds(30);
                 using (var doc1 = new MutableDocument("doc1")) {
                     doc1.SetString("str", "string");
 
-                    colA.Invoking(d => d.Save(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Save after collection colA is deleted.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.Save(doc1),
+                        "Because Save after collection colA is deleted.");
 
-                    colA.Invoking(d => d.Delete(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Delete after collection colA is deleted.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.Delete(doc1),
+                        "Because Delete after collection colA is deleted.");
 
-                    colA.Invoking(d => d.Purge(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Purge after collection colA is deleted.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.Purge(doc1),
+                        "Because Purge after collection colA is deleted.");
 
-                    colA.Invoking(d => d.SetDocumentExpiration("doc1", dto30))
-                        .Should().Throw<CouchbaseLiteException>("Because SetDocumentExpiration after collection colA is deleted.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.SetDocumentExpiration("doc1", dto30),
+                        "Because SetDocumentExpiration after collection colA is deleted.");
 
-                    colA.Invoking(d => d.GetDocumentExpiration("doc1"))
-                        .Should().Throw<CouchbaseLiteException>("Because GetDocumentExpiration after collection colA is deleted.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.GetDocumentExpiration("doc1"),
+                        "Because GetDocumentExpiration after collection colA is deleted.");
                 }
 
-                colA.Invoking(d => d.CreateQuery($"SELECT firstName, lastName FROM *"))
-                        .Should().Throw<CouchbaseLiteException>("Because CreateQuery after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() =>
+                    colA.CreateQuery($"SELECT firstName, lastName FROM *"),
+                    "Because CreateQuery after collection colA is deleted.");
 
                 var item = ValueIndexItem.Expression(Expression.Property("firstName"));
                 var index = IndexBuilder.ValueIndex(item);
-                colA.Invoking(d => d.CreateIndex("myindex", index))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.CreateIndex("myindex", index),
+                    "Because CreateIndex after collection colA is deleted.");
 
                 var index1 = new ValueIndexConfiguration(new string[] { "firstName", "lastName" });
-                colA.Invoking(d => d.CreateIndex("index1", index1))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.CreateIndex("index1", index1),
+                    "Because CreateIndex after collection colA is deleted.");
 
-                colA.Invoking(d => d.GetIndexes())
-                    .Should().Throw<CouchbaseLiteException>("Because GetIndexes after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.GetIndexes(),
+                    "Because GetIndexes after collection colA is deleted.");
 
-                colA.Invoking(d => d.DeleteIndex("index1"))
-                    .Should().Throw<CouchbaseLiteException>("Because DeleteIndex after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.DeleteIndex("index1"),
+                    "Because DeleteIndex after collection colA is deleted.");
 
-                colA.Invoking(d => d.AddChangeListener(null, (sender, args) => { }))
-                    .Should().Throw<CouchbaseLiteException>("Because AddChangeListener after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.AddChangeListener(null, (sender, args) => { }),
+                    "Because AddChangeListener after collection colA is deleted.");
 
-                colA.Invoking(d => d.AddDocumentChangeListener("doc1", (sender, args) => { }))
-                    .Should().Throw<CouchbaseLiteException>("Because AddDocumentChangeListener after collection colA is deleted.");
-
-                colA.Invoking(d => d.RemoveChangeListener(d.AddDocumentChangeListener("doc1", (sender, args) => { })))
-                    .Should().Throw<CouchbaseLiteException>("Because RemoveChangeListener after collection colA is deleted.");
+                Should.Throw<CouchbaseLiteException>(() => colA.AddDocumentChangeListener("doc1", (sender, args) => { }),
+                    "Because AddDocumentChangeListener after collection colA is deleted.");
             }
         }
 
@@ -621,60 +619,57 @@ namespace Test
 
             using (var otherDB = OpenDB(Db.Name)) {
                 var colA1 = otherDB.GetCollection("colA", "scopeA");
-                colA1.Should().NotBeNull("because it was created previously");
-                colA1!.GetDocument("doc")?.GetString("str").Should().Be("string");
+                colA1.ShouldNotBeNull("because it was created previously");
+                colA1!.GetDocument("doc")?.GetString("str").ShouldBe("string");
 
                 otherDB.DeleteCollection("colA", "scopeA");
 
-                colA1.Invoking(d => d.GetDocument("doc"))
-                    .Should().Throw<CouchbaseLiteException>("Because GetDocument after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.GetDocument("doc"),
+                    "Because GetDocument after collection colA is deleted from the other db.");
 
                 var dto30 = DateTimeOffset.UtcNow.AddSeconds(30);
                 using (var doc1 = new MutableDocument("doc1")) {
                     doc1.SetString("str", "string");
 
-                    colA1.Invoking(d => d.Save(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Save after collection colA is deleted from the other db.");
+                    Should.Throw<CouchbaseLiteException>(() => colA1.Save(doc1),
+                        "Because Save after collection colA is deleted from the other db.");
 
-                    colA1.Invoking(d => d.Delete(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Delete after collection colA is deleted from the other db.");
+                    Should.Throw<CouchbaseLiteException>(() => colA1.Delete(doc1),
+                        "Because Delete after collection colA is deleted from the other db.");
 
-                    colA1.Invoking(d => d.Purge(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Purge after collection colA is deleted from the other db.");
+                    Should.Throw<CouchbaseLiteException>(() => colA1.Purge(doc1),
+                        "Because Purge after collection colA is deleted from the other db.");
 
-                    colA1.Invoking(d => d.SetDocumentExpiration("doc1", dto30))
-                        .Should().Throw<CouchbaseLiteException>("Because SetDocumentExpiration after collection colA is deleted from the other db.");
+                    Should.Throw<CouchbaseLiteException>(() => colA1.SetDocumentExpiration("doc1", dto30),
+                        "Because SetDocumentExpiration after collection colA is deleted from the other db.");
 
-                    colA1.Invoking(d => d.GetDocumentExpiration("doc1"))
-                        .Should().Throw<CouchbaseLiteException>("Because GetDocumentExpiration after collection colA is deleted from the other db.");
+                    Should.Throw<CouchbaseLiteException>(() => colA1.GetDocumentExpiration("doc1"),
+                        "Because GetDocumentExpiration after collection colA is deleted from the other db.");
                 }
 
-                colA1.Invoking(d => d.CreateQuery($"SELECT firstName, lastName FROM *"))
-                        .Should().Throw<CouchbaseLiteException>("Because CreateQuery after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.CreateQuery($"SELECT firstName, lastName FROM *"),
+                        "Because CreateQuery after collection colA is deleted from the other db.");
 
                 var item = ValueIndexItem.Expression(Expression.Property("firstName"));
                 var index = IndexBuilder.ValueIndex(item);
-                colA1.Invoking(d => d.CreateIndex("myindex", index))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.CreateIndex("myindex", index),
+                    "Because CreateIndex after collection colA is deleted from the other db.");
 
                 var index1 = new ValueIndexConfiguration(new string[] { "firstName", "lastName" });
-                colA1.Invoking(d => d.CreateIndex("index1", index1))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.CreateIndex("index1", index1),
+                    "Because CreateIndex after collection colA is deleted from the other db.");
 
-                colA1.Invoking(d => d.GetIndexes())
-                    .Should().Throw<CouchbaseLiteException>("Because GetIndexes after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.GetIndexes(),
+                    "Because GetIndexes after collection colA is deleted from the other db.");
 
-                colA1.Invoking(d => d.DeleteIndex("index1"))
-                    .Should().Throw<CouchbaseLiteException>("Because DeleteIndex after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.DeleteIndex("index1"),
+                    "Because DeleteIndex after collection colA is deleted from the other db.");
 
-                colA1.Invoking(d => d.AddChangeListener(null, (sender, args) => { }))
-                .Should().Throw<CouchbaseLiteException>("Because AddChangeListener after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.AddChangeListener(null, (sender, args) => { }),
+                    "Because AddChangeListener after collection colA is deleted from the other db.");
 
-                colA1.Invoking(d => d.AddDocumentChangeListener("doc1", (sender, args) => { }))
-                    .Should().Throw<CouchbaseLiteException>("Because AddDocumentChangeListener after collection colA is deleted from the other db.");
-
-                colA1.Invoking(d => d.RemoveChangeListener(d.AddDocumentChangeListener("doc1", (sender, args) => { })))
-                    .Should().Throw<CouchbaseLiteException>("Because RemoveChangeListener after collection colA is deleted from the other db.");
+                Should.Throw<CouchbaseLiteException>(() => colA1.AddDocumentChangeListener("doc1", (sender, args) => { }),
+                    "Because AddDocumentChangeListener after collection colA is deleted from the other db.");
             }
         }
 #endif
@@ -724,12 +719,12 @@ namespace Test
             //GetCollections() empty result
             using (var colA = Db.CreateCollection("colA", "scopeA")) {
                 var scopeA = Db.GetScope("scopeA");//colA.Scope;
-                scopeA.Should().NotBeNull("because it was just created");
+                scopeA.ShouldNotBeNull("because it was just created");
 
                 Db.DeleteCollection("colA", "scopeA");
 
-                scopeA!.GetCollection("colA").Should().BeNull("Because GetCollection after all collections are deleted.");
-                scopeA.GetCollections().Count.Should().Be(0, "Because GetCollections after all collections are deleted.");
+                scopeA!.GetCollection("colA").ShouldBeNull("Because GetCollection after all collections are deleted.");
+                scopeA.GetCollections().Count.ShouldBe(0, "Because GetCollections after all collections are deleted.");
             }
         }
 
@@ -748,9 +743,9 @@ namespace Test
                     otherDB.DeleteCollection("colA", "scopeA");
 
                     using (var col = scopeA!.GetCollection("colA"))
-                        col.Should().BeNull("Because GetCollection after collection colA is deleted from the other db.");
+                        col.ShouldBeNull("Because GetCollection after collection colA is deleted from the other db.");
 
-                    scopeA.GetCollections().Count.Should().Be(0, "Because GetCollections after collection colA is deleted from the other db.");
+                    scopeA.GetCollections().Count.ShouldBe(0, "Because GetCollections after collection colA is deleted from the other db.");
                 }
             }
         }
@@ -767,36 +762,36 @@ namespace Test
             // 3.1 TestGetFullNameFromDefaultCollection
             using (var col = Db.GetDefaultCollection())
             {
-                col.Should().NotBeNull("Default collection should not be null");
-                col.FullName.Should().Be("_default._default");
+                col.ShouldNotBeNull("Default collection should not be null");
+                col.FullName.ShouldBe("_default._default");
             }
 
             // 3.2 TestGetFullNameFromNewCollectionInDefaultScope
             using (var col = Db.CreateCollection("colA"))
             {
-                col.Should().NotBeNull("Created colA should not be null");
-                col.FullName.Should().Be("_default.colA");
+                col.ShouldNotBeNull("Created colA should not be null");
+                col.FullName.ShouldBe("_default.colA");
             }
 
             // 3.3 TestGetFullNameFromNewCollectionInCustomScope
             using (var col = Db.CreateCollection("colA", "scopeA"))
             {
-                col.Should().NotBeNull("Created colA should not be null");
-                col.FullName.Should().Be("scopeA.colA");
+                col.ShouldNotBeNull("Created colA should not be null");
+                col.FullName.ShouldBe("scopeA.colA");
             }
 
             // 3.4 TestGetFullNameExistingCollectionInDefaultScope
             using (var col = Db.GetCollection("colA"))
             {
-                col.Should().NotBeNull("Existing colA should not be null");
-                col!.FullName.Should().Be("_default.colA");
+                col.ShouldNotBeNull("Existing colA should not be null");
+                col!.FullName.ShouldBe("_default.colA");
             }
 
             // 3.5 TestGetFullNameFromExistingCollectionInCustomScope
             using (var col = Db.GetCollection("colA", "scopeA"))
             {
-                col.Should().NotBeNull("Existing colA should not be null");
-                col!.FullName.Should().Be("scopeA.colA");
+                col.ShouldNotBeNull("Existing colA should not be null");
+                col!.FullName.ShouldBe("scopeA.colA");
             }
         }
 
@@ -811,15 +806,15 @@ namespace Test
             // 3.1 TestGetDatabaseFromNewCollection
             using (var col = Db.CreateCollection("colA", "scopeA"))
             {
-                col.Should().NotBeNull("Created colA should not be null");
-                col!.Database.Should().Be(Db);
+                col.ShouldNotBeNull("Created colA should not be null");
+                col!.Database.ShouldBe(Db);
             }
 
             // 3.2 TestGetDatabaseFromExistingCollection
             using (var col = Db.GetCollection("colA", "scopeA"))
             {
-                col.Should().NotBeNull("Created colA should not be null");
-                col!.Database.Should().Be(Db);
+                col.ShouldNotBeNull("Created colA should not be null");
+                col!.Database.ShouldBe(Db);
             }
         }
 
@@ -829,17 +824,17 @@ namespace Test
             // 3.3 TestGetDatabaseFromScopeObtainedFromCollection
             using (var col = Db.CreateCollection("colA", "scopeA"))
             {
-                col.Should().NotBeNull("Created colA should not be null");
+                col.ShouldNotBeNull("Created colA should not be null");
                 var scope = col.Scope;
-                scope.Should().NotBeNull("scopeA should not be null");
-                scope.Database.Should().Be(Db);
+                scope.ShouldNotBeNull("scopeA should not be null");
+                scope.Database.ShouldBe(Db);
             }
 
             // 3.4 TestGetDatabaseFromScopeObtainedFromDatabase
             using (var scope = Db.GetScope("scopeA"))
             {
-                scope.Should().NotBeNull("scopeA should not be null");
-                scope!.Database.Should().Be(Db);
+                scope.ShouldNotBeNull("scopeA should not be null");
+                scope!.Database.ShouldBe(Db);
             }
         }
 
@@ -859,7 +854,7 @@ namespace Test
                 docs.Add(doc);
             }
 
-            CollA.Count.Should().Be((ulong)n, "because otherwise an incorrect number of documents were made");
+            CollA.Count.ShouldBe((ulong)n, "because otherwise an incorrect number of documents were made");
 
             // Reindex when there is no index
             Db.PerformMaintenance(MaintenanceType.Reindex);
@@ -869,25 +864,25 @@ namespace Test
             var keyItem = ValueIndexItem.Expression(key);
             var keyIndex = IndexBuilder.ValueIndex(keyItem);
             CollA.CreateIndex("KeyIndex", keyIndex);
-            CollA.GetIndexes().Count.Should().Be(1);
+            CollA.GetIndexes().Count.ShouldBe(1);
 
             var q = QueryBuilder.Select(SelectResult.Expression(key))
                 .From(DataSource.Collection(CollA))
                 .Where(key.GreaterThan(Expression.Int(9)));
-            q.Explain().Contains("USING INDEX KeyIndex").Should().BeTrue();
+            q.Explain().Contains("USING INDEX KeyIndex").ShouldBeTrue();
 
             //Reindex
             Db.PerformMaintenance(MaintenanceType.Reindex);
 
             //Check if the index is still there and used
-            CollA.GetIndexes().Count.Should().Be(1);
-            q.Explain().Contains("USING INDEX KeyIndex").Should().BeTrue();
+            CollA.GetIndexes().Count.ShouldBe(1);
+            q.Explain().Contains("USING INDEX KeyIndex").ShouldBeTrue();
         }
 
         [Fact]
         public void TestCreateIndex()
         {
-            CollA.GetIndexes().Should().BeEmpty();
+            CollA.GetIndexes().ShouldBeEmpty();
 
             var lName = Expression.Property("lastName");
             var fNameItem = ValueIndexItem.Property("firstName");
@@ -904,7 +899,7 @@ namespace Test
             var index3 = IndexBuilder.FullTextIndex(detailItem2).IgnoreAccents(true).SetLanguage("es");
             CollA.CreateIndex("index3", index3);
 
-            CollA.GetIndexes().Should().BeEquivalentTo(new[] { "index1", "index2", "index3" });
+            CollA.GetIndexes().ShouldBeEquivalentToFluent(new[] { "index1", "index2", "index3" });
         }
 
         [Fact]
@@ -915,7 +910,7 @@ namespace Test
             CollA.CreateIndex("myindex", index);
             CollA.CreateIndex("myindex", index);
 
-            CollA.GetIndexes().Should().BeEquivalentTo(new[] { "myindex" });
+            CollA.GetIndexes().ShouldBeEquivalentToFluent(new[] { "myindex" });
         }
 
         [Fact]
@@ -932,13 +927,13 @@ namespace Test
             var lNameIndex = IndexBuilder.ValueIndex(lNameItem);
             CollA.CreateIndex("myindex", lNameIndex);
 
-            CollA.GetIndexes().Should().BeEquivalentTo(new[] { "myindex" }, "because lNameIndex should overwrite fNameIndex");
+            CollA.GetIndexes().ShouldBeEquivalentToFluent(new[] { "myindex" }, "because lNameIndex should overwrite fNameIndex");
 
             var detailItem = FullTextIndexItem.Property("detail");
             var detailIndex = IndexBuilder.FullTextIndex(detailItem);
             CollA.CreateIndex("myindex", detailIndex);
 
-            CollA.GetIndexes().Should().BeEquivalentTo(new[] { "myindex" }, "because detailIndex should overwrite lNameIndex");
+            CollA.GetIndexes().ShouldBeEquivalentToFluent(new[] { "myindex" }, "because detailIndex should overwrite lNameIndex");
         }
 
         #endregion
@@ -959,11 +954,11 @@ namespace Test
 
             scope = Db.GetDefaultScope();
             collection = scope.GetCollection("foo");
-            collection?.IsValid.Should().BeTrue("because it still exists in LiteCore");
+            collection?.IsValid.ShouldBeTrue("because it still exists in LiteCore");
             defaultCollection = Db.GetDefaultCollection();
-            defaultCollection.Should().NotBeNull("because a new object should be created");
-            defaultCollection.IsValid.Should().BeTrue("because the new created object should be valid");
-            defaultCollection.Count.Should().Be(0);
+            defaultCollection.ShouldNotBeNull("because a new object should be created");
+            defaultCollection.IsValid.ShouldBeTrue("because the new created object should be valid");
+            defaultCollection.Count.ShouldBe(0UL);
         }
 
         #region Document Subscript
@@ -973,17 +968,17 @@ namespace Test
         {
             var defaultCollection = Db.GetDefaultCollection();
             var doc1 = defaultCollection["doc1"];
-            doc1.Exists.Should().BeFalse("because the document id'doc1' doesn't exist in the collection");
+            doc1.Exists.ShouldBeFalse("because the document id'doc1' doesn't exist in the collection");
 
             using (var doc = new MutableDocument("doc1")) {
                 doc.SetString("str", "string");
                 defaultCollection.Save(doc);    
             }
             doc1 = defaultCollection["doc1"];
-            doc1.Exists.Should().BeTrue("because the document id 'doc1' exists in the collection");
-            doc1["foo"].Exists.Should().BeFalse("because this portion of the data doesn't exist");
-            doc1["str"].Exists.Should().BeTrue("because this portion of the data exists");
-            doc1["str"].String.Should().Be("string", "because that is the stored value");
+            doc1.Exists.ShouldBeTrue("because the document id 'doc1' exists in the collection");
+            doc1["foo"].Exists.ShouldBeFalse("because this portion of the data doesn't exist");
+            doc1["str"].Exists.ShouldBeTrue("because this portion of the data exists");
+            doc1["str"].String.ShouldBe("string", "because that is the stored value");
         }
         
         #endregion
@@ -996,29 +991,29 @@ namespace Test
 
             dbDispose();
 
-            Db.Invoking(d => d.GetDefaultCollection())
-                    .Should().Throw<InvalidOperationException>("Because GetDefaultCollection after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.GetDefaultCollection(),
+                "Because GetCollection after db is disposed.");
 
-            Db.Invoking(d => d.GetDefaultScope())
-                    .Should().Throw<InvalidOperationException>("Because GetDefaultScope after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.GetDefaultScope(),
+                "Because GetDefaultScope after db is disposed.");
 
-            Db.Invoking(d => d.GetCollection("colA", "scopeA"))
-                    .Should().Throw<InvalidOperationException>("Because GetCollection after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.GetCollection("colA", "scopeA"),
+                "Because GetCollection after db is disposed.");
 
-            Db.Invoking(d => d.GetCollections("scopeA"))
-                    .Should().Throw<InvalidOperationException>("Because GetCollections after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.GetCollections("scopeA"),
+                "Because GetCollections after db is disposed.");
 
-            Db.Invoking(d => d.GetScope("scopeA"))
-                    .Should().Throw<InvalidOperationException>("Because GetScope after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.GetScope("scopeA"),
+                "Because GetScope after db is disposed.");;
 
-            Db.Invoking(d => d.GetScopes())
-                    .Should().Throw<InvalidOperationException>("Because GetScopes after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.GetScopes(),
+                "Because GetScopes after db is disposed.");
 
-            Db.Invoking(d => d.CreateCollection("colA", "scopeA"))
-                    .Should().Throw<InvalidOperationException>("Because CreateCollection after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.CreateCollection("colA", "scopeA"),
+                "Because CreateCollection after db is disposed.");
 
-            Db.Invoking(d => d.DeleteCollection("colA", "scopeA"))
-                    .Should().Throw<InvalidOperationException>("Because DeleteCollection after db is disposed.");
+            Should.Throw<InvalidOperationException>(() => Db.DeleteCollection("colA", "scopeA"),
+                "Because DeleteCollection after db is disposed.");
         }
 
         private void TestUseCollectionAPIs(Action dbDispose)
@@ -1031,55 +1026,52 @@ namespace Test
 
                 Db.Delete();
 
-                colA.Invoking(d => d.GetDocument("doc"))
-                    .Should().Throw<CouchbaseLiteException>("Because GetDocument after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.GetDocument("doc"),
+                    "Because GetDocument after db is disposed.");
 
                 var dto30 = DateTimeOffset.UtcNow.AddSeconds(30);
                 using (var doc1 = new MutableDocument("doc1")) {
                     doc1.SetString("str", "string");
 
-                    colA.Invoking(d => d.Save(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Save after db is disposed.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.Save(doc1),
+                        "Because Save after db is disposed.");
 
-                    colA.Invoking(d => d.Delete(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Delete after db is disposed.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.Delete(doc1),
+                        "Because Delete after db is disposed.");
 
-                    colA.Invoking(d => d.Purge(doc1))
-                        .Should().Throw<CouchbaseLiteException>("Because Purge after db is disposed.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.Purge(doc1),
+                        "Because Purge after db is disposed.");
 
-                    colA.Invoking(d => d.SetDocumentExpiration("doc1", dto30))
-                        .Should().Throw<CouchbaseLiteException>("Because SetDocumentExpiration after db is disposed.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.SetDocumentExpiration("doc1", dto30),
+                        "Because SetDocumentExpiration after db is disposed.");
 
-                    colA.Invoking(d => d.GetDocumentExpiration("doc1"))
-                        .Should().Throw<CouchbaseLiteException>("Because GetDocumentExpiration after db is disposed.");
+                    Should.Throw<CouchbaseLiteException>(() => colA.GetDocumentExpiration("doc1"),
+                        "Because GetDocumentExpiration after db is disposed.");
                 }
 
-                colA.Invoking(d => d.CreateQuery($"SELECT firstName, lastName FROM *"))
-                        .Should().Throw<CouchbaseLiteException>("Because CreateQuery after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.CreateQuery($"SELECT firstName, lastName FROM *"),
+                        "Because CreateQuery after db is disposed.");
 
                 var item = ValueIndexItem.Expression(Expression.Property("firstName"));
                 var index = IndexBuilder.ValueIndex(item);
-                colA.Invoking(d => d.CreateIndex("myindex", index))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.CreateIndex("myindex", index),
+                    "Because CreateIndex after db is disposed.");
 
                 var index1 = new ValueIndexConfiguration(new string[] { "firstName", "lastName" });
-                colA.Invoking(d => d.CreateIndex("index1", index1))
-                    .Should().Throw<CouchbaseLiteException>("Because CreateIndex after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.CreateIndex("index1", index1),
+                    "Because CreateIndex after db is disposed.");
 
-                colA.Invoking(d => d.GetIndexes())
-                    .Should().Throw<CouchbaseLiteException>("Because GetIndexes after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.GetIndexes(),
+                    "Because GetIndexes after db is disposed.");
 
-                colA.Invoking(d => d.DeleteIndex("index1"))
-                    .Should().Throw<CouchbaseLiteException>("Because DeleteIndex after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.DeleteIndex("index1"),
+                    "Because DeleteIndex after db is disposed.");
 
-                colA.Invoking(d => d.AddChangeListener(null, (sender, args) => { }))
-                    .Should().Throw<CouchbaseLiteException>("Because AddChangeListener after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.AddChangeListener(null, (sender, args) => { }),
+                    "Because AddChangeListener after db is disposed.");
 
-                colA.Invoking(d => d.AddDocumentChangeListener("doc1", (sender, args) => { }))
-                    .Should().Throw<CouchbaseLiteException>("Because AddDocumentChangeListener after db is disposed.");
-
-                colA.Invoking(d => d.RemoveChangeListener(d.AddDocumentChangeListener("doc1", (sender, args) => { })))
-                    .Should().Throw<CouchbaseLiteException>("Because RemoveChangeListener after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => colA.AddDocumentChangeListener("doc1", (sender, args) => { }),
+                    "Because AddDocumentChangeListener after db is disposed.");
             }
         }
 
@@ -1091,11 +1083,11 @@ namespace Test
 
                 dbDispose();
 
-                scope.Invoking(d => d.GetCollection("colA"))
-                    .Should().Throw<CouchbaseLiteException>("Because GetCollection after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => scope.GetCollection("colA"),
+                    "Because GetCollection after db is disposed.");
 
-                scope.Invoking(d => d.GetCollections())
-                    .Should().Throw<CouchbaseLiteException>("Because GetCollections after db is disposed.");
+                Should.Throw<CouchbaseLiteException>(() => scope.GetCollections(),
+                    "Because GetCollections after db is disposed.");
             }
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.QueryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.QueryTest.cs
@@ -24,7 +24,7 @@ using System.Text.RegularExpressions;
 using Couchbase.Lite;
 using Couchbase.Lite.Query;
 
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -119,12 +119,12 @@ namespace Test
                     var count = row.GetInt(1);
                     var maxZip = row.GetString(2);
                     if (n - 1 < expectedStates.Length) {
-                        state.Should().Be(expectedStates[n - 1]);
-                        count.Should().Be(expectedCounts[n - 1]);
-                        maxZip.Should().Be(expectedZips[n - 1]);
+                        state.ShouldBe(expectedStates[n - 1]);
+                        count.ShouldBe(expectedCounts[n - 1]);
+                        maxZip.ShouldBe(expectedZips[n - 1]);
                     }
                 });
-                numRows.Should().Be(31);
+                numRows.ShouldBe(31);
             }
 
             expectedStates = new[] { "CA", "IA", "IN" };
@@ -143,12 +143,12 @@ namespace Test
                     var count = row.GetInt(1);
                     var maxZip = row.GetString(2);
                     if (n - 1 < expectedStates.Length) {
-                        state.Should().Be(expectedStates[n - 1]);
-                        count.Should().Be(expectedCounts[n - 1]);
-                        maxZip.Should().Be(expectedZips[n - 1]);
+                        state.ShouldBe(expectedStates[n - 1]);
+                        count.ShouldBe(expectedCounts[n - 1]);
+                        maxZip.ShouldBe(expectedZips[n - 1]);
                     }
                 });
-                numRows.Should().Be(15);
+                numRows.ShouldBe(15);
             }
         }
 
@@ -161,16 +161,16 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
                     var expectedID = $"doc-{n:D3}";
-                    row.GetString(0).Should().Be(expectedID, "because otherwise the IDs were out of order");
-                    row.GetLong(1).Should().Be(n, "because otherwise the sequences were out of order");
+                    row.GetString(0).ShouldBe(expectedID, "because otherwise the IDs were out of order");
+                    row.GetLong(1).ShouldBe(n, "because otherwise the sequences were out of order");
 
                     var doc = CollA.GetDocument(row.GetString(0)!);
-                    doc?.Id.Should().Be(expectedID, "because the document ID on the row should match the document");
-                    doc?.Sequence.Should()
-                        .Be((ulong)n, "because the sequence on the row should match the document");
+                    doc?.Id.ShouldBe(expectedID, "because the document ID on the row should match the document");
+                    doc?.Sequence
+                        .ShouldBe((ulong)n, "because the sequence on the row should match the document");
                 });
 
-                numRows.Should().Be(100, "because otherwise the incorrect number of rows was returned");
+                numRows.ShouldBe(100, "because otherwise the incorrect number of rows was returned");
             }
         }
 
@@ -199,15 +199,15 @@ namespace Test
                         }
                     });
 
-                    numRows.Should().Be(100, "because otherwise the wrong number of rows was retrieved");
-                    firstNames.Should().HaveCount(numRows, "because otherwise some rows were null");
+                    numRows.ShouldBe(100, "because otherwise the wrong number of rows was retrieved");
+                    firstNames.Count.ShouldBe(numRows, "because otherwise some rows were null");
                     var firstNamesCopy = new List<object>(firstNames);
                     firstNames.Sort();
                     if (!ascending) {
                         firstNames.Reverse();
                     }
 
-                    firstNames.Should().ContainInOrder(firstNamesCopy, "because otherwise the results were not sorted");
+                    firstNames.ShouldBeEquivalentToFluent(firstNamesCopy, "because otherwise the results were not sorted");
                 }
             }
         }
@@ -225,7 +225,7 @@ namespace Test
                 var expected = new[] { "doc-017", "doc-021", "doc-023", "doc-045", "doc-060" };
                 var results = q.Execute();
                 var received = results.Select(x => x.GetString("id"));
-                received.Should().BeEquivalentTo(expected);
+                received.ShouldBeEquivalentToFluent(expected);
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
@@ -234,8 +234,8 @@ namespace Test
                     .Satisfies(ArrayExpression.Variable("like").EqualTo(Expression.String("taxes"))))) {
                 var results = q.Execute();
                 var received = results.Select(x => x.GetString("id")).ToList();
-                received.Count.Should().Be(42, "because empty array results are included");
-                received[0].Should().Be("doc-007");
+                received.Count.ShouldBe(42, "because empty array results are included");
+                received[0].ShouldBe("doc-007");
             }
 
             using (var q = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
@@ -244,7 +244,7 @@ namespace Test
                     .Satisfies(ArrayExpression.Variable("like").EqualTo(Expression.String("taxes"))))) {
                 var results = q.Execute();
                 var received = results.Select(x => x.GetString("id")).ToList();
-                received.Count.Should().Be(0, "because nobody likes taxes...");
+                received.Count.ShouldBe(0, "because nobody likes taxes...");
             }
         }
 
@@ -268,13 +268,13 @@ namespace Test
                 .From(DataSource.Collection(CollA))) {
                 var numRows = VerifyQuery(q, (n, r) =>
                 {
-                    r.GetValue("firstname").Should().Be(r.GetValue(0));
-                    r.GetValue("lastname").Should().Be(r.GetValue(1));
-                    r.GetValue("gender").Should().Be(r.GetValue(2));
-                    r.GetValue("city").Should().Be(r.GetValue(3));
+                    r.GetValue("firstname").ShouldBe(r.GetValue(0));
+                    r.GetValue("lastname").ShouldBe(r.GetValue(1));
+                    r.GetValue("gender").ShouldBe(r.GetValue(2));
+                    r.GetValue("city").ShouldBe(r.GetValue(3));
                 });
 
-                numRows.Should().Be(100);
+                numRows.ShouldBe(100);
             }
         }
 
@@ -295,10 +295,10 @@ namespace Test
                 var numRows = VerifyQuery(q, (n, row) =>
                 {
                     var name = row.GetString(0);
-                    name.Should().Be(expected[n - 1], "because otherwise incorrect rows were returned");
+                    name.ShouldBe(expected[n - 1], "because otherwise incorrect rows were returned");
                 });
 
-                numRows.Should().Be(expected.Length, "because otherwise an incorrect number of rows were returned");
+                numRows.ShouldBe(expected.Length, "because otherwise an incorrect number of rows were returned");
             }
         }
 
@@ -322,9 +322,8 @@ namespace Test
                     }
                 });
 
-                numRows.Should().Be(5, "because there are 5 rows like that in the data source");
-                firstNames.Should()
-                    .OnlyContain(str => str.Contains("Mar"), "because otherwise an incorrect entry came in");
+                numRows.ShouldBe(5, "because there are 5 rows like that in the data source");
+                firstNames.All(x => x.Contains("Mar")).ShouldBeTrue("because otherwise an incorrect entry came in");
             }
         }
 
@@ -348,10 +347,9 @@ namespace Test
                     }
                 });
 
-                numRows.Should().Be(5, "because there are 5 rows like that in the data source");
+                numRows.ShouldBe(5, "because there are 5 rows like that in the data source");
                 var regex = new Regex("^Mar.*");
-                firstNames.Should()
-                    .OnlyContain(str => regex.IsMatch(str), "because otherwise an incorrect entry came in");
+                firstNames.All(x => regex.IsMatch(x)).ShouldBeTrue("because otherwise an incorrect entry came in");
             }
         }
 
@@ -372,8 +370,8 @@ namespace Test
             foreach (var qExp in listQueries) {
                 using (var q = DefaultCollection.CreateQuery(qExp)) {
                     var res = q.Execute().ToList();
-                    res.Count().Should().Be(1);
-                    res[0].GetString("first").Should().Be("Abe");
+                    res.Count().ShouldBe(1);
+                    res[0].GetString("first").ShouldBe("Abe");
                 }
             }
         }
@@ -393,8 +391,8 @@ namespace Test
                 foreach (var qExp in listQueries) {
                     using (var q = collWithDefaultScope.CreateQuery(qExp)) {
                         var res = q.Execute().ToList();
-                        res.Count().Should().Be(1);
-                        res[0].GetString("first").Should().Be("Abe");
+                        res.Count().ShouldBe(1);
+                        res[0].GetString("first").ShouldBe("Abe");
                     }
                 }
             }
@@ -408,8 +406,8 @@ namespace Test
                 LoadJSONResource("names_100", coll: coll);
                 using (var q = coll.CreateQuery("SELECT name.first FROM people.names ORDER BY name.first limit 1")) {
                     var res = q.Execute().ToList();
-                    res.Count().Should().Be(1);
-                    res[0].GetString("first").Should().Be("Abe");
+                    res.Count().ShouldBe(1);
+                    res[0].GetString("first").ShouldBe("Abe");
                 }
             }
         }
@@ -421,8 +419,8 @@ namespace Test
             using (var coll = Db.CreateCollection("names", "people")) {
                 LoadJSONResource("names_100", coll: coll);
                 Action badAction = (() => coll.CreateQuery("SELECT name.first FROM person.names ORDER BY name.first limit 1"));
-                badAction.Should().Throw<CouchbaseLiteException>()
-                    .WithMessage("CouchbaseLiteException (LiteCoreDomain / 23): no such collection \"person.names\".");
+                Should.Throw<CouchbaseLiteException>(badAction)
+                    .Message.ShouldBe("CouchbaseLiteException (LiteCoreDomain / 23): no such collection \"person.names\".");
             }
         }
         
@@ -467,11 +465,11 @@ namespace Test
 
                 using (var q = Db.CreateQuery("SELECT a.name, b.color FROM test.flowers a JOIN test.colors b ON a.cid = b.cid ORDER BY a.name")) {
                     var res = q.Execute().ToList();
-                    res.Count().Should().Be(2);
-                    res[0].GetString("name").Should().Be("hydrangea");
-                    res[0].GetString("color").Should().Be("blue");
-                    res[1].GetString("name").Should().Be("rose");
-                    res[1].GetString("color").Should().Be("red");
+                    res.Count().ShouldBe(2);
+                    res[0].GetString("name").ShouldBe("hydrangea");
+                    res[0].GetString("color").ShouldBe("blue");
+                    res[1].GetString("name").ShouldBe("rose");
+                    res[1].GetString("color").ShouldBe("red");
                 }
             }
         }
@@ -490,8 +488,8 @@ namespace Test
                 .OrderBy(Ordering.Property("name.first"))
                 .Limit(Expression.Int(1))) {
                 var res = q.Execute().ToList();
-                res.Count().Should().Be(1);
-                res[0].GetString("first").Should().Be("Abe");
+                res.Count().ShouldBe(1);
+                res[0].GetString("first").ShouldBe("Abe");
             }
         }
 
@@ -507,8 +505,8 @@ namespace Test
                     .OrderBy(Ordering.Property("name.first"))
                     .Limit(Expression.Int(1))) {
                     var res = q.Execute().ToList();
-                    res.Count().Should().Be(1);
-                    res[0].GetString("first").Should().Be("Abe");
+                    res.Count().ShouldBe(1);
+                    res[0].GetString("first").ShouldBe("Abe");
                 }
             }
         }

--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
@@ -32,7 +32,7 @@ using Couchbase.Lite.Sync;
 using Couchbase.Lite.Util;
 using Couchbase.Lite.Query;
 
-using FluentAssertions;
+using Shouldly;
 using LiteCore;
 using LiteCore.Interop;
 
@@ -70,17 +70,17 @@ namespace Test
         public void TestCreateConfigWithDatabase()
         {
             var config = new ReplicatorConfiguration(Db, new DatabaseEndpoint(OtherDb));
-            config.Collections.Should().Contain(Db.GetDefaultCollection(), "Because Default collection configuration with default collection is created with ReplicatorConfiguration init.");
+            config.Collections.ShouldContain(Db.GetDefaultCollection(), "Because Default collection configuration with default collection is created with ReplicatorConfiguration init.");
             var collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            collConfig.Should().NotBeNull("because it was just set");
-            collConfig!.GetType().Should().Be(typeof(CollectionConfiguration));
-            collConfig.Equals(config.DefaultCollectionConfig).Should().BeTrue();
-            collConfig.ConflictResolver.Should().Be(ConflictResolver.Default);
-            collConfig.PushFilter.Should().BeNull();
-            collConfig.PullFilter.Should().BeNull();
-            collConfig.Channels.Should().BeNull();
-            collConfig.DocumentIDs.Should().BeNull();
-            config.Database.Should().Be(Db);
+            collConfig.ShouldNotBeNull("because it was just set");
+            collConfig!.GetType().ShouldBe(typeof(CollectionConfiguration));
+            collConfig.Equals(config.DefaultCollectionConfig).ShouldBeTrue();
+            collConfig.ConflictResolver.ShouldBe(ConflictResolver.Default);
+            collConfig.PushFilter.ShouldBeNull();
+            collConfig.PullFilter.ShouldBeNull();
+            collConfig.Channels.ShouldBeNull();
+            collConfig.DocumentIDs.ShouldBeNull();
+            config.Database.ShouldBe(Db);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Test
             });
 
             var collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            collConfig?.ConflictResolver.Should().Be(config.ConflictResolver);
+            collConfig?.ConflictResolver.ShouldBe(config.ConflictResolver);
         }
 
         [Fact]
@@ -103,16 +103,16 @@ namespace Test
         {
             var config = new ReplicatorConfiguration(Db, new DatabaseEndpoint(OtherDb)) { ConflictResolver = new FakeConflictResolver() };
             var collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            collConfig.Should().NotBeNull("because it was just set");
-            collConfig!.ConflictResolver.Should().Be(config.ConflictResolver);
+            collConfig.ShouldNotBeNull("because it was just set");
+            collConfig!.ConflictResolver.ShouldBe(config.ConflictResolver);
             config.ConflictResolver = new TestConflictResolver((conflict) => { return conflict.LocalDocument; });
             collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            collConfig.Should().NotBeNull("because it was just set");
-            collConfig!.ConflictResolver.Should().Be(config.ConflictResolver);
+            collConfig.ShouldNotBeNull("because it was just set");
+            collConfig!.ConflictResolver.ShouldBe(config.ConflictResolver);
             collConfig.ConflictResolver = new FakeConflictResolver();
             config.AddCollection(Db.GetDefaultCollection(), collConfig);
             collConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            collConfig?.ConflictResolver.Should().Be(config.ConflictResolver);
+            collConfig?.ConflictResolver.ShouldBe(config.ConflictResolver);
         }
 
         [Fact]
@@ -129,12 +129,12 @@ namespace Test
             };
 
             var defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            defaultCollConfig.Should().NotBeNull("because the default collection should be present by default");
-            defaultCollConfig!.Channels.Should().BeSameAs(config.Channels);
-            defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
-            defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
-            defaultCollConfig.PullFilter.Should().BeSameAs(config.PullFilter);
-            defaultCollConfig.PushFilter.Should().BeSameAs(config.PushFilter);
+            defaultCollConfig.ShouldNotBeNull("because the default collection should be present by default");
+            defaultCollConfig!.Channels.ShouldBeSameAs(config.Channels);
+            defaultCollConfig.DocumentIDs.ShouldBeSameAs(config.DocumentIDs);
+            defaultCollConfig.ConflictResolver.ShouldBeSameAs(config.ConflictResolver);
+            defaultCollConfig.PullFilter.ShouldBeSameAs(config.PullFilter);
+            defaultCollConfig.PushFilter.ShouldBeSameAs(config.PushFilter);
         }
 
         [Fact]
@@ -151,12 +151,12 @@ namespace Test
             };
 
             var defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            defaultCollConfig.Should().NotBeNull("because the default collection should be present by default");
-            defaultCollConfig!.Channels.Should().BeSameAs(config.Channels);
-            defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
-            defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
-            defaultCollConfig.PullFilter.Should().BeSameAs(config.PullFilter);
-            defaultCollConfig.PushFilter.Should().BeSameAs(config.PushFilter);
+            defaultCollConfig.ShouldNotBeNull("because the default collection should be present by default");
+            defaultCollConfig!.Channels.ShouldBeSameAs(config.Channels);
+            defaultCollConfig.DocumentIDs.ShouldBeSameAs(config.DocumentIDs);
+            defaultCollConfig.ConflictResolver.ShouldBeSameAs(config.ConflictResolver);
+            defaultCollConfig.PullFilter.ShouldBeSameAs(config.PullFilter);
+            defaultCollConfig.PushFilter.ShouldBeSameAs(config.PushFilter);
 
             config.Channels = new List<string> { "channelA1", "channelB1" };
             config.DocumentIDs = new List<string> { "doc1a", "doc2a" };
@@ -165,12 +165,12 @@ namespace Test
             config.PushFilter = _replicator__filterCallbackFalse;
 
             defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            defaultCollConfig.Should().NotBeNull("because the default collection should be present by default");
-            defaultCollConfig!.Channels.Should().BeSameAs(config.Channels);
-            defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
-            defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
-            defaultCollConfig.PullFilter.Should().BeSameAs(config.PullFilter);
-            defaultCollConfig.PushFilter.Should().BeSameAs(config.PushFilter);
+            defaultCollConfig.ShouldNotBeNull("because the default collection should be present by default");
+            defaultCollConfig!.Channels.ShouldBeSameAs(config.Channels);
+            defaultCollConfig.DocumentIDs.ShouldBeSameAs(config.DocumentIDs);
+            defaultCollConfig.ConflictResolver.ShouldBeSameAs(config.ConflictResolver);
+            defaultCollConfig.PullFilter.ShouldBeSameAs(config.PullFilter);
+            defaultCollConfig.PushFilter.ShouldBeSameAs(config.PushFilter);
 
             defaultCollConfig.Channels = new List<string> { "channelA", "channelB" };
             defaultCollConfig.DocumentIDs = new List<string> { "doc1", "doc2" };
@@ -181,12 +181,12 @@ namespace Test
             config.AddCollection(Db.GetDefaultCollection(), defaultCollConfig);
 
             defaultCollConfig = config.GetCollectionConfig(Db.GetDefaultCollection());
-            defaultCollConfig.Should().NotBeNull("because the default collection should be present by default");
-            defaultCollConfig!.Channels.Should().BeSameAs(config.Channels);
-            defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
-            defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
-            defaultCollConfig.PullFilter.Should().BeSameAs(config.PullFilter);
-            defaultCollConfig.PushFilter.Should().BeSameAs(config.PushFilter);
+            defaultCollConfig.ShouldNotBeNull("because the default collection should be present by default");
+            defaultCollConfig!.Channels.ShouldBeSameAs(config.Channels);
+            defaultCollConfig.DocumentIDs.ShouldBeSameAs(config.DocumentIDs);
+            defaultCollConfig.ConflictResolver.ShouldBeSameAs(config.ConflictResolver);
+            defaultCollConfig.PullFilter.ShouldBeSameAs(config.PullFilter);
+            defaultCollConfig.PushFilter.ShouldBeSameAs(config.PushFilter);
         }
 
         [Fact]
@@ -194,8 +194,8 @@ namespace Test
         public void TestCreateConfigWithEndpointOnly()
         {
             var config = new ReplicatorConfiguration(new DatabaseEndpoint(OtherDb));
-            config.Collections.Should().BeEmpty("Because no collection was added via AddCollection or AddCollections");
-            config.Invoking(c => c.Database).Should().Throw<CouchbaseLiteException>("Because there is no Database atm since neither AddCollection nor AddCollections were called.");
+            config.Collections.ShouldBeEmpty("Because no collection was added via AddCollection or AddCollections");
+            Should.Throw<CouchbaseLiteException>(() => config.Database, "Because there is no Database atm since neither AddCollection nor AddCollections were called.");
         }
 
         [Fact]
@@ -206,19 +206,19 @@ namespace Test
             var config = new ReplicatorConfiguration(new DatabaseEndpoint(OtherDb));
             config.AddCollection(colA);
             config.AddCollection(colB);
-            config.Collections.Contains(colA).Should().BeTrue("Because collection colA just added via AddCollection method");
-            config.Collections.Contains(colB).Should().BeTrue("Because collection colB just added via AddCollection method");
+            config.Collections.Contains(colA).ShouldBeTrue("Because collection colA just added via AddCollection method");
+            config.Collections.Contains(colB).ShouldBeTrue("Because collection colB just added via AddCollection method");
             var colAConfig = config.GetCollectionConfig(colA);
             var colBConfig = config.GetCollectionConfig(colB);
-            colAConfig.Should().NotBeNull("because it was just set");
-            colBConfig.Should().NotBeNull("because it was just set");
-            colAConfig.Should().NotBeSameAs(colBConfig, "Because the returned configs should be different instances.");
-            colAConfig!.ConflictResolver.Should().Be(ConflictResolver.Default, $"Property was never assigned and default value was {ConflictResolver.Default}.");
-            colAConfig.PushFilter.Should().BeNull("Property was never assigned and default value was null.");
-            colAConfig.PullFilter.Should().BeNull("Property was never assigned and default value was null.");
-            colBConfig!.ConflictResolver.Should().Be(ConflictResolver.Default, $"Property was never assigned and default value was {ConflictResolver.Default}.");
-            colBConfig.PushFilter.Should().BeNull("Property was never assigned and default value was null.");
-            colBConfig.PullFilter.Should().BeNull("Property was never assigned and default value was null.");
+            colAConfig.ShouldNotBeNull("because it was just set");
+            colBConfig.ShouldNotBeNull("because it was just set");
+            colAConfig.ShouldNotBeSameAs(colBConfig, "Because the returned configs should be different instances.");
+            colAConfig!.ConflictResolver.ShouldBe(ConflictResolver.Default, $"Property was never assigned and default value was {ConflictResolver.Default}.");
+            colAConfig.PushFilter.ShouldBeNull("Property was never assigned and default value was null.");
+            colAConfig.PullFilter.ShouldBeNull("Property was never assigned and default value was null.");
+            colBConfig!.ConflictResolver.ShouldBe(ConflictResolver.Default, $"Property was never assigned and default value was {ConflictResolver.Default}.");
+            colBConfig.PushFilter.ShouldBeNull("Property was never assigned and default value was null.");
+            colBConfig.PullFilter.ShouldBeNull("Property was never assigned and default value was null.");
         }
 
         [Fact]
@@ -235,16 +235,16 @@ namespace Test
             };
             config.AddCollection(colA, colConfig);
             config.AddCollection(colB, colConfig);
-            config.Collections.Contains(colA).Should().BeTrue("Because collection colA just added via AddCollection method");
-            config.Collections.Contains(colB).Should().BeTrue("Because collection colB just added via AddCollection method");
+            config.Collections.Contains(colA).ShouldBeTrue("Because collection colA just added via AddCollection method");
+            config.Collections.Contains(colB).ShouldBeTrue("Because collection colB just added via AddCollection method");
             var colAConfig = config.GetCollectionConfig(colA);
             var colBConfig = config.GetCollectionConfig(colB);
-            colAConfig.Should().NotBeNull("because it was just set");
-            colBConfig.Should().NotBeNull("because it was just set");
-            colAConfig.Should().NotBe(colBConfig, "Because the returned configs should be different instances.");
-            colAConfig!.ConflictResolver.Should().Be(colBConfig!.ConflictResolver, "Both properties were assigned with same value.");
-            colAConfig.PushFilter.Should().Be(colBConfig.PushFilter, "Both properties were assigned with same value.");
-            colAConfig.PullFilter.Should().Be(colBConfig.PullFilter, "Both properties were assigned with same value.");
+            colAConfig.ShouldNotBeNull("because it was just set");
+            colBConfig.ShouldNotBeNull("because it was just set");
+            colAConfig.ShouldNotBe(colBConfig, "Because the returned configs should be different instances.");
+            colAConfig!.ConflictResolver.ShouldBe(colBConfig!.ConflictResolver, "Both properties were assigned with same value.");
+            colAConfig.PushFilter.ShouldBe(colBConfig.PushFilter, "Both properties were assigned with same value.");
+            colAConfig.PullFilter.ShouldBe(colBConfig.PullFilter, "Both properties were assigned with same value.");
         }
 
         [Fact]
@@ -261,18 +261,18 @@ namespace Test
                 PushFilter = _replicator__filterCallbackTrue
             };
             config.AddCollection(colB, colConfig);
-            config.Collections.Contains(colA).Should().BeTrue("Because collection colA just added via AddCollection method");
-            config.Collections.Contains(colB).Should().BeTrue("Because collection colB just added via AddCollection method");
+            config.Collections.Contains(colA).ShouldBeTrue("Because collection colA just added via AddCollection method");
+            config.Collections.Contains(colB).ShouldBeTrue("Because collection colB just added via AddCollection method");
             var colAConfig = config.GetCollectionConfig(colA);
             var colBConfig = config.GetCollectionConfig(colB);
-            colAConfig.Should().NotBeNull("because it was just set");
-            colBConfig.Should().NotBeNull("because it was just set");
-            colAConfig!.ConflictResolver.Should().Be(ConflictResolver.Default, $"Property was never assigned and default value was {ConflictResolver.Default}.");
-            colAConfig.PushFilter.Should().BeNull("Property was never assigned and default value was null.");
-            colAConfig.PullFilter.Should().BeNull("Property was never assigned and default value was null.");
-            colBConfig!.ConflictResolver.Should().Be(colConfig.ConflictResolver, "Property was just updated via AddCollection.");
-            colBConfig.PushFilter.Should().Be(colConfig.PushFilter, "Property was just updated via AddCollection.");
-            colBConfig.PullFilter.Should().Be(colConfig.PullFilter, "Property was just updated via AddCollection.");
+            colAConfig.ShouldNotBeNull("because it was just set");
+            colBConfig.ShouldNotBeNull("because it was just set");
+            colAConfig!.ConflictResolver.ShouldBe(ConflictResolver.Default, $"Property was never assigned and default value was {ConflictResolver.Default}.");
+            colAConfig.PushFilter.ShouldBeNull("Property was never assigned and default value was null.");
+            colAConfig.PullFilter.ShouldBeNull("Property was never assigned and default value was null.");
+            colBConfig!.ConflictResolver.ShouldBe(colConfig.ConflictResolver, "Property was just updated via AddCollection.");
+            colBConfig.PushFilter.ShouldBe(colConfig.PushFilter, "Property was just updated via AddCollection.");
+            colBConfig.PullFilter.ShouldBe(colConfig.PullFilter, "Property was just updated via AddCollection.");
         }
 
         [Fact]
@@ -289,19 +289,19 @@ namespace Test
             };
             config.AddCollection(colA, colConfig);
             config.AddCollection(colB, colConfig);
-            config.Collections.Contains(colA).Should().BeTrue("Because collection colA just added via AddCollection method");
-            config.Collections.Contains(colB).Should().BeTrue("Because collection colB just added via AddCollection method");
+            config.Collections.Contains(colA).ShouldBeTrue("Because collection colA just added via AddCollection method");
+            config.Collections.Contains(colB).ShouldBeTrue("Because collection colB just added via AddCollection method");
 
             var colAConfig = config.GetCollectionConfig(colA);
             var colBConfig = config.GetCollectionConfig(colB);
-            colAConfig.Should().NotBeNull("because it was just set");
-            colBConfig.Should().NotBeNull("because it was just set");
-            colAConfig!.ConflictResolver.Should().Be(colConfig.ConflictResolver);
-            colBConfig!.ConflictResolver.Should().Be(colConfig.ConflictResolver);
-            colAConfig.PullFilter.Should().Be(colConfig.PullFilter);
-            colBConfig.PullFilter.Should().Be(colConfig.PullFilter);
-            colAConfig.PushFilter.Should().Be(colConfig.PushFilter);
-            colBConfig.PushFilter.Should().Be(colConfig.PushFilter);
+            colAConfig.ShouldNotBeNull("because it was just set");
+            colBConfig.ShouldNotBeNull("because it was just set");
+            colAConfig!.ConflictResolver.ShouldBe(colConfig.ConflictResolver);
+            colBConfig!.ConflictResolver.ShouldBe(colConfig.ConflictResolver);
+            colAConfig.PullFilter.ShouldBe(colConfig.PullFilter);
+            colBConfig.PullFilter.ShouldBe(colConfig.PullFilter);
+            colAConfig.PushFilter.ShouldBe(colConfig.PushFilter);
+            colBConfig.PushFilter.ShouldBe(colConfig.PushFilter);
 
             config.AddCollection(colA);
             colConfig = new CollectionConfiguration()
@@ -314,14 +314,14 @@ namespace Test
 
             colAConfig = config.GetCollectionConfig(colA);
             colBConfig = config.GetCollectionConfig(colB);
-            colAConfig.Should().NotBeNull("because it was just set");
-            colBConfig.Should().NotBeNull("because it was just set");
-            colAConfig!.ConflictResolver.Should().Be(ConflictResolver.Default);
-            colBConfig!.ConflictResolver.Should().Be(colConfig.ConflictResolver);
-            colAConfig.PullFilter.Should().Be(null);
-            colBConfig.PullFilter.Should().Be(colConfig.PullFilter);
-            colAConfig.PushFilter.Should().Be(null);
-            colBConfig.PushFilter.Should().Be(colConfig.PushFilter);
+            colAConfig.ShouldNotBeNull("because it was just set");
+            colBConfig.ShouldNotBeNull("because it was just set");
+            colAConfig!.ConflictResolver.ShouldBe(ConflictResolver.Default);
+            colBConfig!.ConflictResolver.ShouldBe(colConfig.ConflictResolver);
+            colAConfig.PullFilter.ShouldBe(null);
+            colBConfig.PullFilter.ShouldBe(colConfig.PullFilter);
+            colAConfig.PushFilter.ShouldBe(null);
+            colBConfig.PushFilter.ShouldBe(colConfig.PushFilter);
         }
 
         [Fact]
@@ -338,26 +338,26 @@ namespace Test
             };
             config.AddCollection(colA, colConfig);
             config.AddCollection(colB, colConfig);
-            config.Collections.Contains(colA).Should().BeTrue("Because collection colA just added via AddCollection method");
-            config.Collections.Contains(colB).Should().BeTrue("Because collection colB just added via AddCollection method");
+            config.Collections.Contains(colA).ShouldBeTrue("Because collection colA just added via AddCollection method");
+            config.Collections.Contains(colB).ShouldBeTrue("Because collection colB just added via AddCollection method");
 
             var colAConfig = config.GetCollectionConfig(colA);
             var colBConfig = config.GetCollectionConfig(colB);
-            colAConfig.Should().NotBeNull("because it was just set");
-            colBConfig.Should().NotBeNull("because it was just set");
-            colAConfig!.ConflictResolver.Should().Be(colConfig.ConflictResolver);
-            colBConfig!.ConflictResolver.Should().Be(colConfig.ConflictResolver);
-            colAConfig.PullFilter.Should().Be(colConfig.PullFilter);
-            colBConfig.PullFilter.Should().Be(colConfig.PullFilter);
-            colAConfig.PushFilter.Should().Be(colConfig.PushFilter);
-            colBConfig.PushFilter.Should().Be(colConfig.PushFilter);
+            colAConfig.ShouldNotBeNull("because it was just set");
+            colBConfig.ShouldNotBeNull("because it was just set");
+            colAConfig!.ConflictResolver.ShouldBe(colConfig.ConflictResolver);
+            colBConfig!.ConflictResolver.ShouldBe(colConfig.ConflictResolver);
+            colAConfig.PullFilter.ShouldBe(colConfig.PullFilter);
+            colBConfig.PullFilter.ShouldBe(colConfig.PullFilter);
+            colAConfig.PushFilter.ShouldBe(colConfig.PushFilter);
+            colBConfig.PushFilter.ShouldBe(colConfig.PushFilter);
 
             config.RemoveCollection(colB);
-            config.Collections.Contains(colA).Should().BeTrue("Because collection colA should still be there");
-            config.Collections.Contains(colB).Should().BeFalse("Because collection colB just removed via RemoveCollection method");
+            config.Collections.Contains(colA).ShouldBeTrue("Because collection colA should still be there");
+            config.Collections.Contains(colB).ShouldBeFalse("Because collection colB just removed via RemoveCollection method");
 
-            config.GetCollectionConfig(colA).Should().NotBeNull("Because collection colA should still be there, thus it's config should also exist as well.");
-            config.GetCollectionConfig(colB).Should().BeNull("Because collection colB just removed via RemoveCollection method, thus it's config should also be null.");
+            config.GetCollectionConfig(colA).ShouldNotBeNull("Because collection colA should still be there, thus it's config should also exist as well.");
+            config.GetCollectionConfig(colB).ShouldBeNull("Because collection colB just removed via RemoveCollection method, thus it's config should also be null.");
         }
 
         [Fact]
@@ -367,10 +367,10 @@ namespace Test
             var colB = OtherDb.CreateCollection("colB", "scopeA");
             var config = new ReplicatorConfiguration(new DatabaseEndpoint(OtherDb));
             config.AddCollection(colA);
-            config.Collections.Contains(colA).Should().BeTrue();
-            config.Invoking(c => c.AddCollection(colB)).Should().Throw<CouchbaseLiteException>().Where(
-                        e => e.Error == CouchbaseLiteError.InvalidParameter &&
-                             e.Domain == CouchbaseLiteErrorType.CouchbaseLite);
+            config.Collections.Contains(colA).ShouldBeTrue();
+            var ex = Should.Throw<CouchbaseLiteException>(() => config.AddCollection(colB));
+            ex.Error.ShouldBe(CouchbaseLiteError.InvalidParameter);
+            ex.Domain.ShouldBe(CouchbaseLiteErrorType.CouchbaseLite);
         }
 
         [Fact]
@@ -381,10 +381,10 @@ namespace Test
             OtherDb.DeleteCollection("colB", "scopeA");
             var config = new ReplicatorConfiguration(new DatabaseEndpoint(OtherDb));
             config.AddCollection(colA);
-            config.Collections.Contains(colA).Should().BeTrue();
-            config.Invoking(c=>c.AddCollection(colB)).Should().Throw<CouchbaseLiteException>().Where(
-                        e => e.Error == CouchbaseLiteError.InvalidParameter &&
-                             e.Domain == CouchbaseLiteErrorType.CouchbaseLite);
+            config.Collections.Contains(colA).ShouldBeTrue();
+            var ex = Should.Throw<CouchbaseLiteException>(() => config.AddCollection(colB));
+            ex.Error.ShouldBe(CouchbaseLiteError.InvalidParameter);
+            ex.Domain.ShouldBe(CouchbaseLiteErrorType.CouchbaseLite);
         }
 
         #endregion
@@ -401,16 +401,16 @@ namespace Test
             // Check docs in OtherDb - make sure docs are pushed to the OtherDb from the Db
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -424,16 +424,16 @@ namespace Test
             // Check docs in Db - make sure all docs are pulled from the OtherDb to the Db
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colBInDb = Db.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -448,42 +448,42 @@ namespace Test
             // Check docs in Db - make sure all docs are pulled from the OtherDb to the Db
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colBInDb = Db.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
 
             // Check docs in OtherDb - make sure docs are pushed to the OtherDb from the Db
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
 
             //Test Update doc in replication
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb.Should().NotBeNull("because it was just created");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
                 using (var doc = colAInDb!.GetDocument("doc4"))
                 using (var mdoc = doc?.ToMutable()) {
-                    doc?.GetString("str4").Should().Be("string4");
-                    colAInOtherDb!.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
+                    doc?.GetString("str4").ShouldBe("string4");
+                    colAInOtherDb!.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
                     mdoc!.SetString("str4", "string4 update");
                     colAInDb.Save(mdoc);
                 }
@@ -492,19 +492,19 @@ namespace Test
             RunReplication(config, 0, 0);
 
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA")) {
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb!.GetDocument("doc4")?.GetString("str4").Should().Be("string4 update");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb!.GetDocument("doc4")?.GetString("str4").ShouldBe("string4 update");
             }
 
             //Test Delete doc in replication
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb.Should().NotBeNull("because it was just created");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
 
                 using (var doc = colAInDb!.GetDocument("doc4")) {
-                    doc?.GetString("str4").Should().Be("string4 update");
-                    colAInOtherDb!.GetDocument("doc4")?.GetString("str4").Should().Be("string4 update");
+                    doc?.GetString("str4").ShouldBe("string4 update");
+                    colAInOtherDb!.GetDocument("doc4")?.GetString("str4").ShouldBe("string4 update");
                     colAInDb.Delete(doc!);
                 }
             }
@@ -512,8 +512,8 @@ namespace Test
             RunReplication(config, 0, 0);
 
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA")) {
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb!.GetDocument("doc4").Should().BeNull();
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb!.GetDocument("doc4").ShouldBeNull();
             }
         }
 
@@ -527,16 +527,16 @@ namespace Test
             // Check docs in OtherDb - make sure docs are pushed to the OtherDb from the Db
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -550,16 +550,16 @@ namespace Test
             // Check docs in Db - make sure all docs are pulled from the OtherDb to the Db
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colBInDb = Db.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -574,31 +574,31 @@ namespace Test
             // Check docs in Db - make sure all docs are pulled from the OtherDb to the Db
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colBInDb = Db.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
 
             // Check docs in OtherDb - make sure docs are pushed to the OtherDb from the Db
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInOtherDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -613,50 +613,50 @@ namespace Test
             using (var colBInDb = Db.GetCollection("colB", "scopeA")) 
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
 
                 // Check docs in Db
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
                 var doc4 = colAInDb.GetDocument("doc4");
-                doc4?.GetString("str4").Should().Be("string4");
+                doc4?.GetString("str4").ShouldBe("string4");
                 var doc5 = colAInDb.GetDocument("doc5");
-                doc5?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                doc5?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
 
                 // Purge all docs in colA in Db
                 colAInDb.Purge(doc4!);
                 colAInDb.Purge(doc5!);
 
                 // docs in colA in Db are now purged
-                colAInDb.GetDocument("doc4").Should().BeNull();
-                colAInDb.GetDocument("doc5").Should().BeNull();
+                colAInDb.GetDocument("doc4").ShouldBeNull();
+                colAInDb.GetDocument("doc5").ShouldBeNull();
             }
 
             RunReplication(config, 0, 0);
 
             using (var colAInDb = Db.GetCollection("colA", "scopeA")) {
-                colAInDb.Should().NotBeNull();
+                colAInDb.ShouldNotBeNull();
 
                 // docs in colA in Db are still gone
-                colAInDb!.GetDocument("doc4").Should().BeNull();
-                colAInDb.GetDocument("doc5").Should().BeNull();
+                colAInDb!.GetDocument("doc4").ShouldBeNull();
+                colAInDb.GetDocument("doc5").ShouldBeNull();
             }
 
             RunReplication(config, 0, 0, true);
 
             using (var colAInDb = Db.GetCollection("colA", "scopeA")) {
-                colAInDb.Should().NotBeNull();
+                colAInDb.ShouldNotBeNull();
 
                 // After reset in replication, colA in Db are pulled from otherDb again
-                colAInDb!.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
+                colAInDb!.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
             }
         }
 
@@ -681,10 +681,10 @@ namespace Test
             using (var colBInDb = Db.GetCollection("colB", "scopeA"))
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
 
                 using (var docInColAInDb = colAInDb!.GetDocument("doc"))
                 using (var doc2InColBDb = colBInDb!.GetDocument("doc2"))
@@ -727,33 +727,33 @@ namespace Test
             RunReplication(config, 0, 0);
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb.Should().NotBeNull("because it was just created");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
                 using (var doc = colAInDb!.GetDocument("doc1"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str1", "string1 update");
                     colAInDb.Save(mdoc);
                 }
 
                 using (var doc = colAInOtherDb!.GetDocument("doc1"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str1", "string1 update1");
                     colAInOtherDb.Save(mdoc);
                 }
 
                 using (var doc = colAInOtherDb.GetDocument("doc1"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str1", "string1 update again");
                     colAInOtherDb.Save(mdoc);
                 }
 
                 RunReplication(config, 0, 0);
 
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1 update again");
-                colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1 update again"); 
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1 update again");
+                colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1 update again"); 
             }
         }
 
@@ -767,10 +767,10 @@ namespace Test
             using (var colBInDb = Db.GetCollection("colB", "scopeA"))
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInDb.Should().NotBeNull("because it was just created");
-                colBInDb.Should().NotBeNull("because it was just created");
-                colAInOtherDb.Should().NotBeNull("because it was just created");
-                colBInOtherDb.Should().NotBeNull("because it was just created");
+                colAInDb.ShouldNotBeNull("because it was just created");
+                colBInDb.ShouldNotBeNull("because it was just created");
+                colAInOtherDb.ShouldNotBeNull("because it was just created");
+                colBInOtherDb.ShouldNotBeNull("because it was just created");
 
                 var cllConfigADb = config.GetCollectionConfig(colAInDb!);
                 cllConfigADb!.ConflictResolver = new TestConflictResolver((conflict) => {
@@ -784,36 +784,36 @@ namespace Test
 
                 using (var doc = colAInDb!.GetDocument("doc1"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str1", "string1 update");
                     colAInDb.Save(mdoc);
                 }
 
                 using (var doc = colBInDb!.GetDocument("doc3"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str3", "string3 update");
                     colBInDb.Save(mdoc);
                 }
 
                 using (var doc = colAInOtherDb!.GetDocument("doc1"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str1", "string1 update1");
                     colAInOtherDb.Save(mdoc);
                 }
 
                 using (var doc = colBInOtherDb!.GetDocument("doc3"))
                 using (var mdoc = doc?.ToMutable()) {
-                    mdoc.Should().NotBeNull("because it was just saved");
+                    mdoc.ShouldNotBeNull("because it was just saved");
                     mdoc!.SetString("str3", "string3 update1");
                     colBInOtherDb.Save(mdoc);
                 }
 
                 RunReplication(config, 0, 0);
 
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1 update");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3 update1");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1 update");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3 update1");
             }
         }
 
@@ -832,14 +832,14 @@ namespace Test
                 // Check docs in OtherDb - make sure docs with odd doc ids are pushed to the OtherDb from the Db
                 using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
                 using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                    colAInOtherDb!.GetDocument("doc").Should().BeNull();
-                    colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                    colBInOtherDb!.GetDocument("doc2")?.Should().BeNull();
-                    colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                    colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                    colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                    colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                    colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                    colAInOtherDb!.GetDocument("doc").ShouldBeNull();
+                    colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                    colBInOtherDb!.GetDocument("doc2")?.ShouldBeNull();
+                    colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                    colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                    colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                    colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                    colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
                 }
             }
         }
@@ -857,14 +857,14 @@ namespace Test
                 RunReplication(config, 0, 0);
 
                 // Check docs in Db - make sure all docs with odd doc ids are pulled from the OtherDb to the Db
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInDb.GetDocument("doc4")?.Should().BeNull();
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6")?.Should().BeNull();
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInDb.GetDocument("doc4")?.ShouldBeNull();
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6")?.ShouldBeNull();
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -886,14 +886,14 @@ namespace Test
             // Check docs in OtherDb - make sure docs with odd doc ids are pushed to the OtherDb from the Db
             using (var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA"))
             using (var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA")) {
-                colAInOtherDb!.GetDocument("doc").Should().BeNull();
-                colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInOtherDb!.GetDocument("doc2").Should().BeNull();
-                colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-                colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-                colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInOtherDb!.GetDocument("doc").ShouldBeNull();
+                colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInOtherDb!.GetDocument("doc2").ShouldBeNull();
+                colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+                colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+                colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -913,14 +913,14 @@ namespace Test
             // Check docs in Db - make sure all docs with odd doc ids are pulled from the OtherDb to the Db
             using (var colAInDb = Db.GetCollection("colA", "scopeA"))
             using (var colBInDb = Db.GetCollection("colB", "scopeA")) {
-                colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-                colAInDb.GetDocument("doc4").Should().BeNull();
-                colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-                colBInDb.GetDocument("doc6").Should().BeNull();
-                colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+                colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+                colAInDb.GetDocument("doc4").ShouldBeNull();
+                colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+                colBInDb.GetDocument("doc6").ShouldBeNull();
+                colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
             }
         }
 
@@ -960,7 +960,7 @@ namespace Test
             var config = CreateConfig(ReplicatorType.PushAndPull);
             config.AddCollections(new List<Collection>());
             Action badAction = (() => new Replicator(config));
-            badAction.Should().Throw<CouchbaseLiteException>("Replicator Configuration must contain at least one collection.");
+            Should.Throw<CouchbaseLiteException>(badAction, "Replicator Configuration must contain at least one collection.");
         }
 
         [Fact]
@@ -975,26 +975,26 @@ namespace Test
             // Check docs in Db - make sure all docs are pulled from the OtherDb to the Db
             var colAInDb = Db.GetCollection("colA", "scopeA");
             var colBInDb = Db.GetCollection("colB", "scopeA");
-            colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-            colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-            colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-            colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-            colAInDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-            colAInDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-            colBInDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-            colBInDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+            colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+            colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+            colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+            colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+            colAInDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+            colAInDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+            colBInDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+            colBInDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
 
             // Check docs in OtherDb - make sure docs are pushed to the OtherDb from the Db
             var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA");
             var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA");
-            colAInOtherDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-            colAInOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-            colBInOtherDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-            colBInOtherDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-            colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-            colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-            colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-            colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+            colAInOtherDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+            colAInOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+            colBInOtherDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+            colBInOtherDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+            colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+            colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+            colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+            colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
         }
 
         [Fact]
@@ -1021,11 +1021,11 @@ namespace Test
             config.PushFilter = _replicator__filterCallbackTrue;
 
             var defaultCollConfig = config.GetCollectionConfig(defaultCollection);
-            defaultCollConfig!.Channels.Should().BeSameAs(config.Channels);
-            defaultCollConfig.DocumentIDs.Should().BeSameAs(config.DocumentIDs);
-            defaultCollConfig.ConflictResolver.Should().BeSameAs(config.ConflictResolver);
-            defaultCollConfig.PullFilter.Should().BeSameAs(config.PullFilter);
-            defaultCollConfig.PushFilter.Should().BeSameAs(config.PushFilter);
+            defaultCollConfig!.Channels.ShouldBeSameAs(config.Channels);
+            defaultCollConfig.DocumentIDs.ShouldBeSameAs(config.DocumentIDs);
+            defaultCollConfig.ConflictResolver.ShouldBeSameAs(config.ConflictResolver);
+            defaultCollConfig.PullFilter.ShouldBeSameAs(config.PullFilter);
+            defaultCollConfig.PushFilter.ShouldBeSameAs(config.PushFilter);
         }
 
         [Fact]
@@ -1048,24 +1048,24 @@ namespace Test
             replConfig.AddCollections(new List<Collection>() { defaultCollection, colA }, collConfig);
 
             collConfig = replConfig.GetCollectionConfig(defaultCollection);
-            collConfig!.PullFilter.Should().NotBeNull("Because defaultCollection's collConfig PullFilter is assigned");
-            collConfig.PushFilter.Should().BeNull("Because no PushFilter is assigned in defaultCollection's collConfig");
+            collConfig!.PullFilter.ShouldNotBeNull("Because defaultCollection's collConfig PullFilter is assigned");
+            collConfig.PushFilter.ShouldBeNull("Because no PushFilter is assigned in defaultCollection's collConfig");
 
             collConfig = replConfig.GetCollectionConfig(colA);
-            collConfig!.PullFilter.Should().NotBeNull("Because colA's collConfig PullFilter is assigned");
-            collConfig.PushFilter.Should().BeNull("Because no PushFilter is assigned in colA's collConfig");
+            collConfig!.PullFilter.ShouldNotBeNull("Because colA's collConfig PullFilter is assigned");
+            collConfig.PushFilter.ShouldBeNull("Because no PushFilter is assigned in colA's collConfig");
 
             // Set ReplicationFilter as the push filter using the deprecated ReplicatorConfiguration.setPushFilter method.
             replConfig.PushFilter = _replicator__filterCallbackTrue;
 
             collConfig = replConfig.GetCollectionConfig(defaultCollection);
-            collConfig!.PullFilter.Should().NotBeNull("Because defaultCollection's collConfig PullFilter is assigned");
-            collConfig.PushFilter.Should().NotBeNull("Because defaultCollection's collConfig PushFilter is assigned");
+            collConfig!.PullFilter.ShouldNotBeNull("Because defaultCollection's collConfig PullFilter is assigned");
+            collConfig.PushFilter.ShouldNotBeNull("Because defaultCollection's collConfig PushFilter is assigned");
 
             // Verify that the only thing that has changed is the default collection's push filter.
             collConfig = replConfig.GetCollectionConfig(colA);
-            collConfig!.PullFilter.Should().NotBeNull("Because colA's collConfig PullFilter is assigned");
-            collConfig.PushFilter.Should().BeNull("Because no PushFilter is assigned in colA's collConfig");
+            collConfig!.PullFilter.ShouldNotBeNull("Because colA's collConfig PullFilter is assigned");
+            collConfig.PushFilter.ShouldBeNull("Because no PushFilter is assigned in colA's collConfig");
         }
 
         #endregion
@@ -1134,10 +1134,10 @@ namespace Test
                         {
                             if (args.Status.Activity == ReplicatorActivityLevel.Offline) {
                                 pendingDocIds = replicator.GetPendingDocumentIDs(colAInDb!);
-                                pendingDocIds.Count.Should().Be(0);
+                                pendingDocIds.Count.ShouldBe(0);
 
                                 pendingDocIds = replicator.GetPendingDocumentIDs(colBInDb!);
-                                pendingDocIds.Count.Should().Be(0);
+                                pendingDocIds.Count.ShouldBe(0);
                             }
 
                             return args.Status.Activity == ReplicatorActivityLevel.Stopped;
@@ -1147,20 +1147,20 @@ namespace Test
                     pendingDocIds = replicator.GetPendingDocumentIDs(colAInDb!);
                     var pendingDocIds1 = replicator.GetPendingDocumentIDs(colBInDb!);
                     if (selection == PENDING_DOC_ID_SEL.FILTER) {
-                        pendingDocIds.Count.Should().Be(1);
-                        pendingDocIds.ElementAt(0).Should().Be(colADocId);
-                        pendingDocIds1.Count.Should().Be(1);
-                        pendingDocIds1.ElementAt(0).Should().Be(colBDocId);
+                        pendingDocIds.Count.ShouldBe(1);
+                        pendingDocIds.ElementAt(0).ShouldBe(colADocId);
+                        pendingDocIds1.Count.ShouldBe(1);
+                        pendingDocIds1.ElementAt(0).ShouldBe(colBDocId);
                     } else if (selection == PENDING_DOC_ID_SEL.PURGE) {
-                        pendingDocIds.Contains("doc").Should().BeFalse();
-                        pendingDocIds.Contains("doc1").Should().BeTrue();
-                        pendingDocIds1.Contains("doc2").Should().BeFalse();
-                        pendingDocIds1.Contains("doc3").Should().BeTrue();
+                        pendingDocIds.Contains("doc").ShouldBeFalse();
+                        pendingDocIds.Contains("doc1").ShouldBeTrue();
+                        pendingDocIds1.Contains("doc2").ShouldBeFalse();
+                        pendingDocIds1.Contains("doc3").ShouldBeTrue();
                     } else {
-                        pendingDocIds.Contains("doc").Should().BeTrue();
-                        pendingDocIds.Contains("doc1").Should().BeTrue();
-                        pendingDocIds1.Contains("doc2").Should().BeTrue();
-                        pendingDocIds1.Contains("doc3").Should().BeTrue();
+                        pendingDocIds.Contains("doc").ShouldBeTrue();
+                        pendingDocIds.Contains("doc1").ShouldBeTrue();
+                        pendingDocIds1.Contains("doc2").ShouldBeTrue();
+                        pendingDocIds1.Contains("doc3").ShouldBeTrue();
                     }
 
                     replicator.Start();
@@ -1170,10 +1170,10 @@ namespace Test
                     Try.Condition(() => replicator.Status.Activity == ReplicatorActivityLevel.Stopped)
                         .Times(5)
                         .Delay(TimeSpan.FromMilliseconds(500))
-                        .Go().Should().BeTrue();
+                        .Go().ShouldBeTrue();
 
-                    replicator.GetPendingDocumentIDs(colAInDb!).Count.Should().Be(0);
-                    replicator.GetPendingDocumentIDs(colBInDb!).Count.Should().Be(0);
+                    replicator.GetPendingDocumentIDs(colAInDb!).Count.ShouldBe(0);
+                    replicator.GetPendingDocumentIDs(colBInDb!).Count.ShouldBe(0);
                     token.Remove();
                 }
             }
@@ -1242,9 +1242,9 @@ namespace Test
                     {
                         if (args.Status.Activity == ReplicatorActivityLevel.Offline) {
                             docIdIsPending = replicator.IsDocumentPending(colADocId, colAInDb!);
-                            docIdIsPending.Should().BeFalse();
+                            docIdIsPending.ShouldBeFalse();
                             docIdIsPending = replicator.IsDocumentPending(colBDocId, colBInDb!);
-                            docIdIsPending.Should().BeFalse();
+                            docIdIsPending.ShouldBeFalse();
                         }
 
                         wa.RunConditionalAssert(() =>
@@ -1257,22 +1257,22 @@ namespace Test
                     var docIdIsPending1 = replicator.IsDocumentPending(colBDocId, colBInDb!);
                     if (selection == PENDING_DOC_ID_SEL.CREATE || selection == PENDING_DOC_ID_SEL.UPDATE
                         || selection == PENDING_DOC_ID_SEL.DELETE) {
-                        docIdIsPending.Should().BeTrue();
+                        docIdIsPending.ShouldBeTrue();
                         docIdIsPending = replicator.IsDocumentPending("IdNotThere", colAInDb!);
-                        docIdIsPending.Should().BeFalse();
-                        docIdIsPending1.Should().BeTrue();
+                        docIdIsPending.ShouldBeFalse();
+                        docIdIsPending1.ShouldBeTrue();
                         docIdIsPending1 = replicator.IsDocumentPending("IdNotThere", colBInDb!);
-                        docIdIsPending1.Should().BeFalse();
+                        docIdIsPending1.ShouldBeFalse();
                     } else if (selection == PENDING_DOC_ID_SEL.FILTER) {
-                        docIdIsPending.Should().BeTrue();
+                        docIdIsPending.ShouldBeTrue();
                         docIdIsPending = replicator.IsDocumentPending("doc1", colAInDb!);
-                        docIdIsPending.Should().BeFalse();
-                        docIdIsPending1.Should().BeTrue();
+                        docIdIsPending.ShouldBeFalse();
+                        docIdIsPending1.ShouldBeTrue();
                         docIdIsPending1 = replicator.IsDocumentPending("doc3", colBInDb!);
-                        docIdIsPending1.Should().BeFalse();
+                        docIdIsPending1.ShouldBeFalse();
                     } else if (selection == PENDING_DOC_ID_SEL.PURGE) {
-                        docIdIsPending.Should().BeFalse();
-                        docIdIsPending1.Should().BeFalse();
+                        docIdIsPending.ShouldBeFalse();
+                        docIdIsPending1.ShouldBeFalse();
                     }
 
                     replicator.Start();
@@ -1282,10 +1282,10 @@ namespace Test
                     Try.Condition(() => replicator.Status.Activity == ReplicatorActivityLevel.Stopped)
                         .Times(5)
                         .Delay(TimeSpan.FromMilliseconds(500))
-                        .Go().Should().BeTrue();
+                        .Go().ShouldBeTrue();
 
-                    replicator.IsDocumentPending(colADocId, colAInDb!).Should().BeFalse();
-                    replicator.IsDocumentPending(colBDocId, colBInDb!).Should().BeFalse();
+                    replicator.IsDocumentPending(colADocId, colAInDb!).ShouldBeFalse();
+                    replicator.IsDocumentPending(colBDocId, colBInDb!).ShouldBeFalse();
                     token.Remove();
                 }
             }
@@ -1334,26 +1334,26 @@ namespace Test
             // Check docs in Db - before replication
             var colAInDb = Db.GetCollection("colA", "scopeA");
             var colBInDb = Db.GetCollection("colB", "scopeA");
-            colAInDb!.GetDocument("doc")?.GetString("str").Should().Be("string");
-            colAInDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-            colBInDb!.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-            colBInDb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
-            colAInDb.GetDocument("doc4").Should().BeNull("Because doc4 is not created in colA in Db");
-            colAInDb.GetDocument("doc5").Should().BeNull("Because doc5 is not created in colA in Db");
-            colBInDb.GetDocument("doc6").Should().BeNull("Because doc6 is not created in colB in Db");
-            colBInDb.GetDocument("doc7").Should().BeNull("Because doc7 is not created in colB in Db");
+            colAInDb!.GetDocument("doc")?.GetString("str").ShouldBe("string");
+            colAInDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+            colBInDb!.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+            colBInDb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
+            colAInDb.GetDocument("doc4").ShouldBeNull("Because doc4 is not created in colA in Db");
+            colAInDb.GetDocument("doc5").ShouldBeNull("Because doc5 is not created in colA in Db");
+            colBInDb.GetDocument("doc6").ShouldBeNull("Because doc6 is not created in colB in Db");
+            colBInDb.GetDocument("doc7").ShouldBeNull("Because doc7 is not created in colB in Db");
 
             // Check docs in OtherDb - before replication
             var colAInOtherDb = OtherDb.GetCollection("colA", "scopeA");
             var colBInOtherDb = OtherDb.GetCollection("colB", "scopeA");
-            colAInOtherDb!.GetDocument("doc").Should().BeNull("Because doc is not created in colA in OtherDb");
-            colAInOtherDb.GetDocument("doc1").Should().BeNull("Because doc1 is not created in colA in OtherDb");
-            colBInOtherDb!.GetDocument("doc2").Should().BeNull("Because doc2 is not created in colA in OtherDb");
-            colBInOtherDb.GetDocument("doc3").Should().BeNull("Because doc3 is not created in colA in OtherDb");
-            colAInOtherDb.GetDocument("doc4")?.GetString("str4").Should().Be("string4");
-            colAInOtherDb.GetDocument("doc5")?.GetString("str5").Should().Be("string5");
-            colBInOtherDb.GetDocument("doc6")?.GetString("str6").Should().Be("string6");
-            colBInOtherDb.GetDocument("doc7")?.GetString("str7").Should().Be("string7");
+            colAInOtherDb!.GetDocument("doc").ShouldBeNull("Because doc is not created in colA in OtherDb");
+            colAInOtherDb.GetDocument("doc1").ShouldBeNull("Because doc1 is not created in colA in OtherDb");
+            colBInOtherDb!.GetDocument("doc2").ShouldBeNull("Because doc2 is not created in colA in OtherDb");
+            colBInOtherDb.GetDocument("doc3").ShouldBeNull("Because doc3 is not created in colA in OtherDb");
+            colAInOtherDb.GetDocument("doc4")?.GetString("str4").ShouldBe("string4");
+            colAInOtherDb.GetDocument("doc5")?.GetString("str5").ShouldBe("string5");
+            colBInOtherDb.GetDocument("doc6")?.GetString("str6").ShouldBe("string6");
+            colBInOtherDb.GetDocument("doc7")?.GetString("str7").ShouldBe("string7");
 
             config.AddCollection(colA);
             config.AddCollection(colB);
@@ -1374,7 +1374,7 @@ namespace Test
 
         private bool _replicator__filterAllowsOddDocIdsCallback(Document document, DocumentFlags flags)
         {
-            document.RevisionID.Should().NotBeNull();
+            document.RevisionID.ShouldNotBeNull();
             if (allowOddIds.Any(id => id == document.Id))
                 return true;
 

--- a/src/Couchbase.Lite.Tests.Shared/TLSIdentityTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TLSIdentityTest.cs
@@ -34,7 +34,7 @@ using Couchbase.Lite.Sync;
 using Couchbase.Lite.Util;
 using Couchbase.Lite.Query;
 
-using FluentAssertions;
+using Shouldly;
 using LiteCore;
 using LiteCore.Interop;
 
@@ -91,11 +91,11 @@ namespace Test
                 ClientCertLabel,
                 null);
 
-            identity.Should().NotBeNull();
+            identity.ShouldNotBeNull();
             var certs = identity!.Certs;
 
             id = TLSIdentity.GetIdentity(certs);
-            id.Should().NotBeNull();
+            id.ShouldNotBeNull();
 
             // Delete
             TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
@@ -114,11 +114,11 @@ namespace Test
                 ClientCertLabel,
                 null);
 
-            identity.Should().NotBeNull();
+            identity.ShouldNotBeNull();
             var certs = identity!.Certs;
 
             id = TLSIdentity.GetIdentity(certs);
-            id.Should().NotBeNull();
+            id.ShouldNotBeNull();
 
             // Delete
             TLSIdentity.DeleteIdentity(_store, ClientCertLabel, null);
@@ -141,13 +141,13 @@ namespace Test
 
             // Import
             id = TLSIdentity.ImportIdentity(_store, data, "123", ServerCertLabel, null);
-            id.Should().NotBeNull();
-            id!.Certs.Count.Should().Be(2);
-            ValidateCertsInStore(id.Certs, _store).Should().BeTrue();
+            id.ShouldNotBeNull();
+            id!.Certs.Count.ShouldBe(2);
+            ValidateCertsInStore(id.Certs, _store).ShouldBeTrue();
 
             // Get
             id = TLSIdentity.GetIdentity(_store, ServerCertLabel, null);
-            id.Should().NotBeNull();
+            id.ShouldNotBeNull();
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace Test
 
             //Get
             var id = TLSIdentity.GetIdentity(_store, ServerCertLabel, null);
-            id.Should().BeNull();
+            id.ShouldBeNull();
 
             // Create id with empty Attributes
             Action badAction = (() => TLSIdentity.CreateIdentity(KeyUsages.ServerAuth,
@@ -167,7 +167,8 @@ namespace Test
                 _store,
                 ServerCertLabel,
                 null));
-            badAction.Should().Throw<CouchbaseLiteException>(CouchbaseLiteErrorMessage.CreateCertAttributeEmpty);
+            Should.Throw<CouchbaseLiteException>(badAction)
+                .Message.ShouldBe(CouchbaseLiteErrorMessage.CreateCertAttributeEmpty);
         }
 
         [Fact]
@@ -180,7 +181,7 @@ namespace Test
 
             //Get
             id = TLSIdentity.GetIdentity(_store, ServerCertLabel, null);
-            id.Should().BeNull();
+            id.ShouldBeNull();
 
             var fiveMinToExpireCert = DateTimeOffset.UtcNow.AddMinutes(5);
             id = TLSIdentity.CreateIdentity(KeyUsages.ServerAuth,
@@ -190,9 +191,9 @@ namespace Test
                 ServerCertLabel,
                 null);
 
-            id.Should().NotBeNull();
-            (id!.Expiration - DateTimeOffset.UtcNow).Should().BeGreaterThan(TimeSpan.MinValue);
-            (id.Expiration - DateTimeOffset.UtcNow).Should().BeLessOrEqualTo(TimeSpan.FromMinutes(5));
+            id.ShouldNotBeNull();
+            (id!.Expiration - DateTimeOffset.UtcNow).ShouldBeGreaterThan(TimeSpan.MinValue);
+            (id.Expiration - DateTimeOffset.UtcNow).ShouldBeLessThanOrEqualTo(TimeSpan.FromMinutes(5));
 
             // Delete 
             TLSIdentity.DeleteIdentity(_store, ServerCertLabel, null);
@@ -231,7 +232,7 @@ namespace Test
 
             //Get
             id = TLSIdentity.GetIdentity(_store, label, null);
-            id.Should().BeNull();
+            id.ShouldBeNull();
 
             // Create
             id = TLSIdentity.CreateIdentity(keyUsages,
@@ -240,22 +241,22 @@ namespace Test
                 _store,
                 label,
                 null);
-            id.Should().NotBeNull();
-            id!.Certs.Count.Should().Be(1);
-            ValidateCertsInStore(id.Certs, _store).Should().BeTrue();
+            id.ShouldNotBeNull();
+            id!.Certs.Count.ShouldBe(1);
+            ValidateCertsInStore(id.Certs, _store).ShouldBeTrue();
 
             // Get
             id = TLSIdentity.GetIdentity(_store, label, null);
-            id.Should().NotBeNull();
-            id!.Certs.Count.Should().Be(1);
-            ValidateCertsInStore(id.Certs, _store).Should().BeTrue();
+            id.ShouldNotBeNull();
+            id!.Certs.Count.ShouldBe(1);
+            ValidateCertsInStore(id.Certs, _store).ShouldBeTrue();
 
             // Delete
             TLSIdentity.DeleteIdentity(_store, label, null);
 
             // Get
             id = TLSIdentity.GetIdentity(_store, label, null);
-            id.Should().BeNull();
+            id.ShouldBeNull();
         }
 
         private void CreateDuplicateServerIdentity(KeyUsages keyUsages)
@@ -275,12 +276,12 @@ namespace Test
                 _store,
                 label,
                 null);
-            id.Should().NotBeNull();
-            id!.Certs.Count.Should().Be(1);
+            id.ShouldNotBeNull();
+            id!.Certs.Count.ShouldBe(1);
 
             //Get - Need to check why CryptographicException: Invalid provider type specified
             //id = TLSIdentity.GetIdentity(_store, label, null);
-            //id.Should().NotBeNull();
+            //id.ShouldNotBeNull();
 
             // Create again with the same label
             Action badAction = (() => TLSIdentity.CreateIdentity(keyUsages,
@@ -289,7 +290,8 @@ namespace Test
                 _store,
                 label,
                 null));
-            badAction.Should().Throw<CouchbaseLiteException>(CouchbaseLiteErrorMessage.DuplicateCertificate);
+            Should.Throw<CouchbaseLiteException>(badAction)
+                .Message.ShouldBe(CouchbaseLiteErrorMessage.DuplicateCertificate);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -220,18 +220,18 @@ namespace Test
                         md.GetDate(kvPair.Key).ShouldBe((DateTimeOffset) kvPair.Value!);
                         break;
                     case "array":
-                        md.GetArray(kvPair.Key).ShouldBeEquivalentTo(new MutableArrayObject((List<int>) kvPair.Value!));
-                        md.GetValue(kvPair.Key).ShouldBeEquivalentTo(new MutableArrayObject((List<int>) kvPair.Value!));
+                        md.GetArray(kvPair.Key).ShouldBeEquivalentToFluent(new MutableArrayObject((List<int>) kvPair.Value!));
+                        md.GetValue(kvPair.Key).ShouldBeEquivalentToFluent(new MutableArrayObject((List<int>) kvPair.Value!));
                         break;
                     case "dictionary":
-                        md.GetDictionary(kvPair.Key).ShouldBeEquivalentTo(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
-                        md.GetValue(kvPair.Key).ShouldBeEquivalentTo(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
+                        md.GetDictionary(kvPair.Key).ShouldBeEquivalentToFluent(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
+                        md.GetValue(kvPair.Key).ShouldBeEquivalentToFluent(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
                         break;
                     case "blob":
                         md.GetBlob(kvPair.Key).ShouldBeNull("Because we are getting a dictionary represents Blob object back.");
                         var di = ((MutableDictionaryObject?) md.GetValue(kvPair.Key))!.ToDictionary();
                         Blob.IsBlob(di).ShouldBeTrue();
-                        di.ShouldBeEquivalentTo(((Blob) dic[kvPair.Key]!).JsonRepresentation);
+                        di.ShouldBeEquivalentToFluent(((Blob) dic[kvPair.Key]!).JsonRepresentation);
                         break;
                     default:
                         throw new Exception("This should not happen because all test input values are CBL supported values.");
@@ -257,11 +257,11 @@ namespace Test
                     }
 
                     var blob = new Blob(Db!, b1JsonD!);
-                    blob.ShouldBeEquivalentTo((Blob) dic[i.Key]!);
+                    blob.ShouldBeEquivalentToFluent((Blob) dic[i.Key]!);
                 } else if (i.Key == "floatVal") {
                     (DataOps.ConvertToFloat(jdic![i.Key])).ShouldBe((float) dic[i.Key]!, 0.0000000001f);
                 } else {
-                    (DataOps.ToCouchbaseObject(jdic![i.Key])).ShouldBeEquivalentTo((DataOps.ToCouchbaseObject(dic[i.Key])));
+                    (DataOps.ToCouchbaseObject(jdic![i.Key])).ShouldBeEquivalentToFluent((DataOps.ToCouchbaseObject(dic[i.Key])));
                 }
             }
         }

--- a/src/Couchbase.Lite.Tests.Shared/TestCase.cs
+++ b/src/Couchbase.Lite.Tests.Shared/TestCase.cs
@@ -26,8 +26,7 @@ using Couchbase.Lite;
 using Couchbase.Lite.Logging;
 using Couchbase.Lite.Query;
 
-using FluentAssertions;
-using FluentAssertions.Execution;
+using Shouldly;
 
 using Newtonsoft.Json;
 using Test.Util;
@@ -114,7 +113,7 @@ namespace Test
             eval(document);
             DefaultCollection.Save(document);
             using (var retVal = DefaultCollection.GetDocument(document.Id)) {
-                retVal.Should().NotBeNull("because otherwise the save failed");
+                retVal.ShouldNotBeNull("because otherwise the save failed");
                 WriteLine("After Save...");
                 eval(retVal!);
             }
@@ -178,10 +177,10 @@ namespace Test
             DefaultCollection.Save(document);
 
             using (var savedDoc = DefaultCollection.GetDocument(document.Id)) {
-                savedDoc.Should().NotBeNull("because otherwise the save failed");
-                savedDoc!.Id.Should().Be(document.Id);
+                savedDoc.ShouldNotBeNull("because otherwise the save failed");
+                savedDoc!.Id.ShouldBe(document.Id);
                 if (!TestObjectEquality(document.ToDictionary(), savedDoc.ToDictionary())) {
-                    throw new AssertionFailedException($"Expected the saved document to match the original");
+                    throw new ShouldAssertException("Expected the saved document to match the original");
                 }
             }
         }
@@ -191,48 +190,48 @@ namespace Test
             foreach (var kvPair in dic) {
                 switch (kvPair.Key) {
                     case "nullObj":
-                        md.GetValue(kvPair.Key).Should().Be(kvPair.Value);
+                        md.GetValue(kvPair.Key).ShouldBe(kvPair.Value);
                         break;
                     case "byteVal":
                     case "ushortVal":
                     case "uintVal":
                     case "ulongVal":
-                        Convert.ToUInt64(md.GetValue(kvPair.Key)).Should().Be(Convert.ToUInt64(kvPair.Value));
+                        Convert.ToUInt64(md.GetValue(kvPair.Key)).ShouldBe(Convert.ToUInt64(kvPair.Value));
                         break;
                     case "sbyteVal":
                     case "shortVal":
                     case "intVal":
                     case "longVal":
-                        Convert.ToInt64(md.GetValue(kvPair.Key)).Should().Be(Convert.ToInt64(kvPair.Value));
+                        Convert.ToInt64(md.GetValue(kvPair.Key)).ShouldBe(Convert.ToInt64(kvPair.Value));
                         break;
                     case "boolVal":
-                        md.GetBoolean(kvPair.Key).Should().Be((bool) kvPair.Value!);
+                        md.GetBoolean(kvPair.Key).ShouldBe((bool) kvPair.Value!);
                         break;
                     case "stringVal":
-                        md.GetString(kvPair.Key).Should().Be((string) kvPair.Value!);
+                        md.GetString(kvPair.Key).ShouldBe((string) kvPair.Value!);
                         break;
                     case "floatVal":
-                        md.GetFloat(kvPair.Key).Should().BeApproximately((float) kvPair.Value!, 0.0000000001f);
+                        md.GetFloat(kvPair.Key).ShouldBe((float) kvPair.Value!, 0.0000000001f);
                         break;
                     case "doubleVal":
-                        md.GetDouble(kvPair.Key).Should().BeApproximately((double) kvPair.Value!, 0.00001);
+                        md.GetDouble(kvPair.Key).ShouldBe((double) kvPair.Value!, 0.00001);
                         break;
                     case "dateTimeOffset":
-                        md.GetDate(kvPair.Key).Should().Be((DateTimeOffset) kvPair.Value!);
+                        md.GetDate(kvPair.Key).ShouldBe((DateTimeOffset) kvPair.Value!);
                         break;
                     case "array":
-                        md.GetArray(kvPair.Key).Should().BeEquivalentTo(new MutableArrayObject((List<int>) kvPair.Value!));
-                        md.GetValue(kvPair.Key).Should().BeEquivalentTo(new MutableArrayObject((List<int>) kvPair.Value!));
+                        md.GetArray(kvPair.Key).ShouldBeEquivalentTo(new MutableArrayObject((List<int>) kvPair.Value!));
+                        md.GetValue(kvPair.Key).ShouldBeEquivalentTo(new MutableArrayObject((List<int>) kvPair.Value!));
                         break;
                     case "dictionary":
-                        md.GetDictionary(kvPair.Key).Should().BeEquivalentTo(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
-                        md.GetValue(kvPair.Key).Should().BeEquivalentTo(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
+                        md.GetDictionary(kvPair.Key).ShouldBeEquivalentTo(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
+                        md.GetValue(kvPair.Key).ShouldBeEquivalentTo(new MutableDictionaryObject((Dictionary<string, object?>) kvPair.Value!));
                         break;
                     case "blob":
-                        md.GetBlob(kvPair.Key).Should().BeNull("Because we are getting a dictionary represents Blob object back.");
+                        md.GetBlob(kvPair.Key).ShouldBeNull("Because we are getting a dictionary represents Blob object back.");
                         var di = ((MutableDictionaryObject?) md.GetValue(kvPair.Key))!.ToDictionary();
-                        Blob.IsBlob(di).Should().BeTrue();
-                        di.Should().BeEquivalentTo(((Blob) dic[kvPair.Key]!).JsonRepresentation);
+                        Blob.IsBlob(di).ShouldBeTrue();
+                        di.ShouldBeEquivalentTo(((Blob) dic[kvPair.Key]!).JsonRepresentation);
                         break;
                     default:
                         throw new Exception("This should not happen because all test input values are CBL supported values.");
@@ -244,25 +243,25 @@ namespace Test
         internal void ValidateToJsonValues(string json, Dictionary<string, object?> dic)
         {
             var jdic = DataOps.ParseTo<Dictionary<string, object>>(json);
-            jdic.Should().NotBeNull("because otherwise DataOps.ParseTo failed");
+            jdic.ShouldNotBeNull("because otherwise DataOps.ParseTo failed");
             foreach (var i in dic) {
                 if (i.Key == "blob") {
                     var b1JsonD = ((JObject) jdic![i.Key]).ToObject<IDictionary<string, object?>>();
-                    b1JsonD.Should().NotBeNull("because otherwise ToObject failed");
+                    b1JsonD.ShouldNotBeNull("because otherwise ToObject failed");
                     var b2JsonD = ((Blob?) dic[i.Key])!.JsonRepresentation;
 
                     foreach (var kv in b2JsonD) {
                         var hasValue = b1JsonD!.TryGetValue(kv.Key, out var gotValue);
-                        hasValue.Should().BeTrue("because otherwise b1JsonD is missing the key {key}", kv.Key);
-                        gotValue!.ToString().Should().Be(kv.Value?.ToString());
+                        hasValue.ShouldBeTrue($"because otherwise b1JsonD is missing the key {kv.Key}");
+                        gotValue!.ToString().ShouldBe(kv.Value?.ToString());
                     }
 
                     var blob = new Blob(Db!, b1JsonD!);
-                    blob.Should().BeEquivalentTo((Blob) dic[i.Key]!);
+                    blob.ShouldBeEquivalentTo((Blob) dic[i.Key]!);
                 } else if (i.Key == "floatVal") {
-                    (DataOps.ConvertToFloat(jdic![i.Key])).Should().BeApproximately((float) dic[i.Key]!, 0.0000000001f);
+                    (DataOps.ConvertToFloat(jdic![i.Key])).ShouldBe((float) dic[i.Key]!, 0.0000000001f);
                 } else {
-                    (DataOps.ToCouchbaseObject(jdic![i.Key])).Should().BeEquivalentTo((DataOps.ToCouchbaseObject(dic[i.Key])));
+                    (DataOps.ToCouchbaseObject(jdic![i.Key])).ShouldBeEquivalentTo((DataOps.ToCouchbaseObject(dic[i.Key])));
                 }
             }
         }
@@ -410,7 +409,7 @@ namespace Test
             foreach (var pair in dic1) {
                 var second = dic2.FirstOrDefault(x => x.Key.Equals(pair.Key, StringComparison.Ordinal));
                 if (String.CompareOrdinal(pair.Key, second.Key) != 0) {
-                    throw new AssertionFailedException(
+                    throw new ShouldAssertException(
                         $"Expected a dictionary to contain the key {pair.Key} but it didn't");
                 }
 
@@ -531,20 +530,20 @@ namespace Test
                 });
 
                 wa.WaitForResult(TimeSpan.FromSeconds(2));
-                count.Should().Be(1, "because we should have received a callback");
+                count.ShouldBe(1, "because we should have received a callback");
                 AddPersonInState("after1", "AL", isLegacy: isLegacy);
                 Thread.Sleep(2000);
-                count.Should().Be(1, "because we should not receive a callback since AL is not part of query result");
+                count.ShouldBe(1, "because we should not receive a callback since AL is not part of query result");
                 AddPersonInState("after2", "CA", isLegacy: isLegacy);
                 wa2.WaitForResult(TimeSpan.FromSeconds(2));
-                count.Should().Be(2, "because we should have received a callback, query result has updated");
+                count.ShouldBe(2, "because we should have received a callback, query result has updated");
                 if(isLegacy)
                     DefaultCollection.Purge("after2");
                 else
                     CollA.Purge("after2");
 
                 wa3.WaitForResult(TimeSpan.FromSeconds(2));
-                count.Should().Be(3, "because we should have received a callback, query result has updated");
+                count.ShouldBe(3, "because we should have received a callback, query result has updated");
             }
         }
 
@@ -579,13 +578,13 @@ namespace Test
                 });
 
                 foreach (var handle in new[] { wait1, wait2 }) {
-                    handle.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+                    handle.Wait(TimeSpan.FromSeconds(2)).ShouldBeTrue();
                 }
 
-                qCount.Should().Be(1, "because we should have received a callback");
-                qResultCnt.Should().Be(8);
-                q1Count.Should().Be(1, "because we should have received a callback");
-                q1ResultCnt.Should().Be(8);
+                qCount.ShouldBe(1, "because we should have received a callback");
+                qResultCnt.ShouldBe(8);
+                q1Count.ShouldBe(1, "because we should have received a callback");
+                q1ResultCnt.ShouldBe(8);
                 q2.AddChangeListener(null, (sender, args) =>
                 {
                     q2Count++;
@@ -596,7 +595,7 @@ namespace Test
                 });
 
                 wa2.WaitForResult(TimeSpan.FromSeconds(2));
-                q2Count.Should().Be(1, "because we should have received a callback");
+                q2Count.ShouldBe(1, "because we should have received a callback");
             }
         }
 
@@ -621,12 +620,12 @@ namespace Test
             });
 
             wa.WaitForResult(TimeSpan.FromSeconds(2));
-            count.Should().Be(1, "because we should have received a callback");
+            count.ShouldBe(1, "because we should have received a callback");
             qParameters.SetString("state", "NY");
             query.Parameters = qParameters;
             //query.Parameters.SetString("state", "NY"); //This works as well
             wa2.WaitForResult(TimeSpan.FromSeconds(2));
-            count.Should().Be(2, "because we should have received a callback, query result has updated");
+            count.ShouldBe(2, "because we should have received a callback, query result has updated");
         }
 
         protected void LoadJSONResource(string resourceName, Database? db = null, Collection? coll = null)
@@ -641,7 +640,7 @@ namespace Test
                 {
                     var docID = $"doc-{++n:D3}";
                     var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(line);
-                    json.Should().NotBeNull("because otherwise the line failed to parse");
+                    json.ShouldNotBeNull("because otherwise the line failed to parse");
                     var doc = new MutableDocument(docID);
                     doc.SetData(json!);
                     if(coll == null)

--- a/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/URLEndpointListenerTest.cs
@@ -36,7 +36,7 @@ using Couchbase.Lite;
 using Couchbase.Lite.P2P;
 using Couchbase.Lite.Sync;
 
-using FluentAssertions;
+using Shouldly;
 using LiteCore.Interop;
 using System.Runtime.InteropServices;
 
@@ -107,11 +107,11 @@ namespace Test
             //init and start a listener
             _listener = CreateListener(false);
             //In order to get the test to pass on Linux, temp modify to this:
-            _listener.Port.Should().BeGreaterThan(0);
-            //_listener.Port.Should().Be(WsPort);
+            _listener.Port.ShouldBeGreaterThan((ushort)0);
+            //_listener.Port.ShouldBe(WsPort);
             //stop the listener
             _listener.Stop();
-            _listener.Port.Should().Be(0, "Listener's port should be 0 because the listener is stopped.");
+            _listener.Port.ShouldBe((ushort)0, "Listener's port should be 0 because the listener is stopped.");
         }
 
         [Fact]
@@ -121,11 +121,11 @@ namespace Test
             var config = CreateListenerConfig(false);
             _listener = Listen(config, 0, 0);
 
-            _listener.Port.Should().NotBe(0, "Because the port is dynamically assigned.");
+            _listener.Port.ShouldNotBe((ushort)0, "Because the port is dynamically assigned.");
 
             //stop the listener
             _listener.Stop();
-            _listener.Port.Should().Be(0, "Listener's port should be 0 because the listener is stopped.");
+            _listener.Port.ShouldBe((ushort)0, "Listener's port should be 0 because the listener is stopped.");
         }
 
         [Fact]
@@ -146,15 +146,15 @@ namespace Test
         {
             // TLS is disabled
             _listener = CreateListener(false);
-            _listener.TlsIdentity.Should().BeNull();
+            _listener.TlsIdentity.ShouldBeNull();
             _listener.Stop();
-            _listener.TlsIdentity.Should().BeNull();
+            _listener.TlsIdentity.ShouldBeNull();
 
             // Anonymous Identity
             _listener = CreateListener(true);
-            _listener.TlsIdentity.Should().NotBeNull();
+            _listener.TlsIdentity.ShouldNotBeNull();
             _listener.Stop();
-            _listener.TlsIdentity.Should().BeNull();
+            _listener.TlsIdentity.ShouldBeNull();
 
             // User Identity
             TLSIdentity.DeleteIdentity(_store, ServerCertLabel, null);
@@ -166,12 +166,12 @@ namespace Test
                 null);
             var config = CreateListenerConfig(true, true, null, id);
             _listener = new URLEndpointListener(config);
-            _listener.TlsIdentity.Should().BeNull();
+            _listener.TlsIdentity.ShouldBeNull();
             _listener.Start();
-            _listener.TlsIdentity.Should().NotBeNull();
-            _listener.TlsIdentity.Should().BeEquivalentTo(config.TlsIdentity);
+            _listener.TlsIdentity.ShouldNotBeNull();
+            _listener.TlsIdentity.ShouldBeEquivalentTo(config.TlsIdentity);
             _listener.Stop();
-            _listener.TlsIdentity.Should().BeNull();
+            _listener.TlsIdentity.ShouldBeNull();
         }
 
         [Fact]
@@ -179,9 +179,10 @@ namespace Test
         {
             _listener = CreateListener(false);
 
-            _listener.Urls.Should().HaveCountGreaterThan(0);
+            _listener.Urls.ShouldNotBeNull();
+            _listener.Urls.Count.ShouldBeGreaterThan(0);
             _listener.Stop();
-            _listener.Urls.Should().HaveCount(0);
+            _listener.Urls.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -194,8 +195,8 @@ namespace Test
             _listener = CreateListener(false);
 
             //listener is started at this point
-            _listener.Status.ConnectionCount.Should().Be(0, "Listener's connection count should be 0 because no client connection has been established.");
-            _listener.Status.ActiveConnectionCount.Should().Be(0, "Listener's active connection count should be 0 because no client connection has been established.");
+            _listener.Status.ConnectionCount.ShouldBe(0UL, "Listener's connection count should be 0 because no client connection has been established.");
+            _listener.Status.ActiveConnectionCount.ShouldBe(0UL, "Listener's active connection count should be 0 because no client connection has been established.");
 
             using (var doc1 = new MutableDocument())
             using (var doc2 = new MutableDocument()) {
@@ -241,13 +242,13 @@ namespace Test
                 }
             }
 
-            maxConnectionCount.Should().Be(1);
-            maxActiveCount.Should().Be(1);
+            maxConnectionCount.ShouldBe(1UL);
+            maxActiveCount.ShouldBe(1UL);
 
             //stop the listener
             _listener.Stop();
-            _listener.Status.ConnectionCount.Should().Be(0, "Listener's connection count should be 0 because the connection is stopped.");
-            _listener.Status.ActiveConnectionCount.Should().Be(0, "Listener's active connection count should be 0 because the connection is stopped.");
+            _listener.Status.ConnectionCount.ShouldBe(0UL, "Listener's connection count should be 0 because the connection is stopped.");
+            _listener.Status.ActiveConnectionCount.ShouldBe(0UL, "Listener's active connection count should be 0 because the connection is stopped.");
         }
 
         [Fact]
@@ -320,7 +321,7 @@ namespace Test
                 _store,
                 ClientCertLabel,
                 null);
-            id.Should().NotBeNull();
+            id.ShouldNotBeNull();
 
             RunReplication(
                 _listener.LocalEndpoint(),
@@ -382,7 +383,7 @@ namespace Test
                 ClientCertLabel,
                 null);
 
-            id.Should().NotBeNull();
+            id.ShouldNotBeNull();
             RunReplication(
                 _listener.LocalEndpoint(),
                 ReplicatorType.PushAndPull,
@@ -458,14 +459,14 @@ namespace Test
             var config = CreateListenerConfig(true, true, null, id);
             _listener = Listen(config);
 
-            _listener.TlsIdentity.Should().NotBeNull();
+            _listener.TlsIdentity.ShouldNotBeNull();
 
             using (var doc1 = new MutableDocument("doc1")) {
                 doc1.SetString("name", "Sam");
                 DefaultCollection.Save(doc1);
             }
 
-            OtherDefaultCollection.Count.Should().Be(0);
+            OtherDefaultCollection.Count.ShouldBe(0UL);
 
             RunReplication(
                 _listener.LocalEndpoint(),
@@ -478,7 +479,7 @@ namespace Test
                 0
             );
 
-            OtherDefaultCollection.Count.Should().Be(1);
+            OtherDefaultCollection.Count.ShouldBe(1UL);
 
             _listener.Stop();
         }
@@ -487,9 +488,9 @@ namespace Test
         public void TestAcceptSelfSignedCertWithPinnedCertificate()
         {
             _listener = CreateListener();
-            _listener.TlsIdentity.Should()
-                .NotBeNull("because otherwise the TLS identity was not created for the listener");
-            _listener.TlsIdentity!.Certs.Should().HaveCount(1,
+            _listener.TlsIdentity
+                .ShouldNotBeNull("because otherwise the TLS identity was not created for the listener");
+            _listener.TlsIdentity!.Certs.Count.ShouldBe(1,
                 "because otherwise bogus certs were used");
 
             // listener = cert1; replicator.pin = cert2; acceptSelfSigned = true => fail
@@ -523,9 +524,9 @@ namespace Test
         public void TestAcceptOnlySelfSignedCertMode()
         {
             _listener = CreateListener();
-            _listener.TlsIdentity.Should()
-                .NotBeNull("because otherwise the TLS identity was not created for the listener");
-            _listener.TlsIdentity!.Certs.Count.Should().Be(1,
+            _listener.TlsIdentity
+                .ShouldNotBeNull("because otherwise the TLS identity was not created for the listener");
+            _listener.TlsIdentity!.Certs.Count.ShouldBe(1,
                 "because otherwise bogus certs were used");
 
             DisableDefaultServerCertPinning = true;
@@ -560,9 +561,9 @@ namespace Test
         public void TestDoNotAcceptSelfSignedMode() //aka testPinnedServerCertificate in iOS
         {
             _listener = CreateListener();
-            _listener.TlsIdentity.Should()
-                .NotBeNull("because otherwise the TLS identity was not created for the listener");
-            _listener.TlsIdentity!.Certs.Count.Should().Be(1,
+            _listener.TlsIdentity
+                .ShouldNotBeNull("because otherwise the TLS identity was not created for the listener");
+            _listener.TlsIdentity!.Certs.Count.ShouldBe(1,
                 "because otherwise bogus certs were used");
 
             DisableDefaultServerCertPinning = true;
@@ -662,7 +663,7 @@ namespace Test
             );
 
             listener2.Stop();
-            OtherDefaultCollection.Count.Should().Be(2);
+            OtherDefaultCollection.Count.ShouldBe(2UL);
         }
 
 #if !SANITY_ONLY
@@ -718,15 +719,15 @@ namespace Test
 
             repl1.Start();
             repl2.Start();
-            WaitHandle.WaitAll(new[] {wait1.WaitHandle, wait2.WaitHandle}, TimeSpan.FromSeconds(20))
-                .Should().BeTrue();
+            WaitAssert.WaitAll([wait1, wait2], TimeSpan.FromSeconds(20))
+                .ShouldBeTrue();
 
             token1.Remove();
             token2.Remove();
 
-            DefaultCollection.Count.Should().Be(3, "because otherwise not all docs were received into Db");
-            OtherDefaultCollection.Count.Should().Be(3, "because otherwise not all docs were received into OtherDb");
-            urlepTestDb.GetDefaultCollection().Count.Should().Be(3, "because otherwise not all docs were received into urlepTestDb");
+            DefaultCollection.Count.ShouldBe(3UL, "because otherwise not all docs were received into Db");
+            OtherDefaultCollection.Count.ShouldBe(3UL, "because otherwise not all docs were received into OtherDb");
+            urlepTestDb.GetDefaultCollection().Count.ShouldBe(3UL, "because otherwise not all docs were received into urlepTestDb");
             
             repl1.Dispose();
             repl2.Dispose();
@@ -766,8 +767,8 @@ namespace Test
         {
             Listen(CreateListenerConfig(false));
             OtherDb.Close();
-            _listener.Port.Should().Be(0);
-            _listener.Urls.Should().BeEmpty();
+            _listener.Port.ShouldBe((ushort)0);
+            _listener.Urls.ShouldBeEmpty();
         }
 
         [Fact]
@@ -858,14 +859,15 @@ namespace Test
                 repl.Start();
 
                 // Wait until idle then stop the listener
-                waitIdleAssert.Wait(TimeSpan.FromSeconds(15)).Should().BeTrue();
+                waitIdleAssert.Wait(TimeSpan.FromSeconds(15)).ShouldBeTrue();
 
                 // Wait for the replicator to be stopped
-                waitStoppedAssert.Wait(TimeSpan.FromSeconds(20)).Should().BeTrue();
+                waitStoppedAssert.Wait(TimeSpan.FromSeconds(20)).ShouldBeTrue();
 
                 // Check error
-                var error = repl.Status.Error.As<CouchbaseWebsocketException>();
-                ((int)error.Error).Should().Be((int)CouchbaseLiteError.WebSocketGoingAway);
+                var error = repl.Status.Error as CouchbaseWebsocketException;
+                error.ShouldNotBeNull();
+                ((int)error.Error).ShouldBe((int)CouchbaseLiteError.WebSocketGoingAway);
             }
         }
         
@@ -918,7 +920,7 @@ namespace Test
                 Port = 0,
                 DisableTLS = true
             };
-            badAct.Should().Throw<CouchbaseLiteException>().WithMessage("The given collections must not be null or empty.");
+            Should.Throw<CouchbaseLiteException>(badAct).Message.ShouldBe("The given collections must not be null or empty.");
         }
 
         #endregion
@@ -967,10 +969,10 @@ namespace Test
                 RunReplication(replConfig, 0, 0);
 
                 // Check docs are replicated between collections colADb & colAOtherDb
-                colAOtherDb.GetDocument("doc")?.GetString("str").Should().Be("string");
-                colAOtherDb.GetDocument("doc1")?.GetString("str1").Should().Be("string1");
-                colADb.GetDocument("doc2")?.GetString("str2").Should().Be("string2");
-                colADb.GetDocument("doc3")?.GetString("str3").Should().Be("string3");
+                colAOtherDb.GetDocument("doc")?.GetString("str").ShouldBe("string");
+                colAOtherDb.GetDocument("doc1")?.GetString("str1").ShouldBe("string1");
+                colADb.GetDocument("doc2")?.GetString("str2").ShouldBe("string2");
+                colADb.GetDocument("doc3")?.GetString("str3").ShouldBe("string3");
                 
                 listener.Stop();
             }
@@ -1010,8 +1012,8 @@ namespace Test
             _listener = CreateListener(false);
             var listener2 = CreateNewListener();
 
-            _listener.Config.Collections[0].Database.ActiveStoppables.Count.Should().Be(2);
-            listener2.Config.Collections[0].Database.ActiveStoppables.Count.Should().Be(2);
+            _listener.Config.Collections[0].Database.ActiveStoppables.Count.ShouldBe(2);
+            listener2.Config.Collections[0].Database.ActiveStoppables.Count.ShouldBe(2);
 
             using (var doc1 = new MutableDocument("doc1"))
             using (var doc2 = new MutableDocument("doc2")) {
@@ -1037,7 +1039,7 @@ namespace Test
             repl1.Start();
 
             waitIdleAssert1.WaitForResult(TimeSpan.FromSeconds(10));
-            OtherDb.ActiveStoppables.Count.Should().Be(3);
+            OtherDb.ActiveStoppables.Count.ShouldBe(3);
 
             if (isCloseNotDelete) {
                 OtherDb.Close();
@@ -1045,8 +1047,8 @@ namespace Test
                 OtherDb.Delete();
             }
 
-            OtherDb.ActiveStoppables.Count.Should().Be(0);
-            OtherDb.IsClosedLocked.Should().Be(true);
+            OtherDb.ActiveStoppables.Count.ShouldBe(0);
+            OtherDb.IsClosedLocked.ShouldBe(true);
 
             waitStoppedAssert1.WaitForResult(TimeSpan.FromSeconds(30));
         }
@@ -1063,7 +1065,7 @@ namespace Test
             }
 
             _listener = CreateListener();
-            _listener.Config.Collections[0].Database.ActiveStoppables.Count.Should().Be(1);
+            _listener.Config.Collections[0].Database.ActiveStoppables.Count.ShouldBe(1);
 
             using (var doc1 = new MutableDocument()) {
                 DefaultCollection.Save(doc1);
@@ -1106,11 +1108,11 @@ namespace Test
             repl1.Start();
             repl2.Start();
 
-            WaitHandle.WaitAll(new[] { waitIdleAssert1.WaitHandle, waitIdleAssert2.WaitHandle }, _timeout)
-                .Should().BeTrue();
+            WaitAssert.WaitAll([waitIdleAssert1, waitIdleAssert2], _timeout)
+                .ShouldBeTrue();
 
-            OtherDb.ActiveStoppables.Count.Should().Be(2);
-            urlepTestDb.ActiveStoppables.Count.Should().Be(1);
+            OtherDb.ActiveStoppables.Count.ShouldBe(2);
+            urlepTestDb.ActiveStoppables.Count.ShouldBe(1);
 
             if (isCloseNotDelete) {
                 urlepTestDb.Close();
@@ -1120,13 +1122,13 @@ namespace Test
                 OtherDb.Delete();
             }
 
-            OtherDb.ActiveStoppables.Count.Should().Be(0, "because OtherDb's active items should all be stopped");
-            urlepTestDb.ActiveStoppables.Count.Should().Be(0, "because urlepTestDb's active items should all be stopped");
-            OtherDb.IsClosedLocked.Should().Be(true);
-            urlepTestDb.IsClosedLocked.Should().Be(true);
+            OtherDb.ActiveStoppables.Count.ShouldBe(0, "because OtherDb's active items should all be stopped");
+            urlepTestDb.ActiveStoppables.Count.ShouldBe(0, "because urlepTestDb's active items should all be stopped");
+            OtherDb.IsClosedLocked.ShouldBe(true);
+            urlepTestDb.IsClosedLocked.ShouldBe(true);
 
-            WaitHandle.WaitAll(new[] { waitStoppedAssert1.WaitHandle, waitStoppedAssert2.WaitHandle }, TimeSpan.FromSeconds(20))
-                .Should().BeTrue();
+            WaitAssert.WaitAll([waitStoppedAssert1, waitStoppedAssert2], TimeSpan.FromSeconds(20))
+                .ShouldBeTrue();
 
             waitIdleAssert1.Dispose();
             waitIdleAssert2.Dispose();
@@ -1145,9 +1147,9 @@ namespace Test
             // this show an active count of zero.
             ulong maxConnectionCount = 0UL;
 
-            _listener.Should().NotBeNull();
+            _listener.ShouldNotBeNull();
             var existingDocsInListener = _listener!.Config.Collections[0].Count;
-            existingDocsInListener.Should().Be(1);
+            existingDocsInListener.ShouldBe(1UL);
 
             using (var doc1 = new MutableDocument()) {
                 DefaultCollection.Save(doc1);
@@ -1175,8 +1177,8 @@ namespace Test
             using var stopped2 = new ManualResetEventSlim();
 
             // Grab these now to avoid a race condition between Set() and WaitHandle side effect
-            var busyHandles = new[] { busy1.WaitHandle, busy2.WaitHandle };
-            var stoppedHandles = new[] { stopped1.WaitHandle, stopped2.WaitHandle };
+            var busyHandles = new[] { busy1, busy2 };
+            var stoppedHandles = new[] { stopped1, stopped2 };
             EventHandler<ReplicatorStatusChangedEventArgs> changeListener = (sender, args) =>
             {
                 var senderIsRepl1 = sender == repl1;
@@ -1221,26 +1223,26 @@ namespace Test
             repl1.Start();
             repl2.Start();
 
-            WaitHandle.WaitAll(busyHandles, TimeSpan.FromSeconds(5))
-                .Should().BeTrue("because otherwise one of the replicators never became busy");
+            WaitAssert.WaitAll(busyHandles, TimeSpan.FromSeconds(5))
+                .ShouldBeTrue("because otherwise one of the replicators never became busy");
 
-            WaitHandle.WaitAll(stoppedHandles, TimeSpan.FromSeconds(30))
-                .Should().BeTrue("because otherwise one of the replicators never stopped");
+            WaitAssert.WaitAll(stoppedHandles, TimeSpan.FromSeconds(30))
+                .ShouldBeTrue("because otherwise one of the replicators never stopped");
 
             // Depending on the whim of the divine entity, there are a number of ways in which the connections
             // can happen.  Commonly they run concurrently which results in a max connection count of 2.
             // However they can also run sequentially which means only a count of 1.
-            maxConnectionCount.Should().BeGreaterThan(0);
+            maxConnectionCount.ShouldBeGreaterThan(0UL);
 
             // all data are transferred to/from
             if (replicatorType == ReplicatorType.PushAndPull) {
-                _listener.Config.Collections[0].Count.Should().Be(existingDocsInListener + 2UL);
-                DefaultCollection.Count.Should().Be(existingDocsInListener + 2UL);
-                urlepTestDb.GetDefaultCollection().Count.Should().Be(existingDocsInListener + 2UL);
+                _listener.Config.Collections[0].Count.ShouldBe(existingDocsInListener + 2UL);
+                DefaultCollection.Count.ShouldBe(existingDocsInListener + 2UL);
+                urlepTestDb.GetDefaultCollection().Count.ShouldBe(existingDocsInListener + 2UL);
             } else if(replicatorType == ReplicatorType.Pull) {
-                _listener.Config.Collections[0].Count.Should().Be(1);
-                DefaultCollection.Count.Should().Be(existingDocsInListener + 1UL);
-                urlepTestDb.GetDefaultCollection().Count.Should().Be(existingDocsInListener + 1UL);
+                _listener.Config.Collections[0].Count.ShouldBe(1UL);
+                DefaultCollection.Count.ShouldBe(existingDocsInListener + 1UL);
+                urlepTestDb.GetDefaultCollection().Count.ShouldBe(existingDocsInListener + 1UL);
             }
 
             token1.Remove();
@@ -1268,25 +1270,25 @@ namespace Test
                     }
                 });
 
-                repl.ServerCertificate.Should().BeNull();
+                repl.ServerCertificate.ShouldBeNull();
                 repl.Start();
 
                 if (hasIdle) {
-                    waitIdle.Wait(_timeout).Should().BeTrue();
+                    waitIdle.Wait(_timeout).ShouldBeTrue();
                     if (serverCert == null) {
-                        repl.ServerCertificate.Should().BeNull();
+                        repl.ServerCertificate.ShouldBeNull();
                     } else {
-                        serverCert.Thumbprint.Should().Be(repl.ServerCertificate?.Thumbprint);
+                        serverCert.Thumbprint.ShouldBe(repl.ServerCertificate?.Thumbprint);
                     }
 
                     repl.Stop();
                 }
 
-                waitStopped.Wait(_timeout).Should().BeTrue();
+                waitStopped.Wait(_timeout).ShouldBeTrue();
                 if (serverCert == null) {
-                    repl.ServerCertificate.Should().BeNull();
+                    repl.ServerCertificate.ShouldBeNull();
                 } else {
-                    serverCert.Thumbprint.Should().Be(repl.ServerCertificate?.Thumbprint);
+                    serverCert.Thumbprint.ShouldBe(repl.ServerCertificate?.Thumbprint);
                 }
             }
         }
@@ -1365,11 +1367,12 @@ namespace Test
 
             _listener = new URLEndpointListener(config);
 
-            _listener.Port.Should().Be(0, "Listener's port should be 0 because the listener has not yet started.");
-            _listener.Urls.Should().HaveCount(0, "Listener's Urls count should be 0 because the listener has not yet started.");
-            _listener.TlsIdentity.Should().BeNull("Listener's TlsIdentity should be null because the listener has not yet started.");
-            _listener.Status.ConnectionCount.Should().Be(0, "Listener's connection count should be 0 because the listener has not yet started.");
-            _listener.Status.ActiveConnectionCount.Should().Be(0, "Listener's active connection count should be 0 because the listener has not yet started.");
+            _listener.Port.ShouldBe((ushort)0, "Listener's port should be 0 because the listener has not yet started.");
+            _listener.Urls.ShouldNotBeNull();
+            _listener.Urls.Count.ShouldBe(0, "Listener's Urls count should be 0 because the listener has not yet started.");
+            _listener.TlsIdentity.ShouldBeNull("Listener's TlsIdentity should be null because the listener has not yet started.");
+            _listener.Status.ConnectionCount.ShouldBe(0UL, "Listener's connection count should be 0 because the listener has not yet started.");
+            _listener.Status.ActiveConnectionCount.ShouldBe(0UL, "Listener's active connection count should be 0 because the listener has not yet started.");
 
             try {
                 _listener.Start();
@@ -1378,22 +1381,22 @@ namespace Test
                     throw;
                 }
 
-                e.Domain.Should().Be(expectedErrDomain);
-                ((int)e.Error).Should().Be(expectedErrCode); 
+                e.Domain.ShouldBe(expectedErrDomain);
+                ((int)e.Error).ShouldBe(expectedErrCode); 
             } catch (CouchbaseNetworkException ne) {
                 if (expectedErrCode == 0) {
                     throw;
                 }
 
-                ne.Domain.Should().Be(expectedErrDomain);
-                ((int)ne.Error).Should().Be(expectedErrCode);
+                ne.Domain.ShouldBe(expectedErrDomain);
+                ((int)ne.Error).ShouldBe(expectedErrCode);
             } catch (CouchbasePosixException pe) {
                 if (expectedErrCode == 0) {
                     throw;
                 }
 
-                pe.Domain.Should().Be(expectedErrDomain);
-                pe.Error.Should().Be(expectedErrCode);
+                pe.Domain.ShouldBe(expectedErrDomain);
+                pe.Error.ShouldBe(expectedErrCode);
             }
 
             return _listener;

--- a/src/Couchbase.Lite.Tests.Shared/Util/Try.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/Try.cs
@@ -21,8 +21,6 @@ using System;
 using System.Reflection;
 using System.Threading;
 
-using FluentAssertions.Execution;
-
 using Xunit.Sdk;
 
 namespace Test.Util

--- a/src/Couchbase.Lite.Tests.Shared/Util/WaitAssert.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/WaitAssert.cs
@@ -19,42 +19,47 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Couchbase.Lite
 {
-    public sealed class WaitAssert
+    public sealed class WaitAssert : IDisposable
     {
-        private ManualResetEvent _mre = new ManualResetEvent(false);
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
         private Exception _caughtException;
 
         public IList<Exception> CaughtExceptions { get; } = new List<Exception>();
 
-        public static void WaitFor(TimeSpan timeout, params WaitAssert[] asserts)
+        public static bool WaitAll(IEnumerable<ManualResetEventSlim> handles, TimeSpan timeout)
         {
-            // .NET 4.6.2 has issues with WaitHandle.WaitAll, so sort of simulate it
-            // by giving the first wait handle the full wait time and then subtracting
-            // the runtime and giving the remainder to the next, etc
-            var handles = asserts.Select(x => x._mre).ToArray();
-            if (handles.Length == 0) {
-                return;
+            bool allSignaled = false;
+            if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA) {
+                // STA thread workaround
+                var startTime = DateTime.Now;
+                while (DateTime.Now - startTime < timeout) {
+                    if(handles.All(h => h.IsSet)) { 
+                        allSignaled = true;
+                        break;
+                    }
+                    Thread.Sleep(100);
+                }
+            } else {
+                // MTA thread can use WaitAll directly
+                allSignaled = WaitHandle.WaitAll(
+                    handles.Select(x => x.WaitHandle).ToArray(),
+                    TimeSpan.FromSeconds(20)
+                );
             }
 
-            var timeLeft = timeout;
-            foreach (var handle in handles) {
-                if (timeLeft <= TimeSpan.Zero) {
-                    throw new TimeoutException("Timeout waiting for array of WaitAsserts");
-                }
+            return allSignaled;
+        }
 
-                var sw = Stopwatch.StartNew();
-                if (!handle.WaitOne(timeLeft)) {
-                    throw new TimeoutException("Timeout waiting for array of WaitAsserts");
-                }
-                sw.Stop();
-                timeLeft -= sw.Elapsed;
+        public static void WaitFor(TimeSpan timeout, params WaitAssert[] asserts)
+        {
+            if(!WaitAll(asserts.Select(x => x._mre), timeout)) {
+                throw new TimeoutException("Timeout waiting for array of WaitAsserts");
             }
         }
 
@@ -115,13 +120,18 @@ namespace Couchbase.Lite
 
         public void WaitForResult(TimeSpan timeout)
         {
-            if (!_mre.WaitOne(timeout)) {
+            if (!_mre.Wait(timeout)) {
                 throw new TimeoutException("Timeout waiting for WaitAssert");
             }
 
             if (_caughtException != null) {
                 throw _caughtException;
             }
+        }
+
+        public void Dispose()
+        {
+            _mre.Dispose();
         }
     }
 }

--- a/src/Couchbase.Lite.Tests.Shared/Util/WaitAssert.cs
+++ b/src/Couchbase.Lite.Tests.Shared/Util/WaitAssert.cs
@@ -49,7 +49,7 @@ namespace Couchbase.Lite
                 // MTA thread can use WaitAll directly
                 allSignaled = WaitHandle.WaitAll(
                     handles.Select(x => x.WaitHandle).ToArray(),
-                    TimeSpan.FromSeconds(20)
+                    timeout
                 );
             }
 

--- a/src/Couchbase.Lite.Tests.Shared/VersionVectorTests.cs
+++ b/src/Couchbase.Lite.Tests.Shared/VersionVectorTests.cs
@@ -17,7 +17,7 @@
 // 
 
 using Couchbase.Lite;
-using FluentAssertions;
+using Shouldly;
 using LiteCore.Interop;
 using System.Xml.Linq;
 using Xunit;
@@ -48,16 +48,16 @@ public sealed class VersionVectorTest : TestCase
     ///     5. Get the document id = "doc1" from the database.
     ///     6. Get document's timestamp and check that the timestamp is the same as the timestamp from step 4.
     /// </summary>
-    [Fact]
+    [Fact(Skip = "Version vectors not turned on yet")]
     public void TestDocumentTimestamp()
     {
         using var doc = new MutableDocument("doc1");
-        doc.Timestamp.Should().BeNull("because the doc has not been saved yet");
+        doc.Timestamp.ShouldBeNull("because the doc has not been saved yet");
         DefaultCollection.Save(doc);
-        doc.Timestamp.Should().NotBeNull("because the doc is now saved");
+        doc.Timestamp.ShouldNotBeNull("because the doc is now saved");
         using var savedDoc = DefaultCollection.GetDocument("doc1");
-        savedDoc.Should().NotBeNull("because the document was just saved");
-        savedDoc!.Timestamp.Should().Be(doc.Timestamp, "because the timestamp should not change just from a read");
+        savedDoc.ShouldNotBeNull("because the document was just saved");
+        savedDoc!.Timestamp.ShouldBe(doc.Timestamp, "because the timestamp should not change just from a read");
     }
 
     /// <summary>
@@ -72,17 +72,17 @@ public sealed class VersionVectorTest : TestCase
     ///     5. Get the document id = "doc1" from the database.
     ///     6. Get document's _revisionIDs and check that the value returned is not null
     /// </summary>
-    [Fact]
+    [Fact(Skip = "Version vectors not turned on yet")]
     public void TestDocumentRevisionHistory()
     {
         using var doc = new MutableDocument("doc1");
-        doc.RevisionIDs().Should().BeNull("because the document has not been saved yet");
+        doc.RevisionIDs().ShouldBeNull("because the document has not been saved yet");
         DefaultCollection.Save(doc);
-        doc.RevisionIDs().Should().NotBeNull("because now the document has been saved");
+        doc.RevisionIDs().ShouldNotBeNull("because now the document has been saved");
         using var savedDoc = DefaultCollection.GetDocument("doc1");
-        savedDoc.Should().NotBeNull("because the document was just saved");
+        savedDoc.ShouldNotBeNull("because the document was just saved");
 
-        savedDoc!.RevisionIDs().Should().NotBeNull("because the saved document should contain at least one revision ID");
+        savedDoc!.RevisionIDs().ShouldNotBeNull("because the saved document should contain at least one revision ID");
     }
 
     public enum DefaultConflictLWWMode
@@ -110,7 +110,7 @@ public sealed class VersionVectorTest : TestCase
     ///     6.Start a single shot pull replicator to pull documents from "db2" to "db1".
     ///     7. Get the document "doc2" from "db1" and check that the content is {"key": "value2"}.
     /// </summary>
-    [Theory]
+    [Theory(Skip = "Version vectors not turned on yet")]
     [InlineData(DefaultConflictLWWMode.SaveDB2First)]
     [InlineData(DefaultConflictLWWMode.SaveDB1First)]
     public void TestDefaultConflictResolver(DefaultConflictLWWMode lwwMode)
@@ -147,8 +147,8 @@ public sealed class VersionVectorTest : TestCase
         }
 
         using var doc = db1.GetDefaultCollection().GetDocument("doc1");
-        doc.Should().NotBeNull("because it was just saved");
-        doc!["key"].Value.Should().Be(expectedValue, "because otherwise the conflict resolver behaved unexpectedly");
+        doc.ShouldNotBeNull("because it was just saved");
+        doc!["key"].Value.ShouldBe(expectedValue, "because otherwise the conflict resolver behaved unexpectedly");
     }
 
     /// <summary>
@@ -168,7 +168,7 @@ public sealed class VersionVectorTest : TestCase
     ///     4.Start a single shot pull replicator to pull documents from "db2" to "db1".
     ///     5. Get the document "doc1" from "db1" and check that the returned document is null.
     /// </summary>
-    [Fact]
+    [Fact(Skip = "Version vectors not turned on yet")]
     public void TestDefaultConflictResolverDeleteWins()
     {
         Database.Delete("db1", null);
@@ -199,6 +199,6 @@ public sealed class VersionVectorTest : TestCase
         }
 
         using var finalDoc = db1.GetDefaultCollection().GetDocument("doc1");
-        finalDoc.Should().BeNull("because the deletion should win the conflict");
+        finalDoc.ShouldBeNull("because the deletion should win the conflict");
     }
 }

--- a/src/Couchbase.Lite.Tests.Shared/WebSocketTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/WebSocketTest.cs
@@ -18,7 +18,7 @@
 
 using Couchbase.Lite.DI;
 using Couchbase.Lite.Sync;
-using FluentAssertions;
+using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -79,7 +79,7 @@ namespace Test
             var method = WebSocketWrapperType.GetMethod("Base64Digest", BindingFlags.NonPublic | BindingFlags.Static);
             var res = method!.Invoke(null, new object[1] { input });
 
-            res.Should().Be("/EOfaNlb2IwudhJuOmFE3Ps9D38=");
+            res.ShouldBe("/EOfaNlb2IwudhJuOmFE3Ps9D38=");
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace Test
             var method = WebSocketWrapperType.GetMethod("CheckHeader", BindingFlags.NonPublic | BindingFlags.Static);
             var res = method!.Invoke(null, new object[4] { parser, key, expectedValue, caseSens });
 
-            res.Should().Be(false);
+            res.ShouldBe(false);
 
             parser = new HttpMessageParser("HTTP/1.1 101 Switching Protocols");
             parser.Append("Upgrade: websocket");
@@ -113,7 +113,7 @@ namespace Test
             method = WebSocketWrapperType.GetMethod("CheckHeader", BindingFlags.NonPublic | BindingFlags.Static);
             res = method!.Invoke(null, new object[4] { parser, key, expectedValue, caseSens });
 
-            res.Should().Be(true);
+            res.ShouldBe(true);
 
             key = "Upgrade";
             expectedValue = "websocket";
@@ -122,7 +122,7 @@ namespace Test
             method = WebSocketWrapperType.GetMethod("CheckHeader", BindingFlags.NonPublic | BindingFlags.Static);
             res = method!.Invoke(null, new object[4] { parser, key, expectedValue, caseSens });
 
-            res.Should().Be(true);
+            res.ShouldBe(true);
 
             key = "Sec-WebSocket-Accept";
             expectedValue = "R3ztu/aZLI+izEEtS3Ao1kzub4s=";
@@ -131,7 +131,7 @@ namespace Test
             method = WebSocketWrapperType.GetMethod("CheckHeader", BindingFlags.NonPublic | BindingFlags.Static);
             res = method!.Invoke(null, new object[4] { parser, key, expectedValue, caseSens });
 
-            res.Should().Be(true);
+            res.ShouldBe(true);
         }
     }
 }


### PR DESCRIPTION
On the way I was able to fix a few things:

- Get rid of all WaitHandle.WaitAll calls so that the .NET 4.6.2 tests stop failing because xUnit runs on STAThread threads.
- Turn off version vectors since this is 3.3.0 now