### PR TITLE
More pinning for .NET SDK stuff

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -4,6 +4,7 @@
     },
     "sdk": {
         "version": "8.0.400",
-        "rollForward": "latestPatch"
+        "rollForward": "latestPatch",
+        "workloadVersion": "8.0.421"
     }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -3,7 +3,7 @@
         "MSBuild.Sdk.Extras": "3.0.44"
     },
     "sdk": {
-        "version": "9.0.300",
+        "version": "8.0.400",
         "rollForward": "latestPatch"
     }
 }


### PR DESCRIPTION
To make things less messy, since we are building for net8.0 maui, use the .net 8 sdk segreated from other SDKs since the MAUI workloads can't coexist for multiple versions of .net in a single install (a really annoying flaw imo).