### PR TITLE
Add a release warning github flow

### DIFF
--- a/.github/workflows/warn_release.yml
+++ b/.github/workflows/warn_release.yml
@@ -1,0 +1,9 @@
+on:
+  pull_request:
+    branches: ['release/**']
+
+jobs:
+  warn-release:
+    uses: couchbase/couchbase-lite-core/.github/workflows/warn_release.yml@master
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
This helps keep us honest about what goes into a release branch