### PR TITLE
CBL-8282: Catch ObjectDisposedException in PerformWrite

### DIFF
--- a/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
+++ b/src/Couchbase.Lite.Shared/Sync/WebSocketWrapper.cs
@@ -630,9 +630,7 @@ internal sealed class WebSocketWrapper
                 });
             } catch (OperationCanceledException) {
                 return;
-            } catch (ArgumentNullException) {
-                return; // Sometimes happens because of Dispose() call to _writeQueue, safe to ignore
-            } catch (NullReferenceException) {
+            } catch (SystemException e) when (e is ArgumentNullException or NullReferenceException or ObjectDisposedException) {
                 return; // Sometimes happens because of Dispose() call to _writeQueue, safe to ignore
             }
         }


### PR DESCRIPTION
It has the same reasoning as the other two that are already caught.  Shutting down the connection disposes the underlying streams.