### PR TITLE
Fix malformed SupportedOSPlatform attribute from wrapped csproj lines (release/3.4)

### DIFF
--- a/src/Couchbase.Lite/Couchbase.Lite.csproj
+++ b/src/Couchbase.Lite/Couchbase.Lite.csproj
@@ -22,21 +22,12 @@
       $(TargetFrameworks);$(DotNetFrameworkVersion);$(MauiDotNetVersion)-windows$(WinUIMinimumVersion)</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SupportedOSPlatformVersion
-      Condition="$(TargetFramework.StartsWith('net')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-      $(iOSMinimumVersion)</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion
-      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-      $(MacCatalystMinimumVersion)</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion
-      Condition="$(TargetFramework.StartsWith('net')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-      $(MinimumAndroidAPI)</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion
-      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-      $(WinUIMinimumVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformMinVersion
-      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-      $(WinUIMinimumVersion)</TargetPlatformMinVersion>
+    <!-- Keep each of these on one line: a line break before the value embeds a literal newline/indent into the compiled SupportedOSPlatform attribute (MSBuild doesn't trim it), which breaks CA1416 platform-compat checks for consumers. -->
+    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">$(iOSMinimumVersion)</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">$(MacCatalystMinimumVersion)</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$(TargetFramework.StartsWith('net')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">$(MinimumAndroidAPI)</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(WinUIMinimumVersion)</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(WinUIMinimumVersion)</TargetPlatformMinVersion>
     <AssemblyName>Couchbase.Lite</AssemblyName>
     <PackageId>Couchbase.Lite</PackageId>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
## Summary
Backport of #1780 to `release/3.4`.

- `SupportedOSPlatformVersion`/`TargetPlatformMinVersion` in `Couchbase.Lite.csproj` were line-wrapped (tag+Condition on one line, value on the next). MSBuild does not trim that leading newline/indentation from the property value.
- That whitespace gets concatenated verbatim by the SDK's `GenerateAssemblyInfo` target into the compiled `[assembly: SupportedOSPlatform(...)]` attribute — e.g. `"Android\r\n      24.0"` instead of `"android24.0"`.
- Roslyn's (and Rider's) platform-compat analyzer can't parse a version out of that mangled string, so every consumer calling Couchbase.Lite APIs sees spurious `CA1416` warnings, even when their own `SupportedOSPlatformVersion` matches exactly.
- Fix: collapse each property back to a single line. Added a comment to prevent regression.

## Test plan
- [ ] Build the mobile targets, decompile the resulting `Couchbase.Lite.dll`, confirm the `SupportedOSPlatform` attribute string has no embedded whitespace
- [ ] Confirm downstream consumer project no longer emits CA1416 for Couchbase.Lite API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)