### PR TITLE
Support Native AOT and trimming: remove reflection from JSON serialization and DI

### DIFF
--- a/src/Couchbase.Lite.Shared/API/DI/Service.cs
+++ b/src/Couchbase.Lite.Shared/API/DI/Service.cs
@@ -1,35 +1,30 @@
-﻿// 
+//
 //  Service.cs
-// 
+//
 //  Copyright (c) 2017 Couchbase, Inc All rights reserved.
-// 
+//
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-// 
+//
 //  http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-// 
+//
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reflection;
 
 #if CBL_PLATFORM_DOTNET || CBL_PLATFORM_DOTNETFX
 using System.Runtime.InteropServices;
 #endif
 
-#if !CBL_PLATFORM_APPLE && !CBL_PLATFORM_WINUI
+using Couchbase.Lite.Internal.Logging;
 using Couchbase.Lite.Support;
-#endif
 
-using LiteCore.Interop;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Couchbase.Lite.DI;
@@ -48,10 +43,16 @@ public static class Service
     [ExcludeFromCodeCoverage]
     static Service()
     {
+        // Each platform registers its implementations explicitly instead of scanning
+        // the assembly for [CouchbaseDependency] classes.  Assembly scanning requires
+        // reflection APIs (Assembly.GetTypes / Activator.CreateInstance) that are
+        // unavailable under Native AOT and trimming.  When adding a new dependency
+        // implementation, register it here for the relevant platforms.
         var collection = new ServiceCollection();
 #if CBL_PLATFORM_DOTNET || CBL_PLATFORM_DOTNETFX
-        AutoRegister(typeof(Database).GetTypeInfo().Assembly, collection);
-        
+        collection.AddSingleton<IDefaultDirectoryResolver>(new DefaultDirectoryResolver());
+        collection.AddSingleton<IConsoleLogWriter>(new ConsoleLogWriter());
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             collection.AddSingleton<IProxy>(new WindowsProxy());
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
@@ -60,7 +61,10 @@ public static class Service
             collection.AddSingleton<IProxy>(new LinuxProxy());
         }
 #elif CBL_PLATFORM_WINUI
-        AutoRegister(typeof(Database).GetTypeInfo().Assembly, collection);
+        collection.AddSingleton<IDefaultDirectoryResolver>(new DefaultDirectoryResolver());
+        collection.AddSingleton<IRuntimePlatform>(new WinUIRuntimePlatform());
+        collection.AddSingleton<IProxy>(new WinUIProxy());
+        collection.AddTransient<IReachability>(_ => new Reachability());
 #elif CBL_PLATFORM_ANDROID
         #if !TEST_COVERAGE
         if (Droid.Context == null) {
@@ -68,70 +72,23 @@ public static class Service
                 "Android context not set.  Please ensure that a call to Couchbase.Lite.Support.Droid.Activate() is made.");
         }
 
-        AutoRegister(typeof(Database).Assembly, collection);
+        collection.AddSingleton<IRuntimePlatform>(new AndroidRuntimePlatform());
+        collection.AddSingleton<IConsoleLogWriter>(new ConsoleLogWriter());
+        collection.AddSingleton<IProxy>(new DotnetAndroidProxy());
         collection.AddSingleton<IDefaultDirectoryResolver>(_ => new DefaultDirectoryResolver(Droid.Context));
         collection.AddSingleton<IMainThreadTaskScheduler>(_ => new MainThreadTaskScheduler(Droid.Context));
         #endif
 #elif CBL_PLATFORM_APPLE
-        AutoRegister(typeof(Database).Assembly, collection);
+        collection.AddSingleton<IDefaultDirectoryResolver>(new DefaultDirectoryResolver());
+        collection.AddSingleton<IConsoleLogWriter>(new ConsoleLogWriter());
+        collection.AddSingleton<IRuntimePlatform>(new iOSRuntimePlatform());
+        collection.AddSingleton<IProxy>(new IOSProxy());
+        collection.AddTransient<IMainThreadTaskScheduler>(_ => new MainThreadTaskScheduler());
+        collection.AddTransient<IReachability>(_ => new iOSReachability());
 #else
         #error Unknown Platform
 #endif
-        
+
         Provider = collection.BuildServiceProvider();
-    }
-
-    /// <summary>
-    /// Automatically register all the dependency types declared
-    /// <see cref="CouchbaseDependencyAttribute" />s.  To auto register classes,
-    /// they must implement an interface and must have a default constructor.
-    /// </summary>
-    /// <param name="assembly">The assembly to scan</param>
-    /// <param name="serviceCollection">The collection to add to</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="assembly"/> is <c>null</c></exception>
-    /// <exception cref="InvalidOperationException">Thrown if an invalid type is found inside the assembly (i.e.
-    /// one that does not implement any interfaces and/or does not have a parameter-less constructor)</exception>
-    [ExcludeFromCodeCoverage]
-    private static void AutoRegister(Assembly assembly, IServiceCollection serviceCollection)
-    {
-        if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-
-        foreach (var type in assembly.GetTypes().Where(x => x.GetTypeInfo().IsClass)) {
-            var ti = type.GetTypeInfo();
-
-            var attribute = ti.GetCustomAttribute<CouchbaseDependencyAttribute>();
-            if (attribute == null) {
-                continue;
-            }
-
-            var actualInterfaces = ti.ImplementedInterfaces;
-            if(actualInterfaces == null) {
-                throw new InvalidOperationException($"{type.Name} does not implement any interfaces!");
-            }
-
-            var interfaces = actualInterfaces as Type[] ?? actualInterfaces.ToArray();
-            var minimalInterfaces = interfaces
-                .Except(type.BaseType?.GetInterfaces() ?? Enumerable.Empty<Type>())
-                .Except(interfaces.SelectMany(i => i.GetInterfaces()));
-            var interfaceType = minimalInterfaces.FirstOrDefault();
-            if(interfaceType == null) {
-                throw new InvalidOperationException($"{type.Name} does not implement any interfaces of its own");
-            }
-
-            if(ti.DeclaredConstructors.All(x => x.GetParameters().Length != 0)) {
-                throw new InvalidOperationException($"{type.Name} does not contain a default constructor");
-            }
-
-            if (attribute.Transient) {
-                serviceCollection.AddTransient(interfaceType, type);
-            } else {
-                if (attribute.Lazy) {
-                    serviceCollection.AddSingleton(interfaceType, type);
-                } else {
-                    serviceCollection.AddSingleton(interfaceType, Activator.CreateInstance(type)
-                        ?? throw new CouchbaseLiteException(C4ErrorCode.UnexpectedError, $"Unable to create instance of {type.Name}"));
-                }
-            }
-        }
     }
 }

