### PR TITLE
API breaking changes for 4.0

### DIFF
--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -787,7 +787,7 @@ namespace Couchbase.Lite
         {
             if (document.Collection == null) {
                 document.Collection = this;
-            } else if (document.Collection != this) {
+            } else if (!document.Collection.Equals(this)) {
                 throw new CouchbaseLiteException(C4ErrorCode.InvalidParameter,
                     "The collection being used for Save does not match the one on the document being saved (" +
                     "either it is a different collection or a collection from a different database instance).");

--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -1034,7 +1034,10 @@ namespace Couchbase.Lite
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return Name?.GetHashCode() ?? 0;
+            var hasher = Hasher.Start;
+            hasher.Add(Name);
+            hasher.Add(Scope);
+            return hasher.GetHashCode();
         }
 
         /// <inheritdoc />
@@ -1046,8 +1049,8 @@ namespace Couchbase.Lite
             if (obj is not Collection other) {
                 return false;
             }
-
-            return _c4coll != null && NativeSafe.c4coll_isValid(_c4coll)
+            
+            return IsValid == other.IsValid
                 && String.Equals(Name, other.Name, StringComparison.Ordinal)
                 && String.Equals(Scope.Name, other.Scope.Name, StringComparison.Ordinal)
                 && ReferenceEquals(Database, other.Database);

--- a/src/Couchbase.Lite.Shared/API/Database/Database.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Database.cs
@@ -368,13 +368,8 @@ namespace Couchbase.Lite
         /// <returns>scope object with the given scope name</returns>
         /// <exception cref="CouchbaseException">Thrown if an error condition is returned from LiteCore</exception>
         /// <exception cref="InvalidOperationException">Thrown if this method is called after the database is closed</exception>
-        public Scope? GetScope(string? name = _defaultScopeName)
+        public Scope? GetScope(string name = _defaultScopeName)
         {
-            // TODO: Make name non-null in 4.0
-            if (name == null) {
-                name = _defaultScopeName;
-            }
-
             using var scope = ThreadSafety.BeginLockedScope();
             CheckOpen();
             if(!NativeSafe.c4db_hasScope(c4db, name)) {
@@ -414,11 +409,8 @@ namespace Couchbase.Lite
         /// <returns>The collection with the given name and scope</returns>
         /// <exception cref="CouchbaseException">Thrown if an error condition is returned from LiteCore</exception>
         /// <exception cref="InvalidOperationException">Thrown if this method is called after the database is closed</exception>
-        public Collection? GetCollection(string name, string? scope = _defaultScopeName)
+        public Collection? GetCollection(string name, string scope = _defaultScopeName)
         {
-            // TODO: Make scope non-null in 4.0
-            scope ??= _defaultScopeName;
-
             using var threadSafetyScope = ThreadSafety.BeginLockedScope();
             CheckOpen();
             var s = scope == _defaultScopeName ? GetDefaultScope() : GetScope(scope);

--- a/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
@@ -29,9 +29,9 @@ using System.Runtime.Versioning;
 namespace Couchbase.Lite
 {
     /// <summary>
-    /// A struct containing configuration for creating or opening database data
+    /// A record containing configuration for creating or opening database data
     /// </summary>
-    public sealed class DatabaseConfiguration
+    public sealed record DatabaseConfiguration
     {
         #region Constants
 
@@ -41,7 +41,7 @@ namespace Couchbase.Lite
 
         #region Variables
 
-        private string? _directory;
+        private readonly string? _directory;
 
         #endregion
 
@@ -52,7 +52,7 @@ namespace Couchbase.Lite
         /// </summary>
         public string Directory
         {
-            get => _directory ??= Service.GetRequiredInstance<IDefaultDirectoryResolver>().DefaultDirectory();
+            get => _directory ?? Service.GetRequiredInstance<IDefaultDirectoryResolver>().DefaultDirectory();
             init => _directory = CBDebug.MustNotBeNull(WriteLog.To.Database, Tag, "Directory", value);
         }
 

--- a/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/DatabaseConfiguration.cs
@@ -41,15 +41,7 @@ namespace Couchbase.Lite
 
         #region Variables
 
-        private readonly Freezer _freezer = new Freezer();
-
         private string? _directory;
-        private bool _fullSync = Constants.DefaultDatabaseFullSync;
-        private bool _mmapEnabled = Constants.DefaultDatabaseMmapEnabled;
-
-        #if COUCHBASE_ENTERPRISE
-        private EncryptionKey? _encryptionKey;
-        #endif
 
         #endregion
 
@@ -61,7 +53,7 @@ namespace Couchbase.Lite
         public string Directory
         {
             get => _directory ??= Service.GetRequiredInstance<IDefaultDirectoryResolver>().DefaultDirectory();
-            set => _freezer.SetValue(ref _directory, CBDebug.MustNotBeNull(WriteLog.To.Database, Tag, "Directory", value));
+            init => _directory = CBDebug.MustNotBeNull(WriteLog.To.Database, Tag, "Directory", value);
         }
 
         /// <summary>
@@ -74,11 +66,7 @@ namespace Couchbase.Lite
         /// synchronous is very safe but it is also dramatically slower.
         /// </summary>
         /// <returns>A boolean representing whether or not full sync is enabled</returns>
-        public bool FullSync
-        {
-            get => _fullSync;
-            set => _freezer.SetValue(ref _fullSync, value);
-        }
+        public bool FullSync { get; init; } = Constants.DefaultDatabaseFullSync;
 
         /// <summary>
         /// Hint for enabling or disabling memory-mapped I/O. 
@@ -95,64 +83,14 @@ namespace Couchbase.Lite
             [UnsupportedOSPlatform("osx")]
             [UnsupportedOSPlatform("maccatalyst")]
 #endif
-        public bool MmapEnabled
-        {
-            get {
-                return _mmapEnabled;
-            }
-            set {
-                _freezer.SetValue(ref _mmapEnabled, value);
-            }
-        }
+        public bool MmapEnabled { get; init; } = Constants.DefaultDatabaseMmapEnabled;
 
         #if COUCHBASE_ENTERPRISE
         /// <summary>
         /// Gets or sets the encryption key to use on the database
         /// </summary>
-        public EncryptionKey? EncryptionKey
-        {
-            get => _encryptionKey;
-            set => _freezer.SetValue(ref _encryptionKey, value);
-        }
+        public EncryptionKey? EncryptionKey { get; init; }
         #endif
-
-        #endregion
-
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        public DatabaseConfiguration()
-        {
-        }
-
-
-        internal DatabaseConfiguration(bool frozen)
-        {
-            if (frozen) {
-                _freezer.Freeze("Cannot modify a DatabaseConfiguration that is currently in use");
-            }
-        }
-
-        #region Internal Methods
-
-        internal DatabaseConfiguration Freeze()
-        {
-#pragma warning disable CA1416 // Validate platform compatibility
-            var retVal = new DatabaseConfiguration
-            {
-                Directory = Directory,
-                FullSync = FullSync,
-                MmapEnabled = MmapEnabled
-            };
-#pragma warning restore CA1416 // Validate platform compatibility
-
-#if COUCHBASE_ENTERPRISE
-            retVal.EncryptionKey = EncryptionKey;
-#endif
-
-            retVal._freezer.Freeze("Cannot modify a DatabaseConfiguration that is currently in use");
-            return retVal;
-        }
 
         #endregion
     }

--- a/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
+++ b/src/Couchbase.Lite.Shared/API/Info/Defaults.cs
@@ -68,7 +68,7 @@ public static partial class Constants {
 	/// Default value for <see cref="LogFileConfiguration.MaxRotateCount" /> (1)
 	/// 1 rotated file present (2 total, including the currently active log file)
 	/// </summary>
-	public static readonly int DefaultLogFileMaxRotateCount = 1;
+	public static readonly uint DefaultLogFileMaxRotateCount = 1;
 
 	/// <summary>
 	/// Default value for <see cref="FullTextIndexConfiguration.IgnoreAccents" /> (false)

--- a/src/Couchbase.Lite.Shared/API/Log/FileLogger.cs
+++ b/src/Couchbase.Lite.Shared/API/Log/FileLogger.cs
@@ -47,16 +47,6 @@ namespace Couchbase.Lite.Logging
 
         #endregion
 
-        #region Variables
-
-        private readonly Freezer _freezer = new Freezer();
-
-        private int _maxRotateCount = Constants.DefaultLogFileMaxRotateCount;
-        private long _maxSize = Constants.DefaultLogFileMaxSize;
-        private bool _usePlaintext = Constants.DefaultLogFileUsePlaintext;
-
-        #endregion
-
         #region Properties
 
         /// <summary>
@@ -70,11 +60,7 @@ namespace Couchbase.Lite.Logging
         /// and the 'rotated')
         /// Default value is <see cref="Constants.DefaultLogFileMaxRotateCount" />
         /// </summary>
-        public int MaxRotateCount
-        {
-            get => _maxRotateCount;
-            set => _freezer.SetValue(ref _maxRotateCount, value);
-        }
+        public uint MaxRotateCount { get; init; } = Constants.DefaultLogFileMaxRotateCount;
 
         /// <summary>
         /// Gets or sets the max size of the log files in bytes.  If a log file
@@ -82,23 +68,15 @@ namespace Couchbase.Lite.Logging
         /// number is a best effort and the actual size may go over slightly.
         /// Default value is <see cref="Constants.DefaultLogFileMaxSize" />
         /// </summary>
-        public long MaxSize
-        {
-            get => _maxSize;
-            set => _freezer.SetValue(ref _maxSize, value);
-        }
+        public long MaxSize { get; init; } = Constants.DefaultLogFileMaxSize;
 
-        /// <summary>
+    /// <summary>
         /// Gets or sets whether or not to log in plaintext.  The default is
         /// to log in a binary encoded format that is more CPU and I/O friendly
         /// and enabling plaintext is not recommended in production.
         /// Default value is <see cref="Constants.DefaultLogFileUsePlaintext" />
         /// </summary>
-        public bool UsePlaintext
-        {
-            get => _usePlaintext;
-            set => _freezer.SetValue(ref _usePlaintext, value);
-        }
+        public bool UsePlaintext { get; init; } =  Constants.DefaultLogFileUsePlaintext;
 
         #endregion
 
@@ -144,17 +122,6 @@ namespace Couchbase.Lite.Logging
         }
 
         #endregion
-
-        #region Internal Methods
-
-        internal LogFileConfiguration Freeze()
-        {
-            var retVal = new LogFileConfiguration(this);
-            retVal._freezer.Freeze("Cannot modify a FileConfiguration that is currently in use");
-            return retVal;
-        }
-
-        #endregion
     }
 
     /// <summary>
@@ -186,7 +153,7 @@ namespace Couchbase.Lite.Logging
                     WriteLog.To.Database.W("Logging", "Database.Log.File.Config is now null, meaning file logging is disabled.  Log files required for product support are not being generated.");
                 }
 
-                _config = value?.Freeze();
+                _config = value;
                 UpdateConfig();
             }
         }
@@ -258,7 +225,7 @@ namespace Couchbase.Lite.Logging
                 {
                     base_path = dir.AsFLSlice(),
                     log_level = Config?.Directory == null ? C4LogLevel.None : (C4LogLevel) Level,
-                    max_rotate_count = _config?.MaxRotateCount ?? 1,
+                    max_rotate_count = (int)(_config?.MaxRotateCount ?? 1U),
                     max_size_bytes = _config?.MaxSize ?? 1024 * 500L,
                     use_plaintext = _config?.UsePlaintext ?? false,
                     header = header.AsFLSlice()

--- a/src/Couchbase.Lite.Shared/API/Query/ArrayIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/ArrayIndexConfiguration.cs
@@ -27,7 +27,7 @@ namespace Couchbase.Lite.Query;
 /// Configuration for indexing property values within nested arrays
 /// in documents, intended for use with the UNNEST query keyword.
 /// </summary>
-public sealed class ArrayIndexConfiguration : IndexConfiguration
+public sealed record ArrayIndexConfiguration : IndexConfiguration
 {
     private const string Tag = nameof(ArrayIndexConfiguration);
 

--- a/src/Couchbase.Lite.Shared/API/Query/FullTextIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/FullTextIndexConfiguration.cs
@@ -26,7 +26,7 @@ namespace Couchbase.Lite.Query
     /// <summary>
     /// An class for an index based on full text searching
     /// </summary>
-    public sealed class FullTextIndexConfiguration : IndexConfiguration
+    public sealed record FullTextIndexConfiguration : IndexConfiguration
     {
         #region Properties
 

--- a/src/Couchbase.Lite.Shared/API/Query/ValueIndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/ValueIndexConfiguration.cs
@@ -24,7 +24,7 @@ namespace Couchbase.Lite.Query
     /// <summary>
     /// An class for an index based on a simple property value
     /// </summary>
-    public sealed class ValueIndexConfiguration : IndexConfiguration
+    public sealed record ValueIndexConfiguration : IndexConfiguration
     {
         #region Properties
         internal override C4IndexOptions Options => new C4IndexOptions();

--- a/src/Couchbase.Lite.Shared/API/Sync/BasicAuthenticator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/BasicAuthenticator.cs
@@ -58,7 +58,7 @@ namespace Couchbase.Lite.Sync
         #region Constructors
 
         /// <summary>
-        /// [DEPRECATED] Constructor
+        /// Constructor
         /// </summary>
         /// <param name="username">The username to send through HTTP Basic authentication</param>
         /// <param name="password">The password to send through HTTP Basic authentication</param>

--- a/src/Couchbase.Lite.Shared/API/Sync/CollectionConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/CollectionConfiguration.cs
@@ -35,16 +35,6 @@ namespace Couchbase.Lite.Sync
 
         #endregion
 
-        #region Variables
-
-        private readonly Freezer _freezer = new Freezer();
-        private IConflictResolver _resolver = Lite.ConflictResolver.Default;
-        private Func<Document, DocumentFlags, bool>? _pushFilter;
-        private Func<Document, DocumentFlags, bool>? _pullValidator;
-        internal ReplicatorType _replicatorType = ReplicatorType.PushAndPull;
-
-        #endregion
-
         #region Properties
 
         /// <summary>
@@ -53,39 +43,21 @@ namespace Couchbase.Lite.Sync
         /// When the value is null, the default conflict resolution will be applied.
         /// The default value is <see cref="ConflictResolver.Default" />. 
         /// </summary>
-        public IConflictResolver? ConflictResolver
-        {
-            get => _resolver;
-            set 
-            { 
-                if(value == null) 
-                    _freezer.PerformAction(() => _resolver = Lite.ConflictResolver.Default);
-                else
-                    _freezer.PerformAction(() => _resolver = value); 
-            }
-        }
+        public IConflictResolver? ConflictResolver { get; init; } = Lite.ConflictResolver.Default;
 
         /// <summary>
         /// Func delegate that takes Document input parameter and bool output parameter
         /// Document pull will be allowed if output is true, othewise, Document pull 
         /// will not be allowed
         /// </summary>
-        public Func<Document, DocumentFlags, bool>? PullFilter
-        {
-            get => _pullValidator;
-            set => _freezer.PerformAction(() => _pullValidator = value);
-        }
+        public Func<Document, DocumentFlags, bool>? PullFilter { get; init; }
 
         /// <summary>
         /// Func delegate that takes Document input parameter and bool output parameter
         /// Document push will be allowed if output is true, othewise, Document push 
         /// will not be allowed
         /// </summary>
-        public Func<Document, DocumentFlags, bool>? PushFilter
-        {
-            get => _pushFilter;
-            set => _freezer.PerformAction(() => _pushFilter = value);
-        }
+        public Func<Document, DocumentFlags, bool>? PushFilter { get; init; }
 
         /// <summary>
         /// A set of Sync Gateway channel names to pull from.  Ignored for push replicatoin.
@@ -99,7 +71,7 @@ namespace Couchbase.Lite.Sync
         public IList<string>? Channels
         {
             get => Options.Channels;
-            set => _freezer.PerformAction(() => Options.Channels = value?.Any() == true ? value : null);
+            init => Options.Channels = value?.Any() == true ? value : null;
         }
 
         /// <summary>
@@ -109,20 +81,16 @@ namespace Couchbase.Lite.Sync
         public IList<string>? DocumentIDs
         {
             get => Options.DocIDs;
-            set => _freezer.PerformAction(() => Options.DocIDs = value?.Any() == true ? value : null);
+            init => Options.DocIDs = value?.Any() == true ? value : null;
         }
 
         /// <summary>
         /// A value indicating the direction of the replication.  The default is
         /// <see cref="ReplicatorType.PushAndPull"/> which is bidirectional
         /// </summary>
-        internal ReplicatorType ReplicatorType
-        {
-            get => _replicatorType;
-            set => _replicatorType = value;
-        }
+        internal ReplicatorType ReplicatorType { get; set; } = ReplicatorType.PushAndPull;
 
-        internal ReplicatorOptionsDictionary Options { get; set; } = new ReplicatorOptionsDictionary();
+        internal ReplicatorOptionsDictionary Options { get; } = new();
 
         #endregion
 
@@ -140,25 +108,6 @@ namespace Couchbase.Lite.Sync
             ConflictResolver = copy?.ConflictResolver;
             ReplicatorType = copy?.ReplicatorType ?? ReplicatorType.PushAndPull;
             Options = copy?.Options ?? new ReplicatorOptionsDictionary();
-        }
-
-        #endregion
-
-        #region Internal Methods
-
-        internal CollectionConfiguration Freeze()
-        {
-            var retVal = new CollectionConfiguration()
-            {
-                PushFilter = PushFilter,
-                PullFilter = PullFilter,
-                ConflictResolver = ConflictResolver,
-                ReplicatorType = ReplicatorType,
-                Options = Options
-            };
-
-            retVal._freezer.Freeze("Cannot modify a CollectionConfiguration that is in use");
-            return retVal;
         }
 
         #endregion

--- a/src/Couchbase.Lite.Shared/API/Sync/CollectionConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/CollectionConfiguration.cs
@@ -20,6 +20,9 @@ using Couchbase.Lite.Support;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using Couchbase.Lite.Internal.Logging;
+using Couchbase.Lite.Util;
 
 namespace Couchbase.Lite.Sync
 {
@@ -27,7 +30,7 @@ namespace Couchbase.Lite.Sync
     /// A configuration object for setting the details of how to treat
     /// a collection when used inside of a <see cref="Replicator"/>
     /// </summary>
-    public sealed class CollectionConfiguration
+    public sealed record CollectionConfiguration
     {
         #region Constants
 
@@ -83,32 +86,14 @@ namespace Couchbase.Lite.Sync
             get => Options.DocIDs;
             init => Options.DocIDs = value?.Any() == true ? value : null;
         }
-
+        
         /// <summary>
         /// A value indicating the direction of the replication.  The default is
         /// <see cref="ReplicatorType.PushAndPull"/> which is bidirectional
         /// </summary>
-        internal ReplicatorType ReplicatorType { get; set; } = ReplicatorType.PushAndPull;
+        internal ReplicatorType ReplicatorType { get; init; } = ReplicatorType.PushAndPull;
 
         internal ReplicatorOptionsDictionary Options { get; } = new();
-
-        #endregion
-
-        #region Constructor
-
-        /// <summary>
-        /// The default constructor
-        /// </summary>
-        public CollectionConfiguration() {}
-
-        internal CollectionConfiguration(CollectionConfiguration copy)
-        {
-            PushFilter = copy?.PushFilter;
-            PullFilter = copy?.PullFilter;
-            ConflictResolver = copy?.ConflictResolver;
-            ReplicatorType = copy?.ReplicatorType ?? ReplicatorType.PushAndPull;
-            Options = copy?.Options ?? new ReplicatorOptionsDictionary();
-        }
 
         #endregion
     }

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -148,7 +148,7 @@ namespace Couchbase.Lite.Sync
             if (config.Collections.Count <= 0)
                 throw new CouchbaseLiteException(C4ErrorCode.InvalidParameter, "Replicator Configuration must contain at least one collection.");
 
-            _config = config.Freeze();
+            _config = config;
         }
 
         /// <summary>

--- a/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
+++ b/src/Couchbase.Lite.Shared/API/Sync/Replicator.cs
@@ -970,8 +970,8 @@ namespace Couchbase.Lite.Sync
                         //TODO: in the future we can set different replicator type per collection
                         //var collPush = config.ReplicatorType.HasFlag(ReplicatorType.Push);
                         //var collPull = config.ReplicatorType.HasFlag(ReplicatorType.Pull);
-                        //for now collecion config's ReplicatorType should be the same as ReplicatorType in replicator config
-                        config.ReplicatorType = Config.ReplicatorType; 
+                        //for now collection config's ReplicatorType should be the same as ReplicatorType in replicator config
+                        Config.CollectionConfigs[col] = config with { ReplicatorType = Config.ReplicatorType };
 
                         colConfigOptions.Build();
 

--- a/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
+++ b/src/Couchbase.Lite.Shared/Query/IndexConfiguration.cs
@@ -29,7 +29,7 @@ namespace Couchbase.Lite.Internal.Query
     /// A configuration object that stores the details of how a given <see cref="Couchbase.Lite.Query.IIndex"/>
     /// object should be created
     /// </summary>
-    public abstract class IndexConfiguration
+    public abstract record IndexConfiguration
     {
         private const string Tag = nameof(IndexConfiguration);
 

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -109,6 +109,7 @@ namespace Test
                 var context = new DocContext(Db, null);
                 using (var mRoot = new MRoot(context)) {
                     mRoot.Context.ShouldBeSameAs(context);
+                    Db.c4db.ShouldNotBeNull();
                     FLDoc* fleeceDoc = Native.FLDoc_FromResultData(flData,
                         FLTrust.Trusted,
                         NativeSafe.c4db_getFLSharedKeys(Db.c4db), FLSlice.Null);
@@ -202,6 +203,7 @@ namespace Test
                 var context = new DocContext(Db, null);
                 using (var mRoot = new MRoot(context)) {
                     mRoot.Context.ShouldBeSameAs(context);
+                    Db.c4db.ShouldNotBeNull();
                     FLDoc* fleeceDoc = Native.FLDoc_FromResultData(flData,
                         FLTrust.Trusted,
                         NativeSafe.c4db_getFLSharedKeys(Db.c4db), FLSlice.Null);

--- a/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DatabaseTest.cs
@@ -91,11 +91,6 @@ namespace Test
             } finally {
                 Database.Delete("db", dir);
             }
-
-#if COUCHBASE_ENTERPRISE
-            Should.Throw<InvalidOperationException>(() => options.EncryptionKey = new EncryptionKey("foo"),
-                "because the configuration is in use");
-            #endif
         }
 
         [Fact]
@@ -1177,17 +1172,16 @@ namespace Test
 
 #if COUCHBASE_ENTERPRISE
             config1.EncryptionKey.ShouldBeNull("because it was not set");
+            var key = new EncryptionKey("key");
 #endif
 
             var builder2 = new DatabaseConfiguration()
             {
-                Directory = "/tmp/mydb"
+                Directory = "/tmp/mydb",
+                #if COUCHBASE_ENTERPRISE
+                EncryptionKey = key
+                #endif
             };
-
-#if COUCHBASE_ENTERPRISE
-            var key = new EncryptionKey("key");
-            builder2.EncryptionKey = key;
-#endif
 
             var config2 = builder2;
             config2.Directory.ShouldBe("/tmp/mydb", "because that is what was set");
@@ -1203,7 +1197,6 @@ namespace Test
             var config = new DatabaseConfiguration();
             using (var db = new Database("db", config))
             {
-                db.Config.ShouldNotBeSameAs(config, "because the configuration should be copied and frozen");
                 db.Config.Directory.ShouldBe(config.Directory, "because the directory should be the same");
 
 #if COUCHBASE_ENTERPRISE

--- a/src/Couchbase.Lite.Tests.Shared/DictionaryTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/DictionaryTest.cs
@@ -171,8 +171,9 @@ namespace Test
                     doc.Count.ShouldBe(1);
                     doc.Contains("dict").ShouldBeTrue();
                     var d = doc.GetDictionary("dict");
+                    d.ShouldNotBeNull();
                     d.Count.ShouldBe(4);
-                    d!.Contains("obj-null").ShouldBeTrue(); // If null the previous check will fail
+                    d.Contains("obj-null").ShouldBeTrue(); // If null the previous check will fail
                     d.Contains("string-null").ShouldBeTrue();
                     d.Contains("array-null").ShouldBeTrue();
                     d.Contains("dict-null").ShouldBeTrue();
@@ -224,6 +225,7 @@ namespace Test
             });
 
             var dicts = doc.GetArray("dicts");
+            dicts.ShouldNotBeNull();
             dicts.Count.ShouldBe(4, "because that is the number of entries added");
 
             var d1 = dicts!.GetDictionary(0); // This is not null because otherwise the previous check will fail
@@ -240,6 +242,7 @@ namespace Test
             var gotDoc = DefaultCollection.GetDocument("doc1");
             gotDoc.ShouldNotBeNull("because the document was just saved");
             var savedDicts = gotDoc!.GetArray("dicts");
+            savedDicts.ShouldNotBeNull();
             savedDicts.Count.ShouldBe(4, "because that is the number of entries");
 
             var savedD1 = savedDicts?.GetDictionary(0);

--- a/src/Couchbase.Lite.Tests.Shared/LogTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/LogTest.cs
@@ -116,7 +116,7 @@ namespace Test
                 #endif
 
                 Directory.EnumerateFiles(logDirectory)
-                    .Count().ShouldBe(totalCount, "because old log files should be getting pruned");
+                    .Count().ShouldBe((int)totalCount, "because old log files should be getting pruned");
             });
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/MmapTest.cs
@@ -59,11 +59,11 @@ namespace Test
             config.MmapEnabled.ShouldBeTrue();
             config.MmapEnabled.ShouldBeTrue("because the default should be true");
 
-            config.MmapEnabled = false;
+            config = new DatabaseConfiguration
+            {
+                MmapEnabled = false
+            };
             config.MmapEnabled.ShouldBeFalse("because C# properties should work...");
-
-            config.MmapEnabled = true;
-            config.MmapEnabled.ShouldBeTrue("because C# properties should work...");
 #endif
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/SQLiteOptionsTest.cs
@@ -54,11 +54,12 @@ namespace Test
             var config = new DatabaseConfiguration();
             config.FullSync.ShouldBeFalse("because the default should be false");
 
-            config.FullSync = true;
+            config = new DatabaseConfiguration
+            {
+                FullSync = true,
+            };
+                
             config.FullSync.ShouldBeTrue("because C# properties should work...");
-
-            config.FullSync = false;
-            config.FullSync.ShouldBeFalse("because C# properties should work...");
         }
 
         /// <summary>

