### PR TITLE
Fix some failing release build test

### DIFF
--- a/src/Couchbase.Lite.Tests.Shared/ConcurrencyTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ConcurrencyTest.cs
@@ -242,7 +242,7 @@ namespace Test
             _ = exp1.RunAssertAsync(() =>
             {
                 void BadAct() => _ = CreateDocs(nDocs, "Create").ToList();
-                Should.Throw<InvalidOperationException>(BadAct);
+                Should.Throw<CouchbaseLiteException>(BadAct).Error.ShouldBe(CouchbaseLiteError.NotOpen);
             });
 
             Db.Close();
@@ -258,7 +258,7 @@ namespace Test
             _ = exp1.RunAssertAsync(() =>
             {
                 void BadAct() => _ = CreateDocs(nDocs, "Create").ToList();
-                Should.Throw<InvalidOperationException>(BadAct);
+                Should.Throw<CouchbaseLiteException>(BadAct).Error.ShouldBe(CouchbaseLiteError.NotOpen);
             });
 
             Db.Delete();


### PR DESCRIPTION
Two of them weren't updated to catch the new exception type for closed DB One was a bigger problem of not locking out other API calls during a db transaction on the same db object