--- a/src/Couchbase.Lite.Shared/API/Database/Collection.cs
+++ b/src/Couchbase.Lite.Shared/API/Database/Collection.cs
@@ -32,7 +32,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using System.Text.Json;
 
 namespace Couchbase.Lite;
 
@@ -534,7 +533,7 @@ public sealed unsafe class Collection : IChangeObservable<CollectionChangedEvent
         CheckCollectionValid();
         var concreteIndex = Misc.TryCast<IIndex, QueryIndex>(index);
         var jsonObj = concreteIndex.ToJSON();
-        var json = JsonSerializer.Serialize(jsonObj);
+        var json = CouchbaseJson.Serialize(jsonObj);
         LiteCoreBridge.Check(err =>
         {
             var internalOpts = concreteIndex.Options;

--- a/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/ArrayObject.cs
@@ -183,26 +183,22 @@ internal sealed class IArrayConverter : JsonConverter<IArray>
                 {
                     using var document = JsonDocument.ParseValue(ref reader);
                     var element = document.RootElement;
+                    var properties = CouchbaseJson.ToNetObject(element) as Dictionary<string, object?> ??
+                                     throw new CouchbaseLiteException(C4ErrorCode.UnexpectedError,
+                                         "Error deserializing dict in ReadJson (IArray)");
                     if (element.TryGetProperty(Constants.ObjectTypeProperty, out var prop)
                         && prop.GetString() == Constants.ObjectTypeBlob) {
-                        var blob = element.Deserialize<Blob>(options) ??
-                                   throw new CouchbaseLiteException(C4ErrorCode.UnexpectedError, 
-                                       "Error deserializing blob in ReadJson (IArray)");
-                        arr.AddBlob(blob);
+                        arr.AddBlob(new Blob(properties));
                     }
                     else {
-                        var dict = element.Deserialize<MutableDictionaryObject>(options) ??
-                                   throw new CouchbaseLiteException(C4ErrorCode.UnexpectedError, 
-                                       "Error deserializing dict in ReadJson (IArray)");
+                        var dict = new MutableDictionaryObject();
+                        dict.SetData(properties);
                         arr.AddValue(dict);
                     }
                     break;
                 }
                 case JsonTokenType.StartArray:
-                    var array = JsonSerializer.Deserialize<MutableArrayObject>(ref reader) ??
-                               throw new CouchbaseLiteException(C4ErrorCode.UnexpectedError, 
-                                   "Error deserializing array in ReadJson (IArray)");
-                    arr.AddValue(array);
+                    arr.AddValue(Read(ref reader, typeToConvert, options));
                     break;
                 case JsonTokenType.String:
                     arr.AddValue(reader.GetString());
@@ -236,11 +232,6 @@ internal sealed class IArrayConverter : JsonConverter<IArray>
 
     public override void Write(Utf8JsonWriter writer, IArray value, JsonSerializerOptions options)
     {
-        writer.WriteStartArray();
-        foreach (var item in value) {
-            JsonSerializer.Serialize(writer, item, options);
-        }
-        
-        writer.WriteEndArray();
+        CouchbaseJson.WriteValue(writer, value);
     }
 }

--- a/src/Couchbase.Lite.Shared/API/Document/Blob.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/Blob.cs
@@ -21,10 +21,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Couchbase.Lite.Internal.Doc;
 using Couchbase.Lite.Internal.Logging;
+using Couchbase.Lite.Internal.Serialization;
 using Couchbase.Lite.Util;
 
 using LiteCore;
@@ -377,9 +377,9 @@ public sealed unsafe class Blob : IJSON
 
     /// <inheritdoc />
     public string ToJSON() =>
-        Digest == null 
-            ? throw new InvalidOperationException(CouchbaseLiteErrorMessage.MissingDigestDueToBlobIsNotSavedToDB) 
-            : JsonSerializer.Serialize(JsonRepresentation);
+        Digest == null
+            ? throw new InvalidOperationException(CouchbaseLiteErrorMessage.MissingDigestDueToBlobIsNotSavedToDB)
+            : CouchbaseJson.Serialize(JsonRepresentation);
 
     private void SetupProperties(IDictionary<string, object?> properties)
     {

--- a/src/Couchbase.Lite.Shared/API/Document/DictionaryObject.cs
+++ b/src/Couchbase.Lite.Shared/API/Document/DictionaryObject.cs
@@ -47,7 +47,7 @@ internal sealed class IDictionaryObjectConverter : JsonConverter<IDictionaryObje
             }
 
             reader.Read();
-            var value = JsonSerializer.Deserialize<object?>(ref reader, options);
+            var value = CouchbaseJson.ReadValue(ref reader);
             dict.SetValue(key, value);
         }
 