--- a/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopeCollectionTest.cs
@@ -737,17 +737,15 @@ namespace Test
             //6.5 Get Collections from The Scope Having No Collections
             //GetCollection() NULL
             //GetCollections() empty result
-            using (var colA = Db.CreateCollection("colA", "scopeA")) {
-                using (var scopeA = Db.GetScope("scopeA"))
-                using (var otherDB = OpenDB(Db.Name)) {
-                    otherDB.DeleteCollection("colA", "scopeA");
+            using var colA = Db.CreateCollection("colA", "scopeA");
+            var scopeA = Db.GetScope("scopeA");
+            using var otherDB = OpenDB(Db.Name);
+            otherDB.DeleteCollection("colA", "scopeA");
 
-                    using (var col = scopeA!.GetCollection("colA"))
-                        col.ShouldBeNull("Because GetCollection after collection colA is deleted from the other db.");
+            using var col = scopeA!.GetCollection("colA");
+            col.ShouldBeNull("Because GetCollection after collection colA is deleted from the other db.");
 
-                    scopeA.GetCollections().Count.ShouldBe(0, "Because GetCollections after collection colA is deleted from the other db.");
-                }
-            }
+            scopeA.GetCollections().Count.ShouldBe(0, "Because GetCollections after collection colA is deleted from the other db.");
         }
 
         #endregion
@@ -822,20 +820,15 @@ namespace Test
         public void TestScopeDatabase()
         {
             // 3.3 TestGetDatabaseFromScopeObtainedFromCollection
-            using (var col = Db.CreateCollection("colA", "scopeA"))
-            {
-                col.ShouldNotBeNull("Created colA should not be null");
-                var scope = col.Scope;
-                scope.ShouldNotBeNull("scopeA should not be null");
-                scope.Database.ShouldBe(Db);
-            }
+            using var col = Db.CreateCollection("colA", "scopeA");
+            col.ShouldNotBeNull("Created colA should not be null");
+            col.Scope.ShouldNotBeNull("scopeA should not be null");
+            col.Scope.Database.ShouldBe(Db);
 
             // 3.4 TestGetDatabaseFromScopeObtainedFromDatabase
-            using (var scope = Db.GetScope("scopeA"))
-            {
-                scope.ShouldNotBeNull("scopeA should not be null");
-                scope!.Database.ShouldBe(Db);
-            }
+            var scope = Db.GetScope("scopeA");
+            scope.ShouldNotBeNull("scopeA should not be null");
+            scope!.Database.ShouldBe(Db);
         }
 
         #endregion
@@ -948,7 +941,6 @@ namespace Test
             var collection = scope.CreateCollection("foo");
             var defaultCollection = Db.GetDefaultCollection();
 