@@ -56,13 +56,7 @@ internal sealed class IDictionaryObjectConverter : JsonConverter<IDictionaryObje
 
     public override void Write(Utf8JsonWriter writer, IDictionaryObject value, JsonSerializerOptions options)
     {
-        writer.WriteStartObject();
-        foreach (var pair in value) {
-            writer.WritePropertyName(pair.Key);
-            JsonSerializer.Serialize(writer, pair.Value);
-        }
-        
-        writer.WriteEndObject();
+        CouchbaseJson.WriteValue(writer, value);
     }
 }
 

--- a/src/Couchbase.Lite.Shared/API/Query/Parameters.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/Parameters.cs
@@ -18,9 +18,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using Couchbase.Lite.Internal.Logging;
 using Couchbase.Lite.Internal.Query;
+using Couchbase.Lite.Internal.Serialization;
 using Couchbase.Lite.Support;
 using Couchbase.Lite.Util;
 
@@ -224,5 +224,5 @@ public sealed class Parameters
     internal FLSliceResult FLEncode() => _params.FLEncode();
 
     /// <inheritdoc />
-    public override string ToString() => JsonSerializer.Serialize(_params);
+    public override string ToString() => CouchbaseJson.Serialize(_params);
 }

--- a/src/Couchbase.Lite.Shared/API/Query/Result.cs
+++ b/src/Couchbase.Lite.Shared/API/Query/Result.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using Couchbase.Lite.Internal.Doc;
 using Couchbase.Lite.Internal.Logging;
 using Couchbase.Lite.Internal.Query;
@@ -301,5 +300,5 @@ public sealed unsafe class Result : IArray, IDictionaryObject, IJSON
     }
 
     /// <inheritdoc />
-    public string ToJSON() => JsonSerializer.Serialize(ToDictionary());
+    public string ToJSON() => CouchbaseJson.Serialize(ToDictionary());
 }

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -162,6 +162,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Select.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Where.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\XQuery.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\CouchbaseJson.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\FLValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\MCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\MContext.cs" />

--- a/src/Couchbase.Lite.Shared/Document/DataOps.cs
+++ b/src/Couchbase.Lite.Shared/Document/DataOps.cs
@@ -56,9 +56,11 @@ internal static class DataOps
         T? retVal;
         try {
             // The JsonTypeInfo overload is AOT safe; T must be registered on
-            // CouchbaseJsonContext (or handled by a registered converter)
+            // CouchbaseJsonContext (or handled by a registered converter).
+            // Only JsonException maps to InvalidJSON so that registration
+            // failures (NotSupportedException etc.) surface immediately.
             retVal = (T?)JsonSerializer.Deserialize(json, SerializerOptions.GetTypeInfo(typeof(T)));
-        } catch {
+        } catch (JsonException) {
             throw new CouchbaseLiteException(C4ErrorCode.InvalidParameter, CouchbaseLiteErrorMessage.InvalidJSON);
         }
 

--- a/src/Couchbase.Lite.Shared/Document/DataOps.cs
+++ b/src/Couchbase.Lite.Shared/Document/DataOps.cs
@@ -30,62 +30,12 @@ internal sealed class CouchbaseConverter : JsonConverter<object>
 {
     public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        return reader.TokenType switch
-        {
-            JsonTokenType.True => true,
-            JsonTokenType.False => false,
-            JsonTokenType.Number => ReadNumber(ref reader),
-            JsonTokenType.String => reader.GetString(),
-            JsonTokenType.StartObject => ReadObject(ref reader),
-            JsonTokenType.StartArray => ReadArray(ref reader),
-            JsonTokenType.Null => null,
-            _ => throw new JsonException($"Unexpected token parsing JSON. Token: {reader.TokenType}")
-        };
+        return CouchbaseJson.ReadValue(ref reader);
     }
 
     public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
     {
-        JsonSerializer.Serialize(writer, value, options);
-    }
-    
-    private object ReadNumber(ref Utf8JsonReader reader)
-    {
-        if (reader.TryGetInt64(out var l))
-            return l;
-
-        return reader.GetDouble();
-    }
-
-    private Dictionary<string, object> ReadObject(ref Utf8JsonReader reader)
-    {
-        var dictionary = new Dictionary<string, object>();
-        
-        while (reader.Read()) {
-            if (reader.TokenType == JsonTokenType.EndObject)
-                break;
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException("Expected property name");
-
-            var propertyName = reader.GetString()!;
-            reader.Read();
-            dictionary[propertyName] = Read(ref reader, typeof(object), null!)!;
-        }
-
-        return dictionary;
-    }
-    
-    private List<object> ReadArray(ref Utf8JsonReader reader)
-    {
-        var list = new List<object>();
-        while (reader.Read()) {
-            if (reader.TokenType == JsonTokenType.EndArray)
-                break;
-
-            list.Add(Read(ref reader, typeof(object), null!)!);
-        }
-
-        return list;
+        CouchbaseJson.WriteValue(writer, value);
     }
 }
 