-            scope.Dispose();
             collection.Dispose();
             defaultCollection.Dispose();
 

--- a/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ScopesCollections.ReplicationTest.cs
@@ -108,8 +108,7 @@ namespace Test
             var colBConfig = config.GetCollectionConfig(colB);
             colAConfig.ShouldNotBeNull("because it was just set");
             colBConfig.ShouldNotBeNull("because it was just set");
-            colAConfig.ShouldNotBe(colBConfig, "Because the returned configs should be different instances.");
-            colAConfig!.ConflictResolver.ShouldBe(colBConfig!.ConflictResolver, "Both properties were assigned with same value.");
+            colAConfig.ConflictResolver.ShouldBe(colBConfig!.ConflictResolver, "Both properties were assigned with same value.");
             colAConfig.PushFilter.ShouldBe(colBConfig.PushFilter, "Both properties were assigned with same value.");
             colAConfig.PullFilter.ShouldBe(colBConfig.PullFilter, "Both properties were assigned with same value.");
         }

--- a/src/Couchbase.Lite.Tests.Shared/VersionVectorTests.cs
+++ b/src/Couchbase.Lite.Tests.Shared/VersionVectorTests.cs
@@ -137,9 +137,11 @@ public sealed class VersionVectorTest : TestCase
             expectedValue = "value2";
         }
         