@@ -93,15 +43,21 @@ internal static class DataOps
 {
     internal static readonly JsonSerializerOptions SerializerOptions = new()
     {
+        // The source generated resolver keeps System.Text.Json off of its
+        // reflection based code paths so that deserialization works under
+        // Native AOT / trimming.  The converters do all of the actual work.
+        TypeInfoResolver = CouchbaseJsonContext.Default,
         Converters = { new CouchbaseConverter(), new IArrayConverter(), new IDictionaryObjectConverter() },
         PreferredObjectCreationHandling = JsonObjectCreationHandling.Replace
     };
-    
+
     internal static T? ParseTo<T>(string json)
     {
         T? retVal;
         try {
-            retVal = JsonSerializer.Deserialize<T>(json, SerializerOptions);
+            // The JsonTypeInfo overload is AOT safe; T must be registered on
+            // CouchbaseJsonContext (or handled by a registered converter)
+            retVal = (T?)JsonSerializer.Deserialize(json, SerializerOptions.GetTypeInfo(typeof(T)));
         } catch {
             throw new CouchbaseLiteException(C4ErrorCode.InvalidParameter, CouchbaseLiteErrorMessage.InvalidJSON);
         }
@@ -186,23 +142,7 @@ internal static class DataOps
             case ArrayObject roarr and not MutableArrayObject:
                 return roarr.ToMutable();
             case JsonElement jobj:
-                switch (jobj.ValueKind) {
-                    case JsonValueKind.Array:
-                        return ConvertList(jobj.Deserialize<IList>(SerializerOptions)!);
-                    case JsonValueKind.Object:
-                        return ConvertDictionary(jobj.Deserialize<IDictionary<string, object>>(SerializerOptions)!);
-                    case JsonValueKind.Number:
-                        return jobj.TryGetInt64(out var l) ? l : jobj.GetDouble();
-                    case JsonValueKind.String:
-                        return jobj.GetString();
-                    case JsonValueKind.True:
-                    case JsonValueKind.False:
-                        return jobj.GetBoolean();
-                    case JsonValueKind.Null:
-                        return null;
-                    default:
-                        throw new ArgumentException("Invalid JsonElement type: " + jobj.ValueKind);
-                }
+                return ToCouchbaseObject(CouchbaseJson.ToNetObject(jobj));
             case IDictionary<string, object?> dict:
                 return ConvertDictionary(dict);
             case IList list:

--- a/src/Couchbase.Lite.Shared/Log/LogJsonString.cs
+++ b/src/Couchbase.Lite.Shared/Log/LogJsonString.cs
@@ -20,7 +20,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
+
+using Couchbase.Lite.Internal.Serialization;
 
 namespace Couchbase.Lite.Logging;
 
@@ -47,5 +48,5 @@ internal sealed class LogJsonString(object obj)
 {
     private string? _serialized;
 
-    public override string ToString() => _serialized ??= JsonSerializer.Serialize(obj);
+    public override string ToString() => _serialized ??= CouchbaseJson.SerializeLenient(obj);
 }

--- a/src/Couchbase.Lite.Shared/Log/SecureLogString.cs
+++ b/src/Couchbase.Lite.Shared/Log/SecureLogString.cs
@@ -18,7 +18,8 @@
 
 using System.Linq;
 using System.Text;
-using System.Text.Json;
+
+using Couchbase.Lite.Internal.Serialization;
 
 namespace Couchbase.Lite.Logging;
 
@@ -94,7 +95,7 @@ internal sealed class SecureLogJsonString(object input, LogMessageSensitivity se
                 return _str;
             }
 
-            var str = JsonSerializer.Serialize(_object);
+            var str = CouchbaseJson.SerializeLenient(_object);
             _str = str.Length > 100 ? $"{new string(str.Take(100).ToArray())}..." : str;
 
             return _str;

--- a/src/Couchbase.Lite.Shared/Query/QueryExpression.cs
+++ b/src/Couchbase.Lite.Shared/Query/QueryExpression.cs
@@ -19,9 +19,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text.Json;
 
 using Couchbase.Lite.Internal.Logging;
+using Couchbase.Lite.Internal.Serialization;
 using Couchbase.Lite.Query;
 using Couchbase.Lite.Util;
 
@@ -107,7 +107,7 @@ internal abstract class QueryExpression : IExpression
 
     public override string ToString()
     {
-        return $"[{GetType().Name}] => {JsonSerializer.Serialize(ConvertToJSON())}";
+        return $"[{GetType().Name}] => {CouchbaseJson.Serialize(ConvertToJSON())}";
     }
 
     public IExpression Add(IExpression expression) => 

--- a/src/Couchbase.Lite.Shared/Query/XQuery.cs
+++ b/src/Couchbase.Lite.Shared/Query/XQuery.cs
@@ -20,8 +20,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using Couchbase.Lite.Internal.Logging;
+using Couchbase.Lite.Internal.Serialization;
 using Couchbase.Lite.Query;
 using Couchbase.Lite.Util;
 using LiteCore;
@@ -223,7 +223,7 @@ internal class XQuery : QueryBase
             parameters["HAVING"] = HavingImpl.ToJSON();
         }
 
-        return JsonSerializer.Serialize(parameters);
+        return CouchbaseJson.Serialize(parameters);
     }
 
     private void Check()

--- a/src/Couchbase.Lite.Shared/Serialization/CouchbaseJson.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/CouchbaseJson.cs
@@ -41,6 +41,7 @@ namespace Couchbase.Lite.Internal.Serialization;
 [JsonSerializable(typeof(IList<object>))]
 [JsonSerializable(typeof(IList))]
 [JsonSerializable(typeof(IList<IList<object>>))]
+[JsonSerializable(typeof(Dictionary<string,string[]>))]
 internal sealed partial class CouchbaseJsonContext : JsonSerializerContext
 {
 }

--- a/src/Couchbase.Lite.Shared/Serialization/CouchbaseJson.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/CouchbaseJson.cs
@@ -17,6 +17,7 @@
 //
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -55,12 +56,22 @@ internal static class CouchbaseJson
     // Serializes a tree of Couchbase supported values to a JSON string.
     internal static string Serialize(object? value)
     {
+#if NET6_0_OR_GREATER
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer)) {
+            WriteValue(writer, value);
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+#else
+        // ArrayBufferWriter<byte> is unavailable on .NET Framework
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream)) {
             WriteValue(writer, value);
         }
 
         return Encoding.UTF8.GetString(stream.ToArray());