-        var replConfig = new ReplicatorConfiguration(new DatabaseEndpoint(db2));
+        var replConfig = new ReplicatorConfiguration(new DatabaseEndpoint(db2))
+        {
+            ReplicatorType = ReplicatorType.Pull
+        };
         replConfig.AddCollection(db1.GetDefaultCollection());
-        replConfig.ReplicatorType = ReplicatorType.Pull;
         using var repl = new Replicator(replConfig);
         repl.Start();
         while (repl.Status.Activity != ReplicatorActivityLevel.Stopped) {
@@ -189,9 +191,11 @@ public sealed class VersionVectorTest : TestCase
         db2Doc["key"].Value = "value3";
         db2.GetDefaultCollection().Save(db2Doc);
 
-        var replConfig = new ReplicatorConfiguration(new DatabaseEndpoint(db2));
+        var replConfig = new ReplicatorConfiguration(new DatabaseEndpoint(db2))
+        {
+            ReplicatorType = ReplicatorType.Pull
+        };
         replConfig.AddCollection(db1.GetDefaultCollection());
-        replConfig.ReplicatorType = ReplicatorType.Pull;
         using var repl = new Replicator(replConfig);
         repl.Start();
         while (repl.Status.Activity != ReplicatorActivityLevel.Stopped) {

--- a/src/LiteCore/src/LiteCore.Shared/API/NativeWrapper.cs
+++ b/src/LiteCore/src/LiteCore.Shared/API/NativeWrapper.cs
@@ -33,6 +33,8 @@ internal abstract class NativeWrapper : IDisposable
 
     public ThreadSafety InstanceSafety { get; }
 
+    protected bool IsDisposed => _disposed;
+
     public NativeWrapper(IntPtr instance)
     {
         _nativeInstance = instance;

--- a/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native_safe.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/C4Replicator_native_safe.cs
@@ -34,8 +34,6 @@ internal unsafe sealed class C4ReplicatorWrapper : NativeWrapper
 
     public C4Replicator* RawReplicator => (C4Replicator*)_nativeInstance;
 
-    private bool _disposed;
-
     public C4ReplicatorWrapper(C4Replicator* repl)
         : base((IntPtr)repl)
     {
@@ -43,8 +41,8 @@ internal unsafe sealed class C4ReplicatorWrapper : NativeWrapper
 
     public T UseSafe<T>(NativeCallback<T> a)
     {
-        if (_disposed) {
-            throw new ObjectDisposedException(nameof(C4QueryObserverWrapper));
+        if (IsDisposed) {
+            throw new ObjectDisposedException(nameof(C4ReplicatorWrapper));
         }
 
         using var scope = BeginLockedScope(true);


### PR DESCRIPTION
CBL-1946 CBL-3813

Migrate configuration objects to be init only (much less checking required to ensure it is not changed while in use) Fix a few potential null deferences based on static analysis Undeprecate the BasicAuthenticator string constructor since there are no plans to ever remove it Fix tests to use init only style
Fix an unused variable in C4ReplicatorWrapper