+#endif
     }
 
     // Serialization for logging purposes.  Never throws on unsupported types so

--- a/src/Couchbase.Lite.Shared/Serialization/CouchbaseJson.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/CouchbaseJson.cs
@@ -1,0 +1,265 @@
+//
+//  CouchbaseJson.cs
+//
+//  Copyright (c) 2026 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Couchbase.Lite.Internal.Serialization;
+
+// Source generated serializer metadata for the root types that Couchbase Lite
+// deserializes JSON into (see DataOps.ParseTo<T>).  Using a JsonSerializerContext
+// as the TypeInfoResolver keeps System.Text.Json away from its reflection based
+// resolver so the library remains functional under Native AOT / trimming.  All
+// values inside these roots are handled by the custom converters registered on
+// DataOps.SerializerOptions, which are entirely hand written.
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(IDictionary<string, object>))]
+[JsonSerializable(typeof(List<object>))]
+[JsonSerializable(typeof(IList<object>))]
+[JsonSerializable(typeof(IList))]
+[JsonSerializable(typeof(IList<IList<object>>))]
+internal sealed partial class CouchbaseJsonContext : JsonSerializerContext
+{
+}
+
+// Reflection free JSON reading and writing for the closed set of value types that
+// Couchbase Lite supports (see DataOps.ToCouchbaseObject).  These methods replace
+// the reflection based JsonSerializer code paths, which are unavailable under
+// Native AOT and produce trim warnings (IL2026 / IL3050).
+internal static class CouchbaseJson
+{
+    // Serializes a tree of Couchbase supported values to a JSON string.
+    internal static string Serialize(object? value)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream)) {
+            WriteValue(writer, value);
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    // Serialization for logging purposes.  Never throws on unsupported types so
+    // that a log call cannot take down the library.
+    internal static string SerializeLenient(object? value)
+    {
+        try {
+            return Serialize(value);
+        } catch (ArgumentException) {
+            return value?.ToString() ?? "null";
+        }
+    }
+
+    // Writes a single value of any Couchbase supported type, recursing into
+    // dictionaries and collections.
+    internal static void WriteValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value) {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case string s:
+                writer.WriteStringValue(s);
+                break;
+            case bool b:
+                writer.WriteBooleanValue(b);
+                break;
+            case byte or sbyte or short or ushort or int or uint or long:
+                writer.WriteNumberValue(Convert.ToInt64(value, CultureInfo.InvariantCulture));
+                break;
+            case ulong ul:
+                writer.WriteNumberValue(ul);
+                break;
+            case float f:
+                writer.WriteNumberValue(f);
+                break;
+            case double d:
+                writer.WriteNumberValue(d);
+                break;
+            case decimal dec:
+                writer.WriteNumberValue(dec);
+                break;
+            case DateTimeOffset dto:
+                writer.WriteStringValue(dto);
+                break;
+            case DateTime dt:
+                writer.WriteStringValue(dt);
+                break;
+            case byte[] data:
+                writer.WriteBase64StringValue(data);
+                break;
+            case JsonElement element:
+                element.WriteTo(writer);
+                break;
+            case Blob blob:
+                WriteValue(writer, blob.JsonRepresentation);
+                break;
+            case IDictionaryObject dictObject:
+                writer.WriteStartObject();
+                foreach (var pair in dictObject) {
+                    writer.WritePropertyName(pair.Key);
+                    WriteValue(writer, pair.Value);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case IArray arrayObject:
+                writer.WriteStartArray();
+                foreach (var item in arrayObject) {
+                    WriteValue(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case IEnumerable<KeyValuePair<string, object?>> pairs:
+                writer.WriteStartObject();
+                foreach (var pair in pairs) {
+                    writer.WritePropertyName(pair.Key);
+                    WriteValue(writer, pair.Value);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case IDictionary legacyDict:
+                writer.WriteStartObject();
+                foreach (DictionaryEntry entry in legacyDict) {
+                    writer.WritePropertyName(Convert.ToString(entry.Key, CultureInfo.InvariantCulture)!);
+                    WriteValue(writer, entry.Value);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case IEnumerable enumerable:
+                writer.WriteStartArray();
+                foreach (var item in enumerable) {
+                    WriteValue(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            default:
+                throw new ArgumentException($"Cannot serialize an object of type {value.GetType().FullName} to JSON");
+        }
+    }
+
+    // Reads a single JSON value into plain .NET objects (Dictionary<string, object> /
+    // List<object> / primitives).  The reader must be positioned on the first token
+    // of the value.
+    internal static object? ReadValue(ref Utf8JsonReader reader)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.Number => ReadNumber(ref reader),
+            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.StartObject => ReadObject(ref reader),
+            JsonTokenType.StartArray => ReadArray(ref reader),
+            JsonTokenType.Null => null,
+            _ => throw new JsonException($"Unexpected token parsing JSON. Token: {reader.TokenType}")
+        };
+    }
+
+    // Converts an already parsed JsonElement into plain .NET objects using only
+    // AOT safe JsonElement traversal.
+    internal static object? ToNetObject(JsonElement element)
+    {
+        switch (element.ValueKind) {
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return element.GetBoolean();
+            case JsonValueKind.Number:
+                return element.TryGetInt64(out var l) ? l : element.GetDouble();
+            case JsonValueKind.String:
+                return element.GetString();
+            case JsonValueKind.Array: {
+                var list = new List<object?>(element.GetArrayLength());
+                foreach (var item in element.EnumerateArray()) {
+                    list.Add(ToNetObject(item));
+                }
+
+                return list;
+            }
+            case JsonValueKind.Object: {
+                var dict = new Dictionary<string, object?>();
+                foreach (var property in element.EnumerateObject()) {
+                    dict[property.Name] = ToNetObject(property.Value);
+                }
+
+                return dict;
+            }
+            default:
+                throw new ArgumentException("Invalid JsonElement type: " + element.ValueKind);
+        }
+    }
+
+    private static object ReadNumber(ref Utf8JsonReader reader)
+    {
+        if (reader.TryGetInt64(out var l)) {
+            return l;
+        }
+
+        return reader.GetDouble();
+    }
+
+    private static Dictionary<string, object> ReadObject(ref Utf8JsonReader reader)
+    {
+        var dictionary = new Dictionary<string, object>();
+
+        while (reader.Read()) {
+            if (reader.TokenType == JsonTokenType.EndObject) {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName) {
+                throw new JsonException("Expected property name");
+            }
+
+            var propertyName = reader.GetString()!;
+            reader.Read();
+            dictionary[propertyName] = ReadValue(ref reader)!;
+        }
+
+        return dictionary;
+    }
+
+    private static List<object> ReadArray(ref Utf8JsonReader reader)
+    {
+        var list = new List<object>();
+        while (reader.Read()) {
+            if (reader.TokenType == JsonTokenType.EndArray) {
+                break;
+            }
+
+            list.Add(ReadValue(ref reader)!);
+        }
+
+        return list;
+    }
+}

--- a/src/Couchbase.Lite.Shared/Serialization/FLValueConverter.cs
+++ b/src/Couchbase.Lite.Shared/Serialization/FLValueConverter.cs
@@ -17,9 +17,7 @@
 // 
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 
 using LiteCore;
@@ -34,13 +32,13 @@ internal static unsafe class FLValueConverter
 {
     public delegate object ObjectConvertDelegate(FLDict* dict);
 
-    public static object? ToCouchbaseObject(FLValue* value, Database? db, bool dotNetTypes, Type? hintType1 = null, MRoot? root = null)
+    public static object? ToCouchbaseObject(FLValue* value, Database? db, bool dotNetTypes, MRoot? root = null)
     {
         switch (Native.FLValue_GetType(value)) {
             case FLValueType.Array:
             {
                 if (dotNetTypes) {
-                    return ToObject(value, db, 0, hintType1);
+                    return ToObject(value, db);
                 }
 
                 var array = new ArrayObject(new FleeceMutableArray(new MValue(value), root), false);
@@ -54,7 +52,7 @@ internal static unsafe class FLValueConverter
                     return new DictionaryObject(new MDict(new MValue(value), root), false);
                 }
 
-                return ToObject(value, db, 0, hintType1);
+                return ToObject(value, db);
             }
             case FLValueType.Undefined:
                 return null;
@@ -106,7 +104,7 @@ internal static unsafe class FLValueConverter
         return dict;
     }
 
-    private static object? ToObject(FLValue* value, Database? db, int level = 0, Type? hintType1 = null)
+    private static object? ToObject(FLValue* value, Database? db)
     {
         if (value == null) {
             return null;
@@ -116,20 +114,17 @@ internal static unsafe class FLValueConverter
             case FLValueType.Array:
             {
                 var arr = Native.FLValue_AsArray(value);
-                var hintType = level == 0 && hintType1 != null ? hintType1 : typeof(object);
                 var count = (int)Native.FLArray_Count(arr);
                 if (count == 0) {
                     return new List<object>();
                 }
 
-                var retVal =
-                    (IList)Activator.CreateInstance(typeof(List<>).GetTypeInfo().MakeGenericType(hintType),
-                        count)!;
+                var retVal = new List<object?>(count);
 
                 var i = default(FLArrayIterator);
                 Native.FLArrayIterator_Begin(arr, &i);
                 do {
-                    retVal.Add(ToObject(Native.FLArrayIterator_GetValue(&i), db, level + 1, hintType1));
+                    retVal.Add(ToObject(Native.FLArrayIterator_GetValue(&i), db));
                 } while (Native.FLArrayIterator_Next(&i));
 
                 return retVal;
@@ -142,21 +137,20 @@ internal static unsafe class FLValueConverter
             {
 
                 var dict = Native.FLValue_AsDict(value);
-                var hintType = level == 0 && hintType1 != null ? hintType1 : typeof(object);
                 var count = (int)Native.FLDict_Count(dict);
                 if (count == 0) {
                     return new Dictionary<string, object>();
                 }
 
-                var retVal = (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeof(string), hintType), count)!;
+                var retVal = new Dictionary<string, object?>(count);
                 var i = default(FLDictIterator);
                 Native.FLDictIterator_Begin(dict, &i);
                 do {
                     var key = Native.FLDictIterator_GetKeyString(&i)!;
-                    retVal[key] = ToObject(Native.FLDictIterator_GetValue(&i), db, level + 1, hintType1);
+                    retVal[key] = ToObject(Native.FLDictIterator_GetValue(&i), db);
                 } while (Native.FLDictIterator_Next(&i));
 
-                return ConvertDictionary((retVal as IDictionary<string, object>)!, db) ?? retVal;
+                return ConvertDictionary(retVal, db) ?? retVal;
             }
             case FLValueType.Null:
                 return null;

--- a/src/Couchbase.Lite.Support.NetDesktop/Activate.cs
+++ b/src/Couchbase.Lite.Support.NetDesktop/Activate.cs
@@ -78,6 +78,10 @@ public static partial class NetDesktop
     /// <exception cref="PlatformNotSupportedException">Thrown for 32-bit targets, they are not supported</exception>
     /// <exception cref="DllNotFoundException">LiteCore.dll could not be found</exception>
     /// <exception cref="BadImageFormatException">LiteCore.dll was the wrong architecture or corrupted in some way</exception>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file",
+        Justification = "An empty Assembly.Location is handled by falling back to AppContext.BaseDirectory")]
+#endif
     public static void LoadLiteCore()
     {
         if (Interlocked.Exchange(ref Activated, 1) == 1) {
@@ -94,7 +98,13 @@ public static partial class NetDesktop
         }
 
 #if NET6_0_OR_GREATER
-        var codeBase = Path.GetDirectoryName(typeof(NetDesktop).GetTypeInfo().Assembly.Location);
+        // Assembly.Location is empty when the app is published as single-file or
+        // Native AOT.  In that case the native libraries are extracted to (or sit
+        // next to) the application directory.
+        var assemblyLocation = typeof(NetDesktop).GetTypeInfo().Assembly.Location;
+        var codeBase = assemblyLocation.Length > 0
+            ? Path.GetDirectoryName(assemblyLocation)
+            : AppContext.BaseDirectory;
 #else
         var originalCodeBase = typeof(NetDesktop).GetTypeInfo().Assembly.CodeBase;
         var uri = new UriBuilder(originalCodeBase);

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -15,9 +15,11 @@
 	<SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
-  <!-- Native AOT / trimming support.  Only applicable to .NET 7+. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(ConsoleDotNetVersion)' ">
-    <IsAotCompatible>true</IsAotCompatible>
+  <!-- Native AOT / trimming support, following the documented pattern for libraries
+       that multi-target frameworks without AOT analysis support (net8.0 is the minimum):
+       https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/#target-framework-requirements -->
+  <PropertyGroup>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Packaging|AnyCPU'">
     <DocumentationFile>bin\Packaging\$(TargetFramework)\Couchbase.Lite.Support.NetDesktop.xml</DocumentationFile>

--- a/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
+++ b/src/Couchbase.Lite.Support.NetDesktop/Couchbase.Lite.Support.NetDesktop.csproj
@@ -15,6 +15,10 @@
 	<SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
+  <!-- Native AOT / trimming support.  Only applicable to .NET 7+. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == '$(ConsoleDotNetVersion)' ">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Packaging|AnyCPU'">
     <DocumentationFile>bin\Packaging\$(TargetFramework)\Couchbase.Lite.Support.NetDesktop.xml</DocumentationFile>
     <DebugType>portable</DebugType>

--- a/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/CSharpTest.cs
@@ -295,21 +295,22 @@ namespace Test
                 return true;
             });
 
-            var retrieved = default(List<Dictionary<string, object?>>);
+            var retrieved = default(List<object?>);
             Db.InBatch(() =>
             {
                 using var flData = masterList.FLEncode();
                 retrieved =
                     FLValueConverter.ToCouchbaseObject(NativeRaw.FLValue_FromData((FLSlice) flData, FLTrust.Trusted), Db,
-                            true, typeof(Dictionary<,>).MakeGenericType(typeof(string), typeof(object))) as
-                        List<Dictionary<string, object?>>;
+                            true) as List<object?>;
             });
 
             var i = 0;
             retrieved.ShouldNotBeNull("because otherwise the fleece conversion failed");
-            foreach (var entry in retrieved!) {
+            foreach (var entryObj in retrieved!) {
+                var entry = entryObj as Dictionary<string, object?>;
+                entry.ShouldNotBeNull("because every retrieved entry should be a dictionary");
                 var entry2 = masterList[i];
-                foreach (var key in entry.Keys) {
+                foreach (var key in entry!.Keys) {
                     entry[key].ShouldBe(entry2[key]);
                 }
 

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -68,6 +68,11 @@
     Condition=" '$(TargetFramework)' == '$(DotNetFrameworkVersion)' or '$(TargetFramework)' == '$(ConsoleDotNetVersion)' ">
     <DefineConstants>$(DefineConstants);NEEDS_LITECORE_LOAD</DefineConstants>
   </PropertyGroup>
+  <!-- Native AOT / trimming support.  Only applicable to .NET 7+, so .NET Framework and
+       the MAUI mobile targets (which use their own AOT pipelines) are left untouched. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == '$(ConsoleDotNetVersion)' ">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">

--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -68,10 +68,11 @@
     Condition=" '$(TargetFramework)' == '$(DotNetFrameworkVersion)' or '$(TargetFramework)' == '$(ConsoleDotNetVersion)' ">
     <DefineConstants>$(DefineConstants);NEEDS_LITECORE_LOAD</DefineConstants>
   </PropertyGroup>
-  <!-- Native AOT / trimming support.  Only applicable to .NET 7+, so .NET Framework and
-       the MAUI mobile targets (which use their own AOT pipelines) are left untouched. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(ConsoleDotNetVersion)' ">
-    <IsAotCompatible>true</IsAotCompatible>
+  <!-- Native AOT / trimming support, following the documented pattern for libraries
+       that multi-target frameworks without AOT analysis support (net8.0 is the minimum):
+       https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/#target-framework-requirements -->
+  <PropertyGroup>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />

--- a/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
+++ b/src/LiteCore/src/LiteCore.Shared/Interop/Fleece.cs
@@ -28,6 +28,7 @@ using System.Text;
 using System.Text.Json;
 using Couchbase.Lite;
 using Couchbase.Lite.Internal.Doc;
+using Couchbase.Lite.Internal.Serialization;
 
 namespace LiteCore.Interop;
 
@@ -537,10 +538,11 @@ internal static unsafe class FLSliceExtensions
             case JsonElement jObj:
                 switch (jObj.ValueKind) {
                     case JsonValueKind.Array:
-                        jObj.Deserialize<IList>(DataOps.SerializerOptions)!.FLEncode();
-                        break;
                     case JsonValueKind.Object:
-                        jObj.Deserialize<IDictionary<string, object?>>(DataOps.SerializerOptions)!.FLEncode();
+                        // Convert with AOT safe JsonElement traversal.  This also encodes
+                        // into the current encoder, where the previous code discarded the
+                        // encoded result.
+                        CouchbaseJson.ToNetObject(jObj).FLEncode(enc);
                         break;
                     case JsonValueKind.Number:
                         if (jObj.TryGetInt64(out var l)) {


### PR DESCRIPTION
## Problem

Applications that publish with .NET Native AOT or trimming (`PublishAot` / `PublishTrimmed`) cannot currently use Couchbase Lite .NET. The library depends on runtime reflection in several places, which the trimmer strips out and Native AOT cannot compile:

- **The query path builds its JSON with the reflection-based `System.Text.Json` serializer.** `XQuery.EncodeAsJSON()` (the JSON handed to `c4query_new2`), `Collection.CreateIndex`, `Result.ToJSON()`, and `Parameters` (whose JSON feeds `c4query_setParameters` for live queries) all call `JsonSerializer.Serialize` with the default reflection resolver. The document `SetJSON` / `ToJSON` paths do the same for deserialization.
- **Dependency injection scans the assembly.** `Service` used `Assembly.GetTypes()`, attribute reflection, and `Activator.CreateInstance` to find `[CouchbaseDependency]` implementations.
- **`FLValueConverter` creates containers dynamically** via `Activator.CreateInstance(typeof(List<>).MakeGenericType(...))`.
- **`LoadLiteCore` locates the native library through `Assembly.Location`**, which returns an empty string in single-file and Native AOT apps, so LiteCore can never be found in those deployment models.

With the trim/single-file/AOT analyzers enabled, the library produces **102 warnings** (IL2026, IL2070, IL2072, IL2075, IL3000, IL3050). After this PR it produces **zero**, and a Native AOT console app can use the database, documents, blobs, indexes, and both QueryBuilder and SQL++ queries.

## What changed

**JSON is now written by hand and read through source generation.** Couchbase Lite only ever serializes a closed set of value types (null, booleans, numbers, strings, dates, binary data, dictionaries, lists, `Blob`, `DictionaryObject`/`ArrayObject`), so a new internal `CouchbaseJson` class writes those directly with `Utf8JsonWriter` — no reflection, byte-identical output for the types LiteCore parses. For reading, a source-generated `JsonSerializerContext` (`CouchbaseJsonContext`) is installed as the `TypeInfoResolver` on the shared serializer options, and `DataOps.ParseTo<T>` uses the AOT-safe `JsonTypeInfo` overload. The three custom converters (`CouchbaseConverter`, `IArrayConverter`, `IDictionaryObjectConverter`) are now fully manual in both directions. `JsonElement` values are converted by walking the element tree instead of re-entering the serializer.

**Dependency injection registers explicitly.** Which implementations exist per platform is already decided at compile time by the `CBL_PLATFORM_*` defines, so each platform block in `Service` now registers its implementations directly, with the same lifetimes the `[CouchbaseDependency]` attributes declared. The attributes stay in place as public API and documentation.

**`FLValueConverter` materializes `List<object>` / `Dictionary<string, object>` directly.** The removed `hintType` parameter only shaped the generic type of the top-level container; no library code passed one, and the single test that did now casts per element.

**`LoadLiteCore` falls back to `AppContext.BaseDirectory`** when `Assembly.Location` is empty, which is where the native libraries live in single-file and AOT published apps.

**Analyzers stay on.** `IsAotCompatible=true` is set for the `net8.0` target of `Couchbase.Lite` and `Couchbase.Lite.Support.NetDesktop`, so regressions surface as build warnings and the published packages carry the `IsTrimmable` metadata.

### Bugs found along the way

- The Fleece encoder's `JsonElement` array/object branches called `FLEncode()` without passing the target encoder, discarding the encoded result instead of writing it into the document. Fixed by the tree-walking conversion.
- `IArrayConverter` deserialized `Blob` through its public properties, which cannot work (`Blob` has multiple public constructors and no parameterless one, so `JsonSerializer` throws). It now uses the validating `Blob(IDictionary)` constructor.
- `Parameters.ToString()` serialized `DictionaryObject`/`ArrayObject` values through their public surface, producing malformed parameter JSON for live queries. They are now written as proper JSON objects/arrays, matching what the Fleece encoding of the same parameters produces at `Execute()` time.

## Verification

- `Couchbase.Lite` (net8.0 and net462) builds with **0 warnings** with the trim, single-file, and AOT analyzers enabled (down from 102).
- Verified with a local console harness referencing the local projects (not included in this PR), running with `JsonSerializerIsReflectionEnabledByDefault=false` so that any missed reflection-based JSON call site throws immediately. All steps pass on JIT and as a fully trimmed self-contained publish: open database, CRUD with nested values and a blob, `ToJSON`/`SetJSON` round trip, `Blob.ToJSON`, value index creation, QueryBuilder query with parameters, SQL++ query, `Result.ToJSON`/`ToDictionary`.
- Reverse P/Invoke was audited: all native callbacks are concrete delegate types annotated with `[UnmanagedFunctionPointer(CallingConvention.Cdecl)]` and passed statically in the binding signatures, which Native AOT supports with compile-time thunks.

## Notes for maintainers

- The Enterprise Edition compiles these same shared sources; EE-only (`#if COUCHBASE_ENTERPRISE`) code that uses reflection-based JSON will want the same treatment. `CouchbaseJsonContext` registrations can be extended if EE deserializes additional root types.
- `FLValueConverter.ToCouchbaseObject` lost its internal `hintType` parameter; if EE passes one, the fix is mechanical and surfaces at compile time.
- The MAUI targets were deliberately left out of `IsAotCompatible` for now — the mobile AOT pipelines have different constraints and seem better handled as